### PR TITLE
this changeset puts the radiation flux limiter, lambda, inside qaux

### DIFF
--- a/Exec/science/Detonation/GNUmakefile
+++ b/Exec/science/Detonation/GNUmakefile
@@ -21,7 +21,7 @@ EOS_dir     := helmholtz
 # This sets the EOS directory in $(MICROPHYSICS_HOME)/networks
 Network_dir := aprox19
 
-INTEGRATOR_DIR := BS
+INTEGRATOR_DIR := VODE
 
 else
 

--- a/Source/Castro.cpp
+++ b/Source/Castro.cpp
@@ -550,6 +550,9 @@ Castro::Castro (Amr&            papa,
 #ifdef RADIATION
     init_godunov_indices_rad();
     get_qradvar(&QRADVAR);
+
+    // NQAUX depends on radiation groups, so get it fresh here
+    get_nqaux(&NQAUX);
 #else
     init_godunov_indices();
 #endif
@@ -1767,6 +1770,9 @@ Castro::post_restart ()
 #ifdef RADIATION
     init_godunov_indices_rad();
     get_qradvar(&QRADVAR);
+
+    // NQAUX depends on radiation groups, so get it fresh here
+    get_nqaux(&NQAUX);
 #else
     init_godunov_indices();
 #endif

--- a/Source/Castro_F.H
+++ b/Source/Castro_F.H
@@ -458,7 +458,6 @@ extern "C"
      BL_FORT_FAB_ARG(stateout),
 #ifdef RADIATION
      BL_FORT_FAB_ARG(Er), 
-     BL_FORT_FAB_ARG(lam),
      BL_FORT_FAB_ARG(Erout),
 #endif
      BL_FORT_FAB_ARG(q),

--- a/Source/Castro_hydro.cpp
+++ b/Source/Castro_hydro.cpp
@@ -159,6 +159,9 @@ Castro::construct_hydro_source(Real time, Real dt)
 	  qaux.resize(qbx, NQAUX);
 	  src_q.resize(qbx, QVAR);
 
+	  // convert the conservative state to the primitive variable state.
+	  // this fills both q and qaux.
+
 	  ctoprim(ARLIM_3D(qbx.loVect()), ARLIM_3D(qbx.hiVect()),
 		  statein.dataPtr(), ARLIM_3D(statein.loVect()), ARLIM_3D(statein.hiVect()),
 #ifdef RADIATION
@@ -167,6 +170,9 @@ Castro::construct_hydro_source(Real time, Real dt)
 #endif
 		  q.dataPtr(), ARLIM_3D(q.loVect()), ARLIM_3D(q.hiVect()),
 		  qaux.dataPtr(), ARLIM_3D(qaux.loVect()), ARLIM_3D(qaux.hiVect()));
+
+	  // convert the source terms expressed as sources to the conserved state to those
+	  // expressed as sources for the primitive state.
 
 	  srctoprim(ARLIM_3D(qbx.loVect()), ARLIM_3D(qbx.hiVect()),
 		    q.dataPtr(), ARLIM_3D(q.loVect()), ARLIM_3D(q.hiVect()),
@@ -207,7 +213,6 @@ Castro::construct_hydro_source(Real time, Real dt)
 	     BL_TO_FORTRAN(stateout),
 #ifdef RADIATION
 	     BL_TO_FORTRAN(Er), 
-	     BL_TO_FORTRAN(lam),
 	     BL_TO_FORTRAN(Erout),
 #endif
 	     BL_TO_FORTRAN(q),

--- a/Source/Castro_setup.cpp
+++ b/Source/Castro_setup.cpp
@@ -78,7 +78,7 @@ set_y_vel_bc(BCRec& bc, const BCRec& phys_bc)
   const int* hi_bc = phys_bc.hi();
   bc.setLo(0,tang_vel_bc[lo_bc[0]]);
   bc.setHi(0,tang_vel_bc[hi_bc[0]]);
-#if (BL_SPACEDIM >= 2)    
+#if (BL_SPACEDIM >= 2)
   bc.setLo(1,norm_vel_bc[lo_bc[1]]);
   bc.setHi(1,norm_vel_bc[hi_bc[1]]);
 #endif
@@ -140,10 +140,10 @@ Castro::variableSetUp ()
     if (strlen(buildgithash) > 0){
       std::cout << buildgitname << " git hash: " << buildgithash << "\n";
     }
-    
+
     std::cout << "\n";
   }
-  
+
   BL_ASSERT(desc_lst.size() == 0);
 
   // Get options, set phys_bc
@@ -178,13 +178,13 @@ Castro::variableSetUp ()
   Eden = cnt++;
   Eint = cnt++;
   Temp = cnt++;
-  
+
 #ifdef NUM_ADV
   NumAdv = NUM_ADV;
 #else
   NumAdv = 0;
 #endif
-    
+
   if (NumAdv > 0)
     {
       FirstAdv = cnt;
@@ -195,7 +195,7 @@ Castro::variableSetUp ()
 
   // Get the number of species from the network model.
   get_num_spec(&NumSpec);
-  
+
   if (NumSpec > 0)
     {
       FirstSpec = cnt;
@@ -204,7 +204,7 @@ Castro::variableSetUp ()
 
   // Get the number of auxiliary quantities from the network model.
   get_num_aux(&NumAux);
-  
+
   if (NumAux > 0)
     {
       FirstAux = cnt;
@@ -219,8 +219,8 @@ Castro::variableSetUp ()
 
   // Define NUM_GROW from the f90 module.
   get_method_params(&NUM_GROW);
-  
-  const Real run_strt = ParallelDescriptor::second() ; 
+
+  const Real run_strt = ParallelDescriptor::second() ;
 
 #ifndef DIFFUSION
   static Real diffuse_cutoff_density = -1.e200;
@@ -229,23 +229,23 @@ Castro::variableSetUp ()
   // we want const_grav in F90, get it here from parmparse, since it
   // it not in the Castro namespace
   ParmParse pp("gravity");
-  
+
   // Pass in the name of the gravity type we're using -- we do this
   // manually, since the Fortran parmparse doesn't support strings
   std::string gravity_type = "none";
-  pp.query("gravity_type", gravity_type);    
+  pp.query("gravity_type", gravity_type);
   int gravity_type_length = gravity_type.length();
   Array<int> gravity_type_name(gravity_type_length);
 
   for (int i = 0; i < gravity_type_length; i++)
-    gravity_type_name[i] = gravity_type[i];    
+    gravity_type_name[i] = gravity_type[i];
 
 
   // Read in the input values to Fortran.
 
   set_castro_method_params();
 
-  set_method_params(dm, Density, Xmom, Eden, Eint, Temp, FirstAdv, FirstSpec, FirstAux, 
+  set_method_params(dm, Density, Xmom, Eden, Eint, Temp, FirstAdv, FirstSpec, FirstAux,
 		    NumAdv,
 #ifdef SHOCK_VAR
 		    Shock,
@@ -259,9 +259,9 @@ Castro::variableSetUp ()
   get_nqaux(&NQAUX);
 
   Real run_stop = ParallelDescriptor::second() - run_strt;
- 
+
   ParallelDescriptor::ReduceRealMax(run_stop,ParallelDescriptor::IOProcessorNumber());
- 
+
   if (ParallelDescriptor::IOProcessor())
     std::cout << "\nTime in set_method_params: " << run_stop << '\n' ;
 
@@ -271,27 +271,27 @@ Castro::variableSetUp ()
   Array<Real> center(BL_SPACEDIM, 0.0);
   ParmParse ppc("castro");
   ppc.queryarr("center",center,0,BL_SPACEDIM);
-  
+
   set_problem_params(dm,phys_bc.lo(),phys_bc.hi(),
 		     Interior,Inflow,Outflow,Symmetry,SlipWall,NoSlipWall,coord_type,
 		     Geometry::ProbLo(),Geometry::ProbHi(),center.dataPtr());
-  
+
   // Read in the parameters for the tagging criteria
   // and store them in the Fortran module.
-  
+
   int probin_file_length = probin_file.length();
   Array<int> probin_file_name(probin_file_length);
-  
+
   for (int i = 0; i < probin_file_length; i++)
     probin_file_name[i] = probin_file[i];
-  
+
   get_tagging_params(probin_file_name.dataPtr(),&probin_file_length);
-  
+
 #ifdef SPONGE
   // Read in the parameters for the sponge
   // and store them in the Fortran module.
-  
-  get_sponge_params(probin_file_name.dataPtr(),&probin_file_length);    
+
+  get_sponge_params(probin_file_name.dataPtr(),&probin_file_length);
 #endif
 
   Interpolater* interp;
@@ -311,7 +311,7 @@ Castro::variableSetUp ()
   // We could do this for other cases too, but I'll confine it to
   // neutrino problems for now so as not to change the results of
   // other people's tests.  Better to fix cell_cons_interp!
-  
+
   if (Geometry::IsSPHERICAL() && Radiation::nNeutrinoSpecies > 0) {
     interp = &pc_interp;
   }
@@ -364,12 +364,12 @@ Castro::variableSetUp ()
 			 StateDescriptor::Point, 1, 1,
 			 &cell_cons_interp, state_data_extrap,
 			 store_in_checkpoint);
-  
+
   store_in_checkpoint = false;
   desc_lst.addDescriptor(Rotation_Type,IndexType::TheCellType(),
 			 StateDescriptor::Point,NUM_GROW,3,
 			 &cell_cons_interp,state_data_extrap,store_in_checkpoint);
-#endif    
+#endif
 
 
 #ifdef REACTIONS
@@ -430,10 +430,10 @@ Castro::variableSetUp ()
   for (int i = 0; i < NumSpec; i++) {
     int len = 20;
     Array<int> int_spec_names(len);
-    // This call return the actual length of each string in "len" 
+    // This call return the actual length of each string in "len"
     get_spec_names(int_spec_names.dataPtr(),&i,&len);
     char char_spec_names[len+1];
-    for (int j = 0; j < len; j++) 
+    for (int j = 0; j < len; j++)
       char_spec_names[j] = int_spec_names[j];
     char_spec_names[len] = '\0';
     spec_names.push_back(std::string(char_spec_names));
@@ -442,16 +442,16 @@ Castro::variableSetUp ()
   if ( ParallelDescriptor::IOProcessor())
     {
       std::cout << NumSpec << " Species: " << std::endl;
-      for (int i = 0; i < NumSpec; i++)  
+      for (int i = 0; i < NumSpec; i++)
 	std::cout << spec_names[i] << ' ' << ' ';
       std::cout << std::endl;
-    } 
+    }
 
   for (int i=0; i<NumSpec; ++i)
     {
-      cnt++; 
-      set_scalar_bc(bc,phys_bc); 
-      bcs[cnt] = bc; 
+      cnt++;
+      set_scalar_bc(bc,phys_bc);
+      bcs[cnt] = bc;
       name[cnt] = "rho_" + spec_names[i];
     }
 
@@ -524,7 +524,7 @@ Castro::variableSetUp ()
   for (int i = 0; i < NUM_STATE; i++)
     sources_name[i] = name[i] + "_source";
 
-  desc_lst.setComponent(Source_Type,Density,sources_name,bcs,BndryFunc(ca_denfill,ca_hypfill));       
+  desc_lst.setComponent(Source_Type,Density,sources_name,bcs,BndryFunc(ca_denfill,ca_hypfill));
 
 #ifdef REACTIONS
   std::string name_react;
@@ -615,7 +615,7 @@ Castro::variableSetUp ()
       desc_lst.addDescriptor(Knapsack_Weight_Type, IndexType::TheCellType(), StateDescriptor::Point,
 			     0, 1, &pc_interp);
       // Because we use piecewise constant interpolation, we do not use bc and BndryFunc.
-      desc_lst.setComponent(Knapsack_Weight_Type, 0, "KnapsackWeight", 
+      desc_lst.setComponent(Knapsack_Weight_Type, 0, "KnapsackWeight",
 			    bc, BndryFunc(ca_nullfill));
   }
 
@@ -663,7 +663,7 @@ Castro::variableSetUp ()
 #endif
 
   //
-  // Gravitational forcing 
+  // Gravitational forcing
   //
 #ifdef SELF_GRAVITY
   //    derive_lst.add("rhog",IndexType::TheCellType(),1,
@@ -775,7 +775,7 @@ Castro::variableSetUp ()
   derive_lst.add("angular_momentum_z",IndexType::TheCellType(),1,ca_derangmomz,the_same_box);
   derive_lst.addComponent("angular_momentum_z",desc_lst,State_Type,Density,1);
   derive_lst.addComponent("angular_momentum_z",desc_lst,State_Type,Xmom,3);
-    
+
 #ifdef SELF_GRAVITY
   derive_lst.add("maggrav",IndexType::TheCellType(),1,ca_dermaggrav,the_same_box);
   derive_lst.addComponent("maggrav",desc_lst,Gravity_Type,0,3);
@@ -881,7 +881,7 @@ Castro::variableSetUp ()
 #endif
 
 
-  // 
+  //
   // Problem-specific adds
 #include <Problem_Derives.H>
 

--- a/Source/Radiation/RadSrc_1d/trace_ppm_rad_1d.f90
+++ b/Source/Radiation/RadSrc_1d/trace_ppm_rad_1d.f90
@@ -19,8 +19,8 @@ contains
 
     use bl_constants_module
     use meth_params_module, only : QVAR, QRHO, QU, QREINT, QPRES, &
-         NQ, qrad, qradhi, qptot, qreitot, &
-         QGAME, &
+         NQ, NQAUX, qrad, qradhi, qptot, qreitot, &
+         QGAME, QGAMC, QGAMCG, QC, QCG, QLAMS, &
          small_dens, small_pres, fix_mass_flux, &
          ppm_type, ppm_trace_sources, ppm_temp_fix, &
          ppm_predict_gammae, ppm_reference_eigenvectors, &

--- a/Source/Radiation/RadSrc_1d/trace_ppm_rad_1d.f90
+++ b/Source/Radiation/RadSrc_1d/trace_ppm_rad_1d.f90
@@ -11,16 +11,15 @@ module trace_ppm_rad_module
 
 contains
 
-  subroutine trace_ppm_rad(lam, lam_l1, lam_h1, &
-       q,c,cg,gamc,gamcg,flatn,qd_l1,qd_h1, &
-       dloga,dloga_l1,dloga_h1, &
-       srcQ,src_l1,src_h1,&
-       qxm,qxp,qpd_l1,qpd_h1, &
-       ilo,ihi,domlo,domhi,dx,dt)
+  subroutine trace_ppm_rad(q, qaux, flatn, qd_l1, qd_h1, &
+                           dloga, dloga_l1, dloga_h1, &
+                           srcQ, src_l1, src_h1,&
+                           qxm, qxp, qpd_l1, qpd_h1, &
+                           ilo, ihi, domlo, domhi, dx, dt)
 
     use bl_constants_module
     use meth_params_module, only : QVAR, QRHO, QU, QREINT, QPRES, &
-         QRADVAR, qrad, qradhi, qptot, qreitot, &
+         NQ, qrad, qradhi, qptot, qreitot, &
          QGAME, &
          small_dens, small_pres, fix_mass_flux, &
          ppm_type, ppm_trace_sources, ppm_temp_fix, &
@@ -34,24 +33,19 @@ contains
 
     integer ilo,ihi
     integer domlo(1),domhi(1)
-    integer lam_l1, lam_h1
     integer    qd_l1,   qd_h1
     integer dloga_l1,dloga_h1
     integer   qpd_l1,  qpd_h1
     integer   src_l1,  src_h1
     double precision dx, dt
-    double precision lam(lam_l1:lam_h1, 0:ngroups-1)
-    double precision     q( qd_l1: qd_h1,QRADVAR)
-    double precision  srcQ(src_l1:src_h1,QVAR)
+    double precision     q( qd_l1: qd_h1, NQ)
+    double precision :: qaux(qd_l1:qd_h1, NQAUX)
     double precision flatn(qd_l1:qd_h1)
-    double precision     c(qd_l1:qd_h1)
-    double precision    cg(qd_l1:qd_h1)
-    double precision  gamc(qd_l1:qd_h1)
-    double precision gamcg(qd_l1:qd_h1)
+    double precision  srcQ(src_l1:src_h1,QVAR)
     double precision dloga(dloga_l1:dloga_h1)
 
-    double precision  qxm( qpd_l1: qpd_h1,QRADVAR)
-    double precision  qxp( qpd_l1: qpd_h1,QRADVAR)
+    double precision  qxm( qpd_l1: qpd_h1, NQ)
+    double precision  qxp( qpd_l1: qpd_h1, NQ)
 
     ! Local variables
     integer :: i, g
@@ -133,8 +127,8 @@ contains
     hdt = HALF * dt
     dtdx = dt/dx
 
-    allocate(Ip(ilo-1:ihi+1,3,QRADVAR))
-    allocate(Im(ilo-1:ihi+1,3,QRADVAR))
+    allocate(Ip(ilo-1:ihi+1,3, NQ))
+    allocate(Im(ilo-1:ihi+1,3, NQ))
 
     if (ppm_trace_sources == 1) then
        allocate(Ip_src(ilo-1:ihi+1,3,QVAR))
@@ -171,21 +165,21 @@ contains
     ! Compute Ip and Im -- this does the parabolic reconstruction,
     ! limiting, and returns the integral of each profile under each
     ! wave to each interface
-    do n=1,QRADVAR
-       call ppm(q(:,n),qd_l1,qd_h1, &
-                q(:,QU),c, &
+    do n = 1, NQ
+       call ppm(q(:,n), qd_l1, qd_h1, &
+                q(:,QU), qaux(:,QC), &
                 flatn, &
-                Ip(:,:,n),Im(:,:,n), &
-                ilo,ihi,dx,dt)
+                Ip(:,:,n), Im(:,:,n), &
+                ilo, ihi, dx, dt)
     end do
 
     if (ppm_trace_sources == 1) then
-       do n=1,QVAR
-          call ppm(srcQ(:,n),src_l1,src_h1, &
-                   q(:,QU),c, &
+       do n = 1, QVAR
+          call ppm(srcQ(:,n), src_l1, src_h1, &
+                   q(:,QU), qaux(:,QC), &
                    flatn, &
-                   Ip_src(:,:,n),Im_src(:,:,n), &
-                   ilo,ihi,dx,dt)
+                   Ip_src(:,:,n), Im_src(:,:,n), &
+                   ilo, ihi, dx, dt)
        enddo
     endif
 
@@ -197,15 +191,15 @@ contains
     do i = ilo-1, ihi+1
 
        do g=0, ngroups-1
-          lam0(g) = lam(i,g)
-          lamp(g) = lam(i,g)
-          lamm(g) = lam(i,g)
+          lam0(g) = qaux(i,QLAMS+g)
+          lamp(g) = qaux(i,QLAMS+g)
+          lamm(g) = qaux(i,QLAMS+g)
        end do
 
        ! cgassq is the gas soundspeed **2
        ! cc is the total soundspeed **2 (gas + radiation)
-       cgassq = cg(i)**2
-       cc = c(i)
+       cgassq = qaux(i,QCG)**2
+       cc = qaux(i,QC)
        csq = cc**2
 
        rho = q(i,QRHO)
@@ -223,7 +217,7 @@ contains
 
        Clag = rho*cc
 
-       gam_g = gamcg(i)
+       gam_g = qaux(i,QGAMCG)
        game = q(i,QGAME)
 
        !----------------------------------------------------------------------

--- a/Source/Radiation/RadSrc_2d/trace_ppm_rad_2d.f90
+++ b/Source/Radiation/RadSrc_2d/trace_ppm_rad_2d.f90
@@ -19,8 +19,8 @@ contains
 
     use network, only : nspec
     use bl_constants_module
-    use meth_params_module, only : QVAR, QRHO, QU, QV, QREINT, QPRES, &
-         QGAME, &
+    use meth_params_module, only : NQ, NQAUX, QVAR, QRHO, QU, QV, QREINT, QPRES, &
+         QGAME, QC, QCG, QGAMC, QGAMCG, QLAMS, &
          QRADVAR, qrad, qradhi, qptot, qreitot, &
          small_dens, small_pres, &
          ppm_type, ppm_trace_sources, ppm_temp_fix, &
@@ -49,8 +49,6 @@ contains
     double precision qxp(qpd_l1:qpd_h1,qpd_l2:qpd_h2,NQ)
     double precision qym(qpd_l1:qpd_h1,qpd_l2:qpd_h2,NQ)
     double precision qyp(qpd_l1:qpd_h1,qpd_l2:qpd_h2,NQ)
-    double precision lam(lam_l1:lam_h1,lam_l2:lam_h2,0:ngroups-1)
-
 
     double precision dx, dy, dt
 

--- a/Source/Radiation/RadSrc_2d/trace_ppm_rad_2d.f90
+++ b/Source/Radiation/RadSrc_2d/trace_ppm_rad_2d.f90
@@ -11,13 +11,11 @@ module trace_ppm_rad_module
 
 contains
 
-  subroutine trace_ppm_rad(lam, lam_l1, lam_l2, lam_h1, lam_h2, &
-                           q,c,cg,flatn,qd_l1,qd_l2,qd_h1,qd_h2, &
-                           dloga,dloga_l1,dloga_l2,dloga_h1,dloga_h2, &
-                           qxm,qxp,qym,qyp,qpd_l1,qpd_l2,qpd_h1,qpd_h2, &
-                           srcQ,src_l1,src_l2,src_h1,src_h2, &
-                           gamc,gamcg,gc_l1,gc_l2,gc_h1,gc_h2, &
-                           ilo1,ilo2,ihi1,ihi2,dx,dy,dt)
+  subroutine trace_ppm_rad(q, qaux, flatn, qd_l1, qd_l2, qd_h1, qd_h2, &
+                           dloga, dloga_l1, dloga_l2, dloga_h1, dloga_h2, &
+                           qxm, qxp, qym, qyp, qpd_l1, qpd_l2, qpd_h1, qpd_h2, &
+                           srcQ, src_l1, src_l2, src_h1, src_h2, &
+                           ilo1, ilo2, ihi1, ihi2, dx, dy, dt)
 
     use network, only : nspec
     use bl_constants_module
@@ -35,28 +33,24 @@ contains
     implicit none
 
     integer ilo1,ilo2,ihi1,ihi2
-    integer lam_l1,lam_l2,lam_h1,lam_h2
     integer qd_l1,qd_l2,qd_h1,qd_h2
     integer dloga_l1,dloga_l2,dloga_h1,dloga_h2
     integer qpd_l1,qpd_l2,qpd_h1,qpd_h2
     integer src_l1,src_l2,src_h1,src_h2
     integer gc_l1,gc_l2,gc_h1,gc_h2
 
-    double precision     q(qd_l1:qd_h1,qd_l2:qd_h2,QRADVAR)
-    double precision     c(qd_l1:qd_h1,qd_l2:qd_h2)
-    double precision    cg(qd_l1:qd_h1,qd_l2:qd_h2)
+    double precision     q(qd_l1:qd_h1,qd_l2:qd_h2,NQ)
+    double precision :: qaux(qd_l1:qd_h1,qd_l2:qd_h2, NQAUX)
     double precision flatn(qd_l1:qd_h1,qd_l2:qd_h2)
+    double precision srcQ(src_l1:src_h1,src_l2:src_h2,QVAR)
     double precision dloga(dloga_l1:dloga_h1,dloga_l2:dloga_h2)
 
-    double precision qxm(qpd_l1:qpd_h1,qpd_l2:qpd_h2,QRADVAR)
-    double precision qxp(qpd_l1:qpd_h1,qpd_l2:qpd_h2,QRADVAR)
-    double precision qym(qpd_l1:qpd_h1,qpd_l2:qpd_h2,QRADVAR)
-    double precision qyp(qpd_l1:qpd_h1,qpd_l2:qpd_h2,QRADVAR)
+    double precision qxm(qpd_l1:qpd_h1,qpd_l2:qpd_h2,NQ)
+    double precision qxp(qpd_l1:qpd_h1,qpd_l2:qpd_h2,NQ)
+    double precision qym(qpd_l1:qpd_h1,qpd_l2:qpd_h2,NQ)
+    double precision qyp(qpd_l1:qpd_h1,qpd_l2:qpd_h2,NQ)
     double precision lam(lam_l1:lam_h1,lam_l2:lam_h2,0:ngroups-1)
 
-    double precision srcQ(src_l1:src_h1,src_l2:src_h2,QVAR)
-    double precision gamc(gc_l1:gc_h1,gc_l2:gc_h2)
-    double precision gamcg(gc_l1:gc_h1,gc_l2:gc_h2)
 
     double precision dx, dy, dt
 
@@ -135,8 +129,8 @@ contains
     dtdy = dt/dy
 
     ! indices: (x, y, dimension, wave, variable)
-    allocate(Ip(ilo1-1:ihi1+1,ilo2-1:ihi2+1,2,3,QRADVAR))
-    allocate(Im(ilo1-1:ihi1+1,ilo2-1:ihi2+1,2,3,QRADVAR))
+    allocate(Ip(ilo1-1:ihi1+1,ilo2-1:ihi2+1,2,3,NQ))
+    allocate(Im(ilo1-1:ihi1+1,ilo2-1:ihi2+1,2,3,NQ))
 
     if (ppm_trace_sources == 1) then
        allocate(Ip_src(ilo1-1:ihi1+1,ilo2-1:ihi2+1,2,3,QVAR))
@@ -179,12 +173,12 @@ contains
     ! Compute Ip and Im -- this does the parabolic reconstruction,
     ! limiting, and returns the integral of each profile under each
     ! wave to each interface
-    do n=1,QRADVAR
-       call ppm(q(:,:,n),qd_l1,qd_l2,qd_h1,qd_h2, &
-                q(:,:,QU:QV), c, qd_l1,qd_l2,qd_h1,qd_h2,&
+    do n = 1, NQ
+       call ppm(q(:,:,n), qd_l1, qd_l2, qd_h1, qd_h2, &
+                q(:,:,QU:QV), qaux(:,:,QC), qd_l1, qd_l2, qd_h1, qd_h2,&
                 flatn, &
-                Ip(:,:,:,:,n),Im(:,:,:,:,n), &
-                ilo1,ilo2,ihi1,ihi2,dx,dy,dt)
+                Ip(:,:,:,:,n), Im(:,:,:,:,n), &
+                ilo1, ilo2, ihi1, ihi2, dx, dy, dt)
     end do
 
     ! trace the gas gamma to the edge
@@ -197,12 +191,12 @@ contains
     !   endif
 
     if (ppm_trace_sources == 1) then
-       do n = 1,QVAR
-          call ppm(srcQ(:,:,n),src_l1,src_l2,src_h1,src_h2, &
-                   q(:,:,QU:QV),c,qd_l1,qd_l2,qd_h1,qd_h2, &
+       do n = 1, QVAR
+          call ppm(srcQ(:,:,n), src_l1, src_l2, src_h1, src_h2, &
+                   q(:,:,QU:QV), qaux(:,:,QC), qd_l1, qd_l2, qd_h1, qd_h2, &
                    flatn, &
-                   Ip_src(:,:,:,:,n),Im_src(:,:,:,:,n), &
-                   ilo1,ilo2,ihi1,ihi2,dx,dy,dt)
+                   Ip_src(:,:,:,:,n), Im_src(:,:,:,:,n), &
+                   ilo1, ilo2, ihi1, ihi2, dx, dy, dt)
        enddo
     endif
 
@@ -215,15 +209,15 @@ contains
        do i = ilo1-1, ihi1+1
 
           do g=0, ngroups-1
-             lam0(g) = lam(i,j,g)
-             lamp(g) = lam(i,j,g)
-             lamm(g) = lam(i,j,g)
+             lam0(g) = qaux(i,j,QLAMS+g)
+             lamp(g) = qaux(i,j,QLAMS+g)
+             lamm(g) = qaux(i,j,QLAMS+g)
           end do
 
           ! cgassq is the gas soundspeed **2
           ! cc is the total soundspeed **2 (gas + radiation)
-          cgassq = cg(i,j)**2
-          cc = c(i,j)
+          cgassq = qaux(i,j,QCG)**2
+          cc = qaux(i,j,QC)
           csq = cc**2
 
           rho = q(i,j,QRHO)
@@ -237,7 +231,7 @@ contains
 
           Clag = rho*cc
 
-          gam_g = gamcg(i,j)
+          gam_g = qaux(i,j,QGAMCG)
           game = q(i,j,QGAME)
 
           ptot = q(i,j,qptot)
@@ -704,15 +698,15 @@ contains
        do i = ilo1-1, ihi1+1
 
           do g=0, ngroups-1
-             lam0(g) = lam(i,j,g)
-             lamp(g) = lam(i,j,g)
-             lamm(g) = lam(i,j,g)
+             lam0(g) = qaux(i,j,QLAMS+g)
+             lamp(g) = qaux(i,j,QLAMS+g)
+             lamm(g) = qaux(i,j,QLAMS+g)
           end do
 
           ! cgassq is the gas soundspeed **2
           ! cc is the total soundspeed **2 (gas + radiation)
-          cgassq = cg(i,j)**2
-          cc = c(i,j)
+          cgassq = qaux(i,j,QCG)**2
+          cc = qaux(i,j,QC)
           csq = cc**2
 
           rho = q(i,j,QRHO)
@@ -726,7 +720,7 @@ contains
 
           Clag = rho*cc
 
-          gam_g = gamcg(i,j)
+          gam_g = qaux(i,j,QGAMCG)
           game = q(i,j,QGAME)
 
           ptot = q(i,j,qptot)

--- a/Source/Radiation/RadSrc_3d/trace_ppm_rad_3d.f90
+++ b/Source/Radiation/RadSrc_3d/trace_ppm_rad_3d.f90
@@ -11,17 +11,15 @@ module trace_ppm_rad_module
 
 contains
 
-  subroutine tracexy_ppm_rad(lam, lam_lo, lam_hi, &
-                             q, c, cg, flatn, qd_lo, qd_hi, &
+  subroutine tracexy_ppm_rad(q, qaux, flatn, qd_lo, qd_hi, &
                              Ip, Im, Ip_src, Im_src, &
                              qxm, qxp, qym, qyp, qs_lo, qs_hi, &
-                             gamc,gamcg,gc_lo,gc_hi, &
-                             ilo1,ilo2,ihi1,ihi2,dt,kc,k3d)
+                             ilo1, ilo2, ihi1, ihi2, dt, kc, k3d)
 
     use network, only : nspec, naux
     use meth_params_module, only : QVAR, QRHO, QU, QV, QW, &
          QREINT, QPRES, QGAME, &
-         QRADVAR, qrad, qradhi, qptot, qreitot, &
+         NQ, qrad, qradhi, qptot, qreitot, &
          small_dens, small_pres, &
          ppm_type, ppm_trace_sources, &
          ppm_reference_eigenvectors, ppm_predict_gammae, &
@@ -38,27 +36,22 @@ contains
     integer, intent(in) :: ilo1, ilo2, ihi1, ihi2
     integer, intent(in) :: kc,k3d
 
-    double precision, intent(in) :: lam(lam_lo(1):lam_hi(1),lam_lo(2):lam_hi(2),lam_lo(3):lam_hi(3),0:ngroups-1)
-
-    double precision, intent(in) ::     q(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),QRADVAR)
-    double precision, intent(in) ::     c(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3))
-    double precision, intent(in) ::    cg(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3))
+    double precision, intent(in) ::     q(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),NQ)
+    double precision, intent(in) ::  qaux(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),NQAUX)
     double precision, intent(in) :: flatn(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3))
 
-    double precision, intent(in) :: Ip(ilo1-1:ihi1+1,ilo2-1:ihi2+1,1:2,1:3,1:3,QRADVAR)
-    double precision, intent(in) :: Im(ilo1-1:ihi1+1,ilo2-1:ihi2+1,1:2,1:3,1:3,QRADVAR)
+    double precision, intent(in) :: Ip(ilo1-1:ihi1+1,ilo2-1:ihi2+1,1:2,1:3,1:3,NQ)
+    double precision, intent(in) :: Im(ilo1-1:ihi1+1,ilo2-1:ihi2+1,1:2,1:3,1:3,NQ)
 
-    double precision, intent(in) :: Ip_src(ilo1-1:ihi1+1,ilo2-1:ihi2+1,1:2,1:3,1:3,QRADVAR)
-    double precision, intent(in) :: Im_src(ilo1-1:ihi1+1,ilo2-1:ihi2+1,1:2,1:3,1:3,QRADVAR)
+    double precision, intent(in) :: Ip_src(ilo1-1:ihi1+1,ilo2-1:ihi2+1,1:2,1:3,1:3,NQ)
+    double precision, intent(in) :: Im_src(ilo1-1:ihi1+1,ilo2-1:ihi2+1,1:2,1:3,1:3,NQ)
 
 
-    double precision, intent(inout) :: qxm(qs_lo(1):qs_hi(1),qs_lo(2):qs_hi(2),qs_lo(3):qs_hi(3),QRADVAR)
-    double precision, intent(inout) :: qxp(qs_lo(1):qs_hi(1),qs_lo(2):qs_hi(2),qs_lo(3):qs_hi(3),QRADVAR)
-    double precision, intent(inout) :: qym(qs_lo(1):qs_hi(1),qs_lo(2):qs_hi(2),qs_lo(3):qs_hi(3),QRADVAR)
-    double precision, intent(inout) :: qyp(qs_lo(1):qs_hi(1),qs_lo(2):qs_hi(2),qs_lo(3):qs_hi(3),QRADVAR)
+    double precision, intent(inout) :: qxm(qs_lo(1):qs_hi(1),qs_lo(2):qs_hi(2),qs_lo(3):qs_hi(3),NQ)
+    double precision, intent(inout) :: qxp(qs_lo(1):qs_hi(1),qs_lo(2):qs_hi(2),qs_lo(3):qs_hi(3),NQ)
+    double precision, intent(inout) :: qym(qs_lo(1):qs_hi(1),qs_lo(2):qs_hi(2),qs_lo(3):qs_hi(3),NQ)
+    double precision, intent(inout) :: qyp(qs_lo(1):qs_hi(1),qs_lo(2):qs_hi(2),qs_lo(3):qs_hi(3),NQ)
 
-    double precision, intent(in) :: gamc(gc_lo(1):gc_hi(1),gc_lo(2):gc_hi(2),gc_lo(3):gc_hi(3))
-    double precision, intent(in) :: gamcg(gc_lo(1):gc_hi(1),gc_lo(2):gc_hi(2),gc_lo(3):gc_hi(3))
 
     double precision, intent(in) :: dt
 
@@ -160,9 +153,9 @@ contains
           gfactor = ONE ! to help compiler resolve ANTI dependence
 
           do g=0, ngroups-1
-             lam0(g) = lam(i,j,k3d,g)
-             lamp(g) = lam(i,j,k3d,g)
-             lamm(g) = lam(i,j,k3d,g)
+             lam0(g) = qaux(i,j,k3d,QLAMS+g)
+             lamp(g) = qaux(i,j,k3d,QLAMS+g)
+             lamm(g) = qaux(i,j,k3d,QLAMS+g)
           end do
 
           rho = q(i,j,k3d,QRHO)
@@ -170,8 +163,8 @@ contains
 
           ! cgassq is the gas soundspeed **2
           ! cc is the total soundspeed **2 (gas + radiation)
-          cgassq = cg(i,j,k3d)**2
-          cc = c(i,j,k3d)
+          cgassq = qaux(i,j,k3d,QCG)**2
+          cc = qaux(i,j,k3d,QC)
           csq = cc**2
           Clag = rho*cc
 
@@ -183,7 +176,7 @@ contains
           rhoe_g = q(i,j,k3d,QREINT)
           h_g = ( (p+rhoe_g)/rho)/csq
 
-          gam_g = gamcg(i,j,k3d)
+          gam_g = qaux(i,j,k3d,QGAMCG)
           game = q(i,j,k3d,QGAME)
 
           ptot = q(i,j,k3d,qptot)
@@ -619,16 +612,16 @@ contains
           gfactor = ONE ! to help compiler resolve ANTI dependence
 
           do g=0, ngroups-1
-             lam0(g) = lam(i,j,k3d,g)
-             lamp(g) = lam(i,j,k3d,g)
-             lamm(g) = lam(i,j,k3d,g)
+             lam0(g) = qaux(i,j,k3d,QLAMS+g)
+             lamp(g) = qaux(i,j,k3d,QLAMS+g)
+             lamm(g) = qaux(i,j,k3d,QLAMS+g)
           end do
 
           rho = q(i,j,k3d,QRHO)
           tau = ONE/rho
 
-          cgassq = cg(i,j,k3d)**2
-          cc = c(i,j,k3d)
+          cgassq = qaux(i,j,k3d,QCG)**2
+          cc = qaux(i,j,k3d,QC)
           csq = cc**2
           Clag = rho*cc
 
@@ -640,7 +633,7 @@ contains
           rhoe_g = q(i,j,k3d,QREINT)
           h_g = ( (p + rhoe_g)/rho)/csq
 
-          gam_g = gamcg(i,j,k3d)
+          gam_g = qaux(i,j,k3d,QGAMCG)
           game = q(i,j,k3d,QGAME)
 
           ptot = q(i,j,k3d,qptot)
@@ -1050,17 +1043,15 @@ contains
 
 
 
-  subroutine tracez_ppm_rad(lam, lam_lo, lam_hi, &
-                            q, c, cg, flatn, qd_lo, qd_hi, &
+  subroutine tracez_ppm_rad(q, qaux, flatn, qd_lo, qd_hi, &
                             Ip, Im, Ip_src, Im_src, &
                             qzm, qzp, qs_lo, qs_hi, &
-                            gamc,gamcg,gc_lo,gc_hi, &
-                            ilo1,ilo2,ihi1,ihi2,dt,km,kc,k3d)
+                            ilo1, ilo2, ihi1, ihi2, dt, km, kc, k3d)
 
     use network, only : nspec, naux
     use meth_params_module, only : QVAR, QRHO, QU, QV, QW, &
                                    QREINT, QPRES, QGAME, &
-                                   QRADVAR, qrad, qradhi, qptot, qreitot, &
+                                   NQ, qrad, qradhi, qptot, qreitot, &
                                    small_dens, small_pres, &
                                    ppm_type, ppm_trace_sources, &
                                    ppm_reference_eigenvectors, ppm_predict_gammae, &
@@ -1070,33 +1061,26 @@ contains
 
     implicit none
 
-    integer, intent(in) :: lam_lo(3), lam_hi(3)
     integer, intent(in) :: qd_lo(3), qd_hi(3)
     integer, intent(in) :: qs_lo(3), qs_hi(3)
     integer, intent(in) :: gc_lo(3), gc_hi(3)
     integer, intent(in) :: ilo1, ilo2, ihi1, ihi2
     integer, intent(in) :: km, kc, k3d
 
-    double precision, intent(in) :: lam(lam_lo(1):lam_hi(1),lam_lo(2):lam_hi(2),lam_lo(3):lam_hi(3),0:ngroups-1)
-
-    double precision, intent(in) ::     q(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),QRADVAR)
-    double precision, intent(in) ::     c(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3))
-    double precision, intent(in) ::    cg(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3))
+    double precision, intent(in) ::     q(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),NQ)
+    double precision, intent(in) ::  qaux(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),NQAUX)
     double precision, intent(in) :: flatn(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3))
 
-    double precision, intent(in) :: Ip(ilo1-1:ihi1+1,ilo2-1:ihi2+1,1:2,1:3,1:3,QRADVAR)
-    double precision, intent(in) :: Im(ilo1-1:ihi1+1,ilo2-1:ihi2+1,1:2,1:3,1:3,QRADVAR)
+    double precision, intent(in) :: Ip(ilo1-1:ihi1+1,ilo2-1:ihi2+1,1:2,1:3,1:3,NQ)
+    double precision, intent(in) :: Im(ilo1-1:ihi1+1,ilo2-1:ihi2+1,1:2,1:3,1:3,NQ)
 
-    double precision, intent(in) :: Ip_src(ilo1-1:ihi1+1,ilo2-1:ihi2+1,1:2,1:3,1:3,QRADVAR)
-    double precision, intent(in) :: Im_src(ilo1-1:ihi1+1,ilo2-1:ihi2+1,1:2,1:3,1:3,QRADVAR)
-
-
-    double precision, intent(inout) :: qzm(qs_lo(1):qs_hi(1),qs_lo(2):qs_hi(2),qs_lo(3):qs_hi(3),QRADVAR)
-    double precision, intent(inout) :: qzp(qs_lo(1):qs_hi(1),qs_lo(2):qs_hi(2),qs_lo(3):qs_hi(3),QRADVAR)
+    double precision, intent(in) :: Ip_src(ilo1-1:ihi1+1,ilo2-1:ihi2+1,1:2,1:3,1:3,NQ)
+    double precision, intent(in) :: Im_src(ilo1-1:ihi1+1,ilo2-1:ihi2+1,1:2,1:3,1:3,NQ)
 
 
-    double precision, intent(in) :: gamc(gc_lo(1):gc_hi(1),gc_lo(2):gc_hi(2),gc_lo(3):gc_hi(3))
-    double precision, intent(in) :: gamcg(gc_lo(1):gc_hi(1),gc_lo(2):gc_hi(2),gc_lo(3):gc_hi(3))
+    double precision, intent(inout) :: qzm(qs_lo(1):qs_hi(1),qs_lo(2):qs_hi(2),qs_lo(3):qs_hi(3),NQ)
+    double precision, intent(inout) :: qzp(qs_lo(1):qs_hi(1),qs_lo(2):qs_hi(2),qs_lo(3):qs_hi(3),NQ)
+
 
     double precision, intent(in) :: dt
 
@@ -1177,16 +1161,16 @@ contains
           gfactor = ONE ! to help compiler resolve ANTI dependence
 
           do g=0, ngroups-1
-             lam0(g) = lam(i,j,k3d,g)
-             lamp(g) = lam(i,j,k3d,g)
-             lamm(g) = lam(i,j,k3d,g)
+             lam0(g) = qaux(i,j,k3d,QLAMS+g)
+             lamp(g) = qaux(i,j,k3d,QLAMS+g)
+             lamm(g) = qaux(i,j,k3d,QLAMS+g)
           end do
 
           rho = q(i,j,k3d,QRHO)
           tau = ONE/rho
 
-          cgassq = cg(i,j,k3d)**2
-          cc = c(i,j,k3d)
+          cgassq = qaux(i,j,k3d,QCG)**2
+          cc = qaux(i,j,k3d,QC)
           csq = cc**2
           Clag = rho*cc
 
@@ -1198,7 +1182,7 @@ contains
           rhoe_g = q(i,j,k3d,QREINT)
           h_g = ( (p + rhoe_g)/rho)/csq
 
-          gam_g = gamcg(i,j,k3d)
+          gam_g = qaux(i,j,k3d,QGAMCG)
           game = q(i,j,k3d,QGAME)
 
           ptot = q(i,j,k3d,qptot)
@@ -1397,8 +1381,8 @@ contains
           rho = q(i,j,k3d-1,QRHO)
           tau = ONE/rho
 
-          cgassq = cg(i,j,k3d-1)**2
-          cc = c(i,j,k3d-1)
+          cgassq = qaux(i,j,k3d-1,QCG)**2
+          cc = qaux(i,j,k3d-1,QC)
           csq = cc**2
           Clag = rho*cc
 
@@ -1410,7 +1394,7 @@ contains
           rhoe_g = q(i,j,k3d-1,QREINT)
           h_g = ( (p + rhoe_g)/rho)/csq
 
-          gam_g = gamcg(i,j,k3d-1)
+          gam_g = qaux(i,j,k3d-1,QGAMCG)
           game = q(i,j,k3d-1,QGAME)
 
           ptot = q(i,j,k3d-1,qptot)

--- a/Source/Radiation/RadSrc_3d/trace_ppm_rad_3d.f90
+++ b/Source/Radiation/RadSrc_3d/trace_ppm_rad_3d.f90
@@ -18,7 +18,7 @@ contains
 
     use network, only : nspec, naux
     use meth_params_module, only : QVAR, QRHO, QU, QV, QW, &
-         QREINT, QPRES, QGAME, &
+         QREINT, QPRES, QGAME, QC, QCG, QGAMC, QGAMCG, QLAMS, &
          NQ, qrad, qradhi, qptot, qreitot, &
          small_dens, small_pres, &
          ppm_type, ppm_trace_sources, &

--- a/Source/Radiation/RadSrc_3d/trace_ppm_rad_3d.f90
+++ b/Source/Radiation/RadSrc_3d/trace_ppm_rad_3d.f90
@@ -19,7 +19,7 @@ contains
     use network, only : nspec, naux
     use meth_params_module, only : QVAR, QRHO, QU, QV, QW, &
          QREINT, QPRES, QGAME, QC, QCG, QGAMC, QGAMCG, QLAMS, &
-         NQ, qrad, qradhi, qptot, qreitot, &
+         NQ, NQAUX, qrad, qradhi, qptot, qreitot, &
          small_dens, small_pres, &
          ppm_type, ppm_trace_sources, &
          ppm_reference_eigenvectors, ppm_predict_gammae, &
@@ -29,15 +29,13 @@ contains
 
     implicit none
 
-    integer, intent(in) :: lam_lo(3), lam_hi(3)
     integer, intent(in) :: qd_lo(3), qd_hi(3)
     integer, intent(in) :: qs_lo(3), qs_hi(3)
-    integer, intent(in) :: gc_lo(3), gc_hi(3)
     integer, intent(in) :: ilo1, ilo2, ihi1, ihi2
     integer, intent(in) :: kc,k3d
 
     double precision, intent(in) ::     q(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),NQ)
-    double precision, intent(in) ::  qaux(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),NQAUX)
+    double precision, intent(inout) ::  qaux(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),NQAUX)
     double precision, intent(in) :: flatn(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3))
 
     double precision, intent(in) :: Ip(ilo1-1:ihi1+1,ilo2-1:ihi2+1,1:2,1:3,1:3,NQ)
@@ -1050,8 +1048,8 @@ contains
 
     use network, only : nspec, naux
     use meth_params_module, only : QVAR, QRHO, QU, QV, QW, &
-                                   QREINT, QPRES, QGAME, &
-                                   NQ, qrad, qradhi, qptot, qreitot, &
+                                   QREINT, QPRES, QGAME, QC, QCG, QGAMC, QGAMCG, QLAMS, &
+                                   NQ, NQAUX, qrad, qradhi, qptot, qreitot, &
                                    small_dens, small_pres, &
                                    ppm_type, ppm_trace_sources, &
                                    ppm_reference_eigenvectors, ppm_predict_gammae, &
@@ -1063,7 +1061,6 @@ contains
 
     integer, intent(in) :: qd_lo(3), qd_hi(3)
     integer, intent(in) :: qs_lo(3), qs_hi(3)
-    integer, intent(in) :: gc_lo(3), gc_hi(3)
     integer, intent(in) :: ilo1, ilo2, ihi1, ihi2
     integer, intent(in) :: km, kc, k3d
 
@@ -1373,9 +1370,9 @@ contains
           ! been to find the minus state on face kc+1
 
           do g=0, ngroups-1
-             lam0(g) = lam(i,j,k3d-1,g)
-             lamp(g) = lam(i,j,k3d-1,g)
-             lamm(g) = lam(i,j,k3d-1,g)
+             lam0(g) = qaux(i,j,k3d-1,QLAMS+g)
+             lamp(g) = qaux(i,j,k3d-1,QLAMS+g)
+             lamm(g) = qaux(i,j,k3d-1,QLAMS+g)
           end do
 
           rho = q(i,j,k3d-1,QRHO)

--- a/Source/Src_1d/Castro_1d.F90
+++ b/Source/Src_1d/Castro_1d.F90
@@ -4,7 +4,6 @@ subroutine ca_umdrv(is_finest_level, time, &
                     uout, uout_l1, uout_h1, &
 #ifdef RADIATION
                     Erin, Erin_l1, Erin_h1, &
-                    lam, lam_l1, lam_h1, &
                     Erout, Erout_l1, Erout_h1, &
 #endif
                     q, q_l1, q_h1, &
@@ -59,7 +58,6 @@ subroutine ca_umdrv(is_finest_level, time, &
 #ifdef RADIATION
   integer, intent(inout) :: nstep_fsp
   integer, intent(in) :: Erin_l1, Erin_h1
-  integer, intent(in) :: lam_l1, lam_h1
   integer, intent(in) :: Erout_l1, Erout_h1
   integer, intent(in) :: radflux_l1, radflux_h1
 #endif
@@ -79,7 +77,6 @@ subroutine ca_umdrv(is_finest_level, time, &
   double precision, intent(inout) :: Erout(Erout_l1:Erout_h1, 0:ngroups-1)
   double precision, intent(inout) :: radflux(radflux_l1: radflux_h1, 0:ngroups-1)
   double precision, intent(in) :: Erin( Erin_l1: Erin_h1, 0:ngroups-1)
-  double precision, intent(in) ::  lam( lam_l1: lam_h1, 0:ngroups-1)
 #endif
   double precision, intent(inout) :: pradial(  p_l1:   p_h1)
   double precision, intent(in) :: area( area_l1: area_h1     )
@@ -175,7 +172,6 @@ subroutine ca_umdrv(is_finest_level, time, &
                uout, uout_l1, uout_h1, &
                flux, flux_l1, flux_h1, &
 #ifdef RADIATION
-               lam, lam_l1, lam_h1, &
                radflux,radflux_l1,radflux_h1, &
 #endif
                q1, flux_l1-1, flux_h1+1, &

--- a/Source/Src_1d/Castro_advection_1d.F90
+++ b/Source/Src_1d/Castro_advection_1d.F90
@@ -33,7 +33,6 @@ contains
                      uout, uout_l1, uout_h1, &
                      flux, fd_l1, fd_h1, &
 #ifdef RADIATION
-                     lam, lam_l1, lam_h1, &
                      rflux, rfd_l1, rfd_h1, &
 #endif
                      q1, q1_l1, q1_h1, &
@@ -69,7 +68,6 @@ contains
     integer, intent(in) :: fd_l1, fd_h1
 #ifdef RADIATION
     integer, intent(in) :: rfd_l1, rfd_h1
-    integer, intent(in) :: lam_l1, lam_h1
 #endif
     integer, intent(in) :: q1_l1, q1_h1
     integer, intent(in) :: ilo, ihi
@@ -82,7 +80,6 @@ contains
     double precision, intent(inout) :: flux(fd_l1:fd_h1,NVAR)
 #ifdef RADIATION
     double precision, intent(inout) :: rflux(rfd_l1:rfd_h1,0:ngroups-1)
-    double precision, intent(in) :: lam(lam_l1:lam_h1,0:ngroups-1)
 #endif
     double precision, intent(in) :: srcQ(src_l1  :src_h1,QVAR)
     double precision, intent(inout) :: q1(q1_l1:q1_h1,NGDNV)
@@ -131,8 +128,7 @@ contains
     ! Trace to edges w/o transverse flux correction terms
     if (ppm_type .gt. 0) then
 #ifdef RADIATION
-       call trace_ppm_rad(lam, lam_l1, lam_h1, &
-                          q,qaux(:,QC),qaux(:,QCG),qaux(:,QGAMC),qaux(:,QGAMCG), &
+       call trace_ppm_rad(q,qaux(:,QC),qaux(:,QCG),qaux(:,QGAMC),qaux(:,QGAMCG), &
                           flatn,qd_l1,qd_h1, &
                           dloga,dloga_l1,dloga_h1, &
                           srcQ,src_l1,src_h1, &
@@ -167,7 +163,6 @@ contains
                 flux, fd_l1, fd_h1, &
                 q1, q1_l1, q1_h1, &
 #ifdef RADIATION
-                lam, lam_l1, lam_h1, &
                 rflux, rfd_l1,rfd_h1, &
 #endif
                 qaux, qa_l1, qa_h1, ilo, ihi)

--- a/Source/Src_1d/Castro_advection_1d.F90
+++ b/Source/Src_1d/Castro_advection_1d.F90
@@ -128,12 +128,11 @@ contains
     ! Trace to edges w/o transverse flux correction terms
     if (ppm_type .gt. 0) then
 #ifdef RADIATION
-       call trace_ppm_rad(q,qaux(:,QC),qaux(:,QCG),qaux(:,QGAMC),qaux(:,QGAMCG), &
-                          flatn,qd_l1,qd_h1, &
-                          dloga,dloga_l1,dloga_h1, &
-                          srcQ,src_l1,src_h1, &
-                          qm,qp,ilo-1,ihi+1, &
-                          ilo,ihi,domlo,domhi,dx,dt)
+       call trace_ppm_rad(q, qaux, flatn, qd_l1, qd_h1, &
+                          dloga, dloga_l1, dloga_h1, &
+                          srcQ, src_l1, src_h1, &
+                          qm, qp, ilo-1, ihi+1, &
+                          ilo, ihi, domlo, domhi, dx, dt)
 #else
        call trace_ppm(q,qaux(:,QC),flatn,qaux(:,QGAMC),qd_l1,qd_h1, &
                       dloga,dloga_l1,dloga_h1, &

--- a/Source/Src_1d/riemann_1d.F90
+++ b/Source/Src_1d/riemann_1d.F90
@@ -66,7 +66,7 @@ contains
 
     ! Local variables
     integer i
-    double precision, allocatable :: smallc(:),cavg(:),gamcp(:), gamcm(:)
+    double precision, allocatable :: smallc(:), cavg(:), gamcp(:), gamcm(:)
 #ifdef RADIATION
     double precision, allocatable :: gamcgp(:), gamcgm(:), lam(:,:)
 #endif
@@ -123,6 +123,9 @@ contains
     endif
 
     deallocate (smallc,cavg,gamcm,gamcp)
+#ifdef RADIATION
+    deallocate(gamcgm,gamcgp,lam)
+#endif
 
   end subroutine cmpflx
 

--- a/Source/Src_1d/riemann_1d.F90
+++ b/Source/Src_1d/riemann_1d.F90
@@ -78,7 +78,7 @@ contains
 #ifdef RADIATION
     allocate (gamcgp(ilo:ihi+1) )
     allocate (gamcgm(ilo:ihi+1) )
-    allocate (lam(ilo:ihi+1,0:ngroups-1) )
+    allocate (lam(ilo-1:ihi+2,0:ngroups-1) )
 #endif
 
     do i = ilo, ihi+1
@@ -89,9 +89,14 @@ contains
 #ifdef RADIATION
        gamcgm (i) = qaux(i-1,QGAMCG)
        gamcgp (i) = qaux(i,QGAMCG)
-       lam(i,:) = qaux(i,QLAMS:QLAMS+ngroups-1)
 #endif
     enddo
+
+#ifdef RADIATION
+    do i = ilo-1, ihi+2
+       lam(i,:) = qaux(i,QLAMS:QLAMS+ngroups-1)
+    enddo
+#endif
 
     ! Solve Riemann problem (godunov state passed back, but only (u,p) saved)
     if (riemann_solver == 0) then
@@ -775,7 +780,7 @@ contains
     double precision  qint( qg_l1: qg_h1, NGDNV)
 
 #ifdef RADIATION
-    double precision lam(ilo:ihi+1, 0:ngroups-1)
+    double precision lam(ilo-1:ihi+2, 0:ngroups-1)
     double precision gamcgl(ilo:ihi+1),gamcgr(ilo:ihi+1)
     double precision  rflx(rflx_l1:rflx_h1, 0:ngroups-1)
 

--- a/Source/Src_1d/riemann_1d.F90
+++ b/Source/Src_1d/riemann_1d.F90
@@ -7,7 +7,7 @@ module riemann_module
                                    QFS, QFX, &
                                    NGDNV, GDU, GDPRES, QGAMC, QC, QCSML, &
 #ifdef RADIATION
-                                   GDERADS, GDLAMS, QGAMCG, &
+                                   GDERADS, GDLAMS, QGAMCG, QLAMS, &
 #endif
                                    URHO, UMX, UEDEN, UEINT, &
                                    small_temp, small_dens, small_pres, &
@@ -36,7 +36,6 @@ contains
                     flx, flx_l1, flx_h1, &
                     qint, qg_l1, qg_h1, &
 #ifdef RADIATION
-                    lam, lam_l1, lam_h1, &
                     rflx, rflx_l1, rflx_h1, &
 #endif
                     qaux, qa_l1, qa_h1, ilo, ihi)
@@ -61,9 +60,7 @@ contains
     double precision  qaux( qa_l1: qa_h1, NQAUX)
 
 #ifdef RADIATION
-    integer lam_l1, lam_h1
     integer rflx_l1, rflx_h1
-    double precision lam(lam_l1:lam_h1, 0:ngroups-1)
     double precision rflx(rflx_l1:rflx_h1, 0:ngroups-1)
 #endif
 
@@ -71,7 +68,7 @@ contains
     integer i
     double precision, allocatable :: smallc(:),cavg(:),gamcp(:), gamcm(:)
 #ifdef RADIATION
-    double precision, allocatable :: gamcgp(:), gamcgm(:)
+    double precision, allocatable :: gamcgp(:), gamcgm(:), lam(:,:)
 #endif
 
     allocate ( smallc(ilo:ihi+1) )
@@ -81,6 +78,7 @@ contains
 #ifdef RADIATION
     allocate (gamcgp(ilo:ihi+1) )
     allocate (gamcgm(ilo:ihi+1) )
+    allocate (lam(ilo:ihi+1,0:ngroups-1) )
 #endif
 
     do i = ilo, ihi+1
@@ -91,6 +89,7 @@ contains
 #ifdef RADIATION
        gamcgm (i) = qaux(i-1,QGAMCG)
        gamcgp (i) = qaux(i,QGAMCG)
+       lam(i,:) = qaux(i,QLAMS:QLAMS+ngroups-1)
 #endif
     enddo
 
@@ -103,8 +102,7 @@ contains
                       flx, flx_l1, flx_h1, &
                       qint, qg_l1, qg_h1, &
 #ifdef RADIATION
-                      lam, lam_l1, lam_h1, &
-                      gamcgm, gamcgp, &
+                      lam, gamcgm, gamcgp, &
                       rflx, rflx_l1, rflx_h1, &
 #endif
                       ilo, ihi, domlo, domhi )
@@ -744,8 +742,7 @@ contains
                        uflx,uflx_l1,uflx_h1,&
                        qint,qg_l1,qg_h1, &
 #ifdef RADIATION
-                       lam, lam_l1, lam_h1, &
-                       gamcgl, gamcgr, &
+                       lam, gamcgl, gamcgr, &
                        rflx,rflx_l1,rflx_h1, &
 #endif
                        ilo,ihi,domlo,domhi)
@@ -767,7 +764,6 @@ contains
 
 #ifdef RADIATION
     integer rflx_l1, rflx_h1
-    integer lam_l1, lam_h1
 #endif
 
     double precision ql(qpd_l1:qpd_h1, NQ)
@@ -779,7 +775,7 @@ contains
     double precision  qint( qg_l1: qg_h1, NGDNV)
 
 #ifdef RADIATION
-    double precision lam(lam_l1:lam_h1, 0:ngroups-1)
+    double precision lam(ilo:ihi+1, 0:ngroups-1)
     double precision gamcgl(ilo:ihi+1),gamcgr(ilo:ihi+1)
     double precision  rflx(rflx_l1:rflx_h1, 0:ngroups-1)
 

--- a/Source/Src_2d/Castro_2d.F90
+++ b/Source/Src_2d/Castro_2d.F90
@@ -84,7 +84,7 @@ subroutine ca_umdrv(is_finest_level, time, &
   double precision, intent(inout) :: Erout(Erout_l1:Erout_h1,Erout_l2:Erout_h2,0:ngroups-1)
 #endif
   double precision, intent(inout) :: q(q_l1:q_h1,q_l2:q_h2,NQ)
-  double precision, intent(in) :: qaux(qa_l1:qa_h1,qa_l2:qa_h2,NQAUX)
+  double precision, intent(inout) :: qaux(qa_l1:qa_h1,qa_l2:qa_h2,NQAUX)
   double precision, intent(in) :: srcQ(srQ_l1:srQ_h1,srQ_l2:srQ_h2,QVAR)
   double precision, intent(inout) :: update(updt_l1:updt_h1,updt_l2:updt_h2,NVAR)
   double precision, intent(inout) :: flux1(flux1_l1:flux1_h1,flux1_l2:flux1_h2,NVAR)

--- a/Source/Src_2d/Castro_2d.F90
+++ b/Source/Src_2d/Castro_2d.F90
@@ -4,7 +4,6 @@ subroutine ca_umdrv(is_finest_level, time, &
                     uout, uout_l1, uout_l2, uout_h1, uout_h2, &
 #ifdef RADIATION
                     Erin, Erin_l1, Erin_l2, Erin_h1, Erin_h2, &
-                    lam, lam_l1, lam_l2, lam_h1, lam_h2, &
                     Erout, Erout_l1, Erout_l2, Erout_h1, Erout_h2, &
 #endif
                     q, q_l1, q_l2, q_h1, q_h2, &
@@ -59,7 +58,6 @@ subroutine ca_umdrv(is_finest_level, time, &
   integer, intent(in) :: uin_l1, uin_l2, uin_h1, uin_h2
 #ifdef RADIATION
   integer, intent(in) :: Erin_l1, Erin_l2, Erin_h1, Erin_h2
-  integer, intent(in) :: lam_l1, lam_l2, lam_h1, lam_h2
   integer, intent(in) :: Erout_l1, Erout_l2, Erout_h1, Erout_h2
 #endif
   integer, intent(in) :: uout_l1,uout_l2,uout_h1,uout_h2
@@ -83,7 +81,6 @@ subroutine ca_umdrv(is_finest_level, time, &
   double precision, intent(inout) :: uout(uout_l1:uout_h1,uout_l2:uout_h2,NVAR)
 #ifdef RADIATION
   double precision, intent(in) :: Erin(Erin_l1:Erin_h1,Erin_l2:Erin_h2,0:ngroups-1)
-  double precision, intent(inout) :: lam(lam_l1:lam_h1,lam_l2:lam_h2,0:ngroups-1)
   double precision, intent(inout) :: Erout(Erout_l1:Erout_h1,Erout_l2:Erout_h2,0:ngroups-1)
 #endif
   double precision, intent(inout) :: q(q_l1:q_h1,q_l2:q_h2,NQ)
@@ -198,7 +195,6 @@ subroutine ca_umdrv(is_finest_level, time, &
                flux1, flux1_l1, flux1_l2, flux1_h1, flux1_h2, &
                flux2, flux2_l1, flux2_l2, flux2_h1, flux2_h2, &
 #ifdef RADIATION
-               lam, lam_l1,lam_l2,lam_h1,lam_h2, &
                radflux1,radflux1_l1,radflux1_l2,radflux1_h1,radflux1_h2, &
                radflux2,radflux2_l1,radflux2_l2,radflux2_h1,radflux2_h2, &
 #endif               

--- a/Source/Src_2d/Castro_advection_2d.F90
+++ b/Source/Src_2d/Castro_advection_2d.F90
@@ -37,7 +37,6 @@ contains
                      flux1, fd1_l1, fd1_l2, fd1_h1, fd1_h2, &
                      flux2, fd2_l1, fd2_l2, fd2_h1, fd2_h2, &
 #ifdef RADIATION
-                     lam, lam_l1, lam_l2, lam_h1, lam_h2, &
                      rflux1, rfd1_l1, rfd1_l2, rfd1_h1, rfd1_h2, &
                      rflux2, rfd2_l1, rfd2_l2, rfd2_h1, rfd2_h2, &
 #endif
@@ -83,7 +82,6 @@ contains
 #ifdef RADIATION
     integer, intent(in) :: rfd1_l1, rfd1_l2, rfd1_h1, rfd1_h2
     integer, intent(in) :: rfd2_l1, rfd2_l2, rfd2_h1, rfd2_h2
-    integer, intent(in) :: lam_l1, lam_l2, lam_h1, lam_h2
 #endif
     integer, intent(in) :: q1_l1, q1_l2, q1_h1, q1_h2
     integer, intent(in) :: q2_l1, q2_l2, q2_h1, q2_h2
@@ -105,7 +103,6 @@ contains
     double precision, intent(inout) :: flux1(fd1_l1:fd1_h1,fd1_l2:fd1_h2,NVAR)
     double precision, intent(inout) :: flux2(fd2_l1:fd2_h1,fd2_l2:fd2_h2,NVAR)
 #ifdef RADIATION
-    double precision, intent(inout) :: lam(lam_l1:lam_h1,lam_l2:lam_h2,0:ngroups-1)
     double precision, intent(inout) :: rflux1(rfd1_l1:rfd1_h1,rfd1_l2:rfd1_h2,0:ngroups-1)
     double precision, intent(inout) :: rflux2(rfd2_l1:rfd2_h1,rfd2_l2:rfd2_h2,0:ngroups-1)
 #endif
@@ -209,8 +206,7 @@ contains
 #endif
     else
 #ifdef RADIATION
-       call trace_ppm_rad(lam,lam_l1,lam_l2,lam_h1,lam_h2, &
-                          q,qaux(:,:,QC),qaux(:,:,QCG),flatn,qd_l1,qd_l2,qd_h1,qd_h2, &
+       call trace_ppm_rad(q,qaux(:,:,QC),qaux(:,:,QCG),flatn,qd_l1,qd_l2,qd_h1,qd_h2, &
                           dloga,dloga_l1,dloga_l2,dloga_h1,dloga_h2, &
                           qxm,qxp,qym,qyp,ilo1-1,ilo2-1,ihi1+2,ihi2+2, &
                           srcQ,src_l1,src_l2,src_h1,src_h2, &
@@ -233,7 +229,6 @@ contains
                 fx, ilo1, ilo2-1, ihi1+1, ihi2+1, &
                 qgdxtmp, q1_l1, q1_l2, q1_h1, q1_h2, &
 #ifdef RADIATION
-                lam, lam_l1, lam_l2, lam_h1, lam_h2, &
                 rfx, ilo1, ilo2-1, ihi1+1, ihi2+1, &
 #endif
                 qaux, qa_l1, qa_l2, qa_h1, qa_h2, &
@@ -246,7 +241,6 @@ contains
                 fy, ilo1-1, ilo2, ihi1+1, ihi2+1, &
                 q2, q2_l1, q2_l2, q2_h1, q2_h2, &
 #ifdef RADIATION
-                lam, lam_l1, lam_l2, lam_h1, lam_h2, &
                 rfy, ilo1-1, ilo2, ihi1+1, ihi2+1, &
 #endif
                 qaux, qa_l1, qa_l2, qa_h1, qa_h2, &
@@ -256,11 +250,7 @@ contains
     ! Correct the x-interface states (qxm, qxp) by adding the
     ! transverse flux difference in the y-direction to the x-interface
     ! states.  This results in the new x-interface states qm and qp
-    call transy(&
-#ifdef RADIATION
-                lam,lam_l1,lam_l2,lam_h1,lam_h2, &
-#endif
-                qxm, qm, qxp, qp, ilo1-1, ilo2-1, ihi1+2, ihi2+2, &
+    call transy(qxm, qm, qxp, qp, ilo1-1, ilo2-1, ihi1+2, ihi2+2, &
                 fy, ilo1-1, ilo2, ihi1+1, ihi2+1, &
 #ifdef RADIATION
                 rfy, ilo1-1, ilo2, ihi1+1, ihi2+1, &
@@ -282,7 +272,6 @@ contains
                 flux1, fd1_l1, fd1_l2, fd1_h1, fd1_h2, &
                 q1, q1_l1, q1_l2, q1_h1, q1_h2, &
 #ifdef RADIATION
-                lam,lam_l1,lam_l2,lam_h1,lam_h2, &
                 rflux1, rfd1_l1, rfd1_l2, rfd1_h1, rfd1_h2, &
 #endif
                 qaux, qa_l1, qa_l2, qa_h1, qa_h2, &
@@ -292,11 +281,7 @@ contains
     ! Correct the y-interface states (qym, qyp) by adding the
     ! transverse flux difference in the x-direction to the y-interface
     ! states.  This results in the new y-interface states qm and qp
-    call transx(&
-#ifdef RADIATION
-                lam,lam_l1,lam_l2,lam_h1,lam_h2, &
-#endif
-                qym, qm, qyp, qp, ilo1-1, ilo2-1, ihi1+2, ihi2+2, &
+    call transx(qym, qm, qyp, qp, ilo1-1, ilo2-1, ihi1+2, ihi2+2, &
                 fx, ilo1, ilo2-1, ihi1+1, ihi2+1, &
 #ifdef RADIATION
                 rfx, ilo1, ilo2-1, ihi1+1, ihi2+1, &
@@ -320,7 +305,6 @@ contains
                 flux2, fd2_l1, fd2_l2, fd2_h1, fd2_h2, &
                 q2, q2_l1, q2_l2, q2_h1, q2_h2, &
 #ifdef RADIATION
-                lam,lam_l1,lam_l2,lam_h1,lam_h2, &
                 rflux2, rfd2_l1, rfd2_l2, rfd2_h1, rfd2_h2, &
 #endif
                 qaux, qa_l1, qa_l2, qa_h1, qa_h2, &

--- a/Source/Src_2d/Castro_advection_2d.F90
+++ b/Source/Src_2d/Castro_advection_2d.F90
@@ -93,7 +93,7 @@ contains
 
     double precision, intent(in) :: dx, dy, dt
     double precision, intent(in) :: q(qd_l1:qd_h1,qd_l2:qd_h2,NQ)
-    double precision, intent(in) :: qaux(qa_l1:qa_h1,qa_l2:qa_h2,NQAUX)
+    double precision, intent(inout) :: qaux(qa_l1:qa_h1,qa_l2:qa_h2,NQAUX)
     double precision, intent(in) :: flatn(qd_l1:qd_h1,qd_l2:qd_h2)
     double precision, intent(in) :: srcQ(src_l1:src_h1,src_l2:src_h2,QVAR)
     double precision, intent(in) :: dloga(dloga_l1:dloga_h1,dloga_l2:dloga_h2)

--- a/Source/Src_2d/Castro_advection_2d.F90
+++ b/Source/Src_2d/Castro_advection_2d.F90
@@ -206,12 +206,11 @@ contains
 #endif
     else
 #ifdef RADIATION
-       call trace_ppm_rad(q,qaux(:,:,QC),qaux(:,:,QCG),flatn,qd_l1,qd_l2,qd_h1,qd_h2, &
-                          dloga,dloga_l1,dloga_l2,dloga_h1,dloga_h2, &
-                          qxm,qxp,qym,qyp,ilo1-1,ilo2-1,ihi1+2,ihi2+2, &
-                          srcQ,src_l1,src_l2,src_h1,src_h2, &
-                          qaux(:,:,QGAMC),qaux(:,:,QGAMCG),qa_l1,qa_l2,qa_h1,qa_h2, &
-                          ilo1,ilo2,ihi1,ihi2,dx,dy,dt)
+       call trace_ppm_rad(q, qaux, flatn, qd_l1, qd_l2, qd_h1, qd_h2, &
+                          dloga, dloga_l1, dloga_l2, dloga_h1, dloga_h2, &
+                          qxm, qxp, qym, qyp, ilo1-1, ilo2-1, ihi1+2, ihi2+2, &
+                          srcQ, src_l1, src_l2, src_h1, src_h2, &
+                          ilo1, ilo2, ihi1, ihi2, dx, dy, dt)
 
 #else
        call trace_ppm(q,qaux(:,:,QC),flatn,qd_l1,qd_l2,qd_h1,qd_h2, &

--- a/Source/Src_2d/Castro_advection_2d.F90
+++ b/Source/Src_2d/Castro_advection_2d.F90
@@ -250,16 +250,12 @@ contains
     ! transverse flux difference in the y-direction to the x-interface
     ! states.  This results in the new x-interface states qm and qp
     call transy(qxm, qm, qxp, qp, ilo1-1, ilo2-1, ihi1+2, ihi2+2, &
+                qaux, qa_l1, qa_l2, qa_h1, qa_h2, &
                 fy, ilo1-1, ilo2, ihi1+1, ihi2+1, &
 #ifdef RADIATION
                 rfy, ilo1-1, ilo2, ihi1+1, ihi2+1, &
 #endif
                 q2, q2_l1, q2_l2, q2_h1, q2_h2, &
-#ifdef RADIATION
-                qaux(:,:,QGAMCG), qa_l1, qa_l2, qa_h1, qa_h2, &
-#else
-                qaux(:,:,QGAMC), qa_l1, qa_l2, qa_h1, qa_h2, &
-#endif
                 srcQ, src_l1, src_l2, src_h1, src_h2, &
                 hdt, hdtdy, &
                 ilo1-1, ihi1+1, ilo2, ihi2)
@@ -281,16 +277,12 @@ contains
     ! transverse flux difference in the x-direction to the y-interface
     ! states.  This results in the new y-interface states qm and qp
     call transx(qym, qm, qyp, qp, ilo1-1, ilo2-1, ihi1+2, ihi2+2, &
+                qaux, qa_l1, qa_l2, qa_h1, qa_h2, &
                 fx, ilo1, ilo2-1, ihi1+1, ihi2+1, &
 #ifdef RADIATION
                 rfx, ilo1, ilo2-1, ihi1+1, ihi2+1, &
 #endif
                 qgdxtmp, q1_l1, q1_l2, q1_h1, q1_h2, &
-#ifdef RADIATION
-                qaux(:,:,QGAMCG), qa_l1, qa_l2, qa_h1, qa_h2, &
-#else
-                qaux(:,:,QGAMC), qa_l1, qa_l2, qa_h1, qa_h2, &
-#endif
                 srcQ,  src_l1,  src_l2,  src_h1,  src_h2, &
                 hdt, hdtdx, &
                 area1, area1_l1, area1_l2, area1_h1, area1_h2, &

--- a/Source/Src_2d/riemann_2d.F90
+++ b/Source/Src_2d/riemann_2d.F90
@@ -10,7 +10,7 @@ module riemann_module
                                  GDPRES, GDGAME, QGAMC, QC, QCSML, &
 #ifdef RADIATION
                                  qrad, qradhi, qptot, qreitot, fspace_type, &
-                                 GDERADS, GDLAMS, QGAMCG, &
+                                 GDERADS, GDLAMS, QGAMCG, QLAMS, &
 #endif
                                  NGDNV, small_dens, small_pres, small_temp, &
                                  cg_maxiter, cg_tol, cg_blend, &
@@ -41,7 +41,6 @@ contains
                     flx, flx_l1, flx_l2, flx_h1, flx_h2, &
                     qint, qg_l1, qg_l2, qg_h1, qg_h2, &
 #ifdef RADIATION
-                    lam, lam_l1, lam_l2, lam_h1, lam_h2, &
                     rflx, rflx_l1, rflx_l2, rflx_h1, rflx_h2, &
 #endif
                     qaux, qa_l1, qa_l2, qa_h1, qa_h2, &
@@ -62,9 +61,7 @@ contains
     integer, intent(in) :: domlo(2),domhi(2)
 
 #ifdef RADIATION
-    integer, intent(in) :: lam_l1,lam_l2,lam_h1,lam_h2
     integer, intent(in) :: rflx_l1,rflx_l2,rflx_h1,rflx_h2
-    double precision, intent(inout) :: lam(lam_l1:lam_h1,lam_l2:lam_h2,0:ngroups-1)
     double precision, intent(inout) :: rflx(rflx_l1:rflx_h1,rflx_l2:rflx_h2,0:ngroups-1)
 #endif
 
@@ -83,7 +80,7 @@ contains
     double precision, allocatable :: smallc(:,:), cavg(:,:)
     double precision, allocatable :: gamcm(:,:), gamcp(:,:)
 #ifdef RADIATION    
-    double precision, allocatable :: gamcgm(:,:), gamcgp(:,:)
+    double precision, allocatable :: gamcgm(:,:), gamcgp(:,:), lam(:,:,:)
 #endif
     
     integer :: imin, imax, jmin, jmax
@@ -98,6 +95,7 @@ contains
 #ifdef RADIATION   
     allocate ( gamcgm(ilo-1:ihi+1,jlo-1:jhi+1) )
     allocate ( gamcgp(ilo-1:ihi+1,jlo-1:jhi+1) )
+    allocate (    lam(ilo-1:ihi+1,jlo-1:jhi+1,0:ngroups-1) )
 #endif
 
 #ifdef RADIATION
@@ -138,6 +136,14 @@ contains
           enddo
        enddo
     endif
+
+#ifdef RADIATION
+    do j = jlo-1, jhi+1
+       do i = ilo-1, ihi+1
+          lam(i,j,:) = qaux(i,j,QLAMS:QLAMS+ngroups-1)
+       enddo
+    enddo
+#endif
 
     if (ppm_temp_fix == 2) then
        ! recompute the thermodynamics on the interface to make it
@@ -220,8 +226,7 @@ contains
                       flx, flx_l1, flx_l2, flx_h1, flx_h2, &
                       qint, qg_l1, qg_l2, qg_h1, qg_h2, &
 #ifdef RADIATION
-                      lam,lam_l1,lam_l2,lam_h1,lam_h2,&
-                      gamcgm, gamcgp, &
+                      lam, gamcgm, gamcgp, &
                       rflx, rflx_l1, rflx_l2, rflx_h1, rflx_h2, &
 #endif
                       idir, ilo, ihi, jlo, jhi, domlo, domhi)
@@ -291,7 +296,7 @@ contains
 
     deallocate(smallc,cavg,gamcm,gamcp)
 #ifdef RADIATION
-    deallocate(gamcgm,gamcgp)
+    deallocate(gamcgm,gamcgp,lam)
 #endif
 
   end subroutine cmpflx
@@ -944,8 +949,7 @@ contains
                        uflx, uflx_l1, uflx_l2, uflx_h1, uflx_h2, &
                        qint, qg_l1, qg_l2, qg_h1, qg_h2, &
 #ifdef RADIATION
-                       lam,lam_l1,lam_l2,lam_h1,lam_h2, &
-                       gamcgl,gamcgr, &
+                       lam, gamcgl, gamcgr, &
                        rflx, rflx_l1, rflx_l2, rflx_h1, rflx_h2, &
 #endif
                        idir, ilo1, ihi1, ilo2, ihi2, domlo, domhi)
@@ -959,7 +963,6 @@ contains
     integer :: uflx_l1, uflx_l2, uflx_h1, uflx_h2
     integer :: qg_l1, qg_l2, qg_h1, qg_h2
 #ifdef RADIATION
-    integer :: lam_l1, lam_l2, lam_h1, lam_h2
     integer :: rflx_l1, rflx_l2, rflx_h1, rflx_h2
 #endif
     integer :: idir, ilo1, ihi1, ilo2, ihi2
@@ -975,7 +978,7 @@ contains
     double precision :: uflx(uflx_l1:uflx_h1,uflx_l2:uflx_h2,NVAR)
     double precision :: qint(qg_l1:qg_h1,qg_l2:qg_h2,NGDNV)
 #ifdef RADIATION
-    double precision :: lam(lam_l1:lam_h1,lam_l2:lam_h2,0:ngroups-1)
+    double precision ::    lam(gd_l1:gd_h1,gd_l2:gd_h2,0:ngroups-1)
     double precision :: gamcgl(gd_l1:gd_h1,gd_l2:gd_h2)
     double precision :: gamcgr(gd_l1:gd_h1,gd_l2:gd_h2)
     double precision :: rflx(rflx_l1:rflx_h1,rflx_l2:rflx_h2,0:ngroups-1)

--- a/Source/Src_2d/trans_2d.F90
+++ b/Source/Src_2d/trans_2d.F90
@@ -5,12 +5,10 @@ module transverse_module
   use meth_params_module, only : NQ, QVAR, NVAR, QRHO, QU, QV, QW, QPRES, QREINT, QGAME, &
                                  URHO, UMX, UMY, UEDEN, UEINT, QFS, QFX, &
                                  GDU, GDV, GDPRES, GDGAME, &
-#ifdef RADIATION
-                                 GDERADS, &
-#endif
                                  NGDNV, &
 #ifdef RADIATION
                                  qrad, qradhi, qptot, qreitot, &
+                                 GDERADS, &
                                  fspace_type, comoving, &
 #endif
                                  small_pres, small_temp, &
@@ -34,29 +32,21 @@ module transverse_module
 
 contains
 
-  subroutine transx( &
-#ifdef RADIATION
-                    lam, lam_l1, lam_l2, lam_h1, lam_h2, &
-#endif
-                    qm, qmo, qp, qpo, qd_l1, qd_l2, qd_h1, qd_h2, &
+  subroutine transx(qm, qmo, qp, qpo, qd_l1, qd_l2, qd_h1, qd_h2, &
+                    qaux, qa_l1, qa_l2, qa_h1, qa_h2, &
                     fx, fx_l1, fx_l2, fx_h1, fx_h2, &
 #ifdef RADIATION
                     rfx, rfx_l1, rfx_l2, rfx_h1, rfx_h2, &
 #endif
                     qgdx, qgdx_l1, qgdx_l2, qgdx_h1, qgdx_h2, &
-                    gamc, gc_l1, gc_l2, gc_h1, gc_h2, &
                     srcQ, src_l1, src_l2, src_h1, src_h2, &
                     hdt, cdtdx,  &
                     area1, area1_l1, area1_l2, area1_h1, area1_h2, &
                     vol, vol_l1, vol_l2, vol_h1, vol_h2, &
                     ilo, ihi, jlo, jhi)
 
-#ifdef RADIATION
-    integer lam_l1,lam_l2,lam_h1,lam_h2
-    integer rfx_l1, rfx_l2, rfx_h1, rfx_h2
-#endif
     integer qd_l1, qd_l2, qd_h1, qd_h2
-    integer gc_l1, gc_l2, gc_h1, gc_h2
+    integer qa_l1, qa_l2, qa_h1, qa_h2
     integer fx_l1, fx_l2, fx_h1, fx_h2
     integer qgdx_l1, qgdx_l2, qgdx_h1, qgdx_h2
     integer src_l1, src_l2, src_h1, src_h2
@@ -65,7 +55,7 @@ contains
     integer ilo, ihi, jlo, jhi
 
 #ifdef RADIATION
-    double precision lam(lam_l1:lam_h1,lam_l2:lam_h2,0:ngroups-1)
+    integer rfx_l1, rfx_l2, rfx_h1, rfx_h2
     double precision rfx(rfx_l1:rfx_h1,rfx_l2:rfx_h2,0:ngroups-1)
 #endif
 
@@ -73,10 +63,10 @@ contains
     double precision qmo(qd_l1:qd_h1,qd_l2:qd_h2,NQ)
     double precision qp(qd_l1:qd_h1,qd_l2:qd_h2,NQ)
     double precision qpo(qd_l1:qd_h1,qd_l2:qd_h2,NQ)
+    double precision qaux(ga_l1:ga_h1,ga_l2:ga_h2,NQAUX)
 
     double precision fx(fx_l1:fx_h1,fx_l2:fx_h2,NVAR)
     double precision qgdx(qgdx_l1:qgdx_h1,qgdx_l2:qgdx_h2,NGDNV)
-    double precision gamc(gc_l1:gc_h1,gc_l2:gc_h2)
     double precision srcQ(src_l1:src_h1,src_l2:src_h2,QVAR)
     double precision area1(area1_l1:area1_h1,area1_l2:area1_h2)
     double precision vol(vol_l1:vol_h1,vol_l2:vol_h2)
@@ -93,7 +83,7 @@ contains
 
     ! here, pggp/pggm is the Godunov gas pressure (not radiation contribution)
     double precision :: pggp, pggm, ugp, ugm, dAup, pav, uav, dAu, pnewl,pnewr
-    double precision :: geav, dge, gegp, gegm
+    double precision :: geav, dge, gegp, gegm, gamc
     double precision :: rhotmp
 
 #ifdef RADIATION
@@ -156,7 +146,7 @@ contains
           gegm = qgdx(i,  j,GDGAME)
 
 #ifdef RADIATION
-          lambda(:) = lam(i,j,:)
+          lambda(:) = qaux(i,j,QLAMS:QLAMS+ngroups-1)
           ugc = 0.5d0*(ugp+ugm)
           ergp(:) = qgdx(i+1,j,GDERADS:GDERADS-1+ngroups)
           ergm(:) = qgdx(i  ,j,GDERADS:GDERADS-1+ngroups)
@@ -172,6 +162,13 @@ contains
           dAu = area1(i+1,j)*ugp-area1(i,j)*ugm
           geav = HALF*(gegp+gegm)
           dge = gegp-gegm
+
+          ! this is the gas gamma_1
+#ifdef RADIATION
+          gamc = qaux(i,j,QGAMCG)
+#else
+          gamc = qaux(i,j,QGAMCG)
+#endif
 
 #ifdef RADIATION
           lamge(:) = lambda(:) * (ergp(:)-ergm(:))
@@ -316,7 +313,7 @@ contains
                       !   p_t + div{Up} + (gamma_1 - 1)p div{U} = 0
                       ! The transverse term is d(up)/dx + (gamma_1 - 1)p du/dx,
                       ! but these are divergences, so we need area factors
-                      pnewr = qp(i,j,QPRES) - hdt*(dAup + pav*dAu*(gamc(i,j)-ONE))/vol(i,j)
+                      pnewr = qp(i,j,QPRES) - hdt*(dAup + pav*dAu*(gamc - ONE))/vol(i,j)
                       qpo(i,j,QPRES) = pnewr + hdt*srcQ(i,j,QPRES)
                    endif
 
@@ -326,7 +323,7 @@ contains
 
                    ! Update gammae with its transverse terms
                    qpo(i,j,QGAME) = qp(i,j,QGAME) + &
-                        hdt*( (geav-ONE)*(geav-gamc(i,j))*dAu)/vol(i,j) - cdtdx*uav*dge
+                        hdt*( (geav-ONE)*(geav - gamc)*dAu)/vol(i,j) - cdtdx*uav*dge
 
                    ! and compute the p edge state from this and (rho e)
                    qpo(i,j,QPRES) = qpo(i,j,QREINT)*(qpo(i,j,QGAME)-ONE)
@@ -453,7 +450,7 @@ contains
                       !   p_t + div{Up} + (gamma_1 - 1)p div{U} = 0
                       ! The transverse term is d(up)/dx + (gamma_1 - 1)p du/dx,
                       ! but these are divergences, so we need area factors
-                      pnewl = qm(i,j+1,QPRES) - hdt*(dAup + pav*dAu*(gamc(i,j)-ONE))/vol(i,j)
+                      pnewl = qm(i,j+1,QPRES) - hdt*(dAup + pav*dAu*(gamc - ONE))/vol(i,j)
                       qmo(i,j+1,QPRES) = pnewl + hdt*srcQ(i,j,QPRES)
                    endif
 
@@ -463,7 +460,7 @@ contains
 
                    ! Update gammae with its transverse terms
                    qmo(i,j+1,QGAME) = qm(i,j+1,QGAME) + &
-                        hdt*( (geav-ONE)*(geav-gamc(i,j))*dAu)/vol(i,j) - cdtdx*uav*dge
+                        hdt*( (geav-ONE)*(geav - gamc)*dAu)/vol(i,j) - cdtdx*uav*dge
 
                    ! and compute the p edge state from this and (rho e)
                    qmo(i,j+1,QPRES) = qmo(i,j+1,QREINT)*(qmo(i,j+1,QGAME)-ONE)
@@ -488,34 +485,25 @@ contains
   end subroutine transx
 
 
-  subroutine transy( &
-#ifdef RADIATION
-                    lam, lam_l1, lam_l2, lam_h1, lam_h2, &
-#endif
-                    qm, qmo, qp, qpo, qd_l1, qd_l2, qd_h1, qd_h2, &
+  subroutine transy(qm, qmo, qp, qpo, qd_l1, qd_l2, qd_h1, qd_h2, &
+                    qaux, qa_l1, qa_l2, qa_h1, qa_h2, &
                     fy,fy_l1,fy_l2,fy_h1,fy_h2, &
 #ifdef RADIATION
                     rfy,rfy_l1,rfy_l2,rfy_h1,rfy_h2, &
 #endif
                     qgdy, qgdy_l1, qgdy_l2, qgdy_h1, qgdy_h2, &
-                    gamc, gc_l1, gc_l2, gc_h1, gc_h2, &
                     srcQ, src_l1, src_l2, src_h1, src_h2, &
                     hdt, cdtdy, ilo, ihi, jlo, jhi)
 
-#ifdef RADIATION
-    integer lam_l1,lam_l2,lam_h1,lam_h2
-    integer rfy_l1, rfy_l2, rfy_h1, rfy_h2
-#endif
-
     integer qd_l1, qd_l2, qd_h1, qd_h2
-    integer gc_l1, gc_l2, gc_h1, gc_h2
+    integer qa_l1, qa_l2, qa_h1, qa_h2
     integer fy_l1, fy_l2, fy_h1, fy_h2
     integer qgdy_l1, qgdy_l2, qgdy_h1, qgdy_h2
     integer src_l1, src_l2, src_h1, src_h2
     integer ilo, ihi, jlo, jhi
 
 #ifdef RADIATION
-    double precision lam(lam_l1:lam_h1,lam_l2:lam_h2,0:ngroups-1)
+    integer rfy_l1, rfy_l2, rfy_h1, rfy_h2
     double precision rfy(rfy_l1:rfy_h1,rfy_l2:rfy_h2,0:ngroups-1)
 #endif
 
@@ -526,7 +514,6 @@ contains
 
     double precision fy(fy_l1:fy_h1,fy_l2:fy_h2,NVAR)
     double precision qgdy(qgdy_l1:qgdy_h1,qgdy_l2:qgdy_h2,NGDNV)
-    double precision gamc(gc_l1:gc_h1,gc_l2:gc_h2)
     double precision srcQ(src_l1:src_h1,src_l2:src_h2,QVAR)
     double precision hdt, cdtdy
 
@@ -535,7 +522,7 @@ contains
 
     double precision :: rr,rrnew
     double precision :: pggp, pggm, ugp, ugm, dup, pav, uav, du, pnewr,pnewl
-    double precision :: gegp, gegm, geav, dge
+    double precision :: gegp, gegm, geav, dge, gamc
     double precision :: rrr, rur, rvr, rer, ekinr, rhoekinr
     double precision :: rrnewr, runewr, rvnewr, renewr
     double precision :: rrl, rul, rvl, rel, ekinl, rhoekinl
@@ -598,7 +585,7 @@ contains
           gegm = qgdy(i,j  ,GDGAME)
 
 #ifdef RADIATION
-          lambda(:) = lam(i,j,:)
+          lambda(:) = qaux(i,j,QLAMS:QLAMS+ngroups-1)
           ugc = 0.5d0*(ugp+ugm)
           ergp(:) = qgdy(i,j+1,GDERADS:GDERADS-1+ngroups)
           ergm(:) = qgdy(i,j  ,GDERADS:GDERADS-1+ngroups)
@@ -613,6 +600,14 @@ contains
           du = ugp-ugm
           geav = HALF*(gegp+gegm)
           dge = gegp-gegm
+
+          ! this is the gas gamma_1
+#ifdef RADIATION
+          gamc = qaux(i,j,QGAMCG)
+#else
+          gamc = qaux(i,j,QGAMCG)
+#endif
+
 
 #ifdef RADIATION
           lamge(:) = lambda(:) * (ergp(:)-ergm(:))
@@ -733,7 +728,7 @@ contains
                       qpo(i,j,QPRES ) = pnewr
                       qpo(i,j,QREINT) = eos_state % e * eos_state % rho
                    else
-                      pnewr = qp(i  ,j,QPRES)-cdtdy*(dup + pav*du*(gamc(i,j)-ONE))
+                      pnewr = qp(i  ,j,QPRES)-cdtdy*(dup + pav*du*(gamc - ONE))
                       qpo(i,j,QPRES) = pnewr + hdt*srcQ(i,j,QPRES)
                    endif
 
@@ -743,7 +738,7 @@ contains
 
                    ! Update gammae with its transverse terms
                    qpo(i,j,QGAME) = qp(i,j,QGAME) + &
-                        cdtdy*( (geav-ONE)*(geav-gamc(i,j))*du - uav*dge )
+                        cdtdy*( (geav-ONE)*(geav - gamc)*du - uav*dge )
 
                    ! and compute the p edge state from this and (rho e)
                    qpo(i,j,QPRES) = qpo(i,j,QREINT)*(qpo(i,j,QGAME)-ONE)
@@ -856,7 +851,7 @@ contains
                       qmo(i+1,j,QPRES ) = pnewr
                       qmo(i+1,j,QREINT) = eos_state % e * eos_state % rho
                    else
-                      pnewl = qm(i+1,j,QPRES)-cdtdy*(dup + pav*du*(gamc(i,j)-ONE))
+                      pnewl = qm(i+1,j,QPRES)-cdtdy*(dup + pav*du*(gamc - ONE))
                       qmo(i+1,j,QPRES) = pnewl + hdt*srcQ(i,j,QPRES)
                    endif
 
@@ -866,7 +861,7 @@ contains
 
                    ! Update gammae with its transverse terms
                    qmo(i+1,j,QGAME) = qm(i+1,j,QGAME) + &
-                        cdtdy*( (geav-ONE)*(geav-gamc(i,j))*du - uav*dge )
+                        cdtdy*( (geav-ONE)*(geav - gamc)*du - uav*dge )
 
                    ! and compute the p edge state from this and (rho e)
                    qmo(i+1,j,QPRES) = qmo(i+1,j,QREINT)*(qmo(i+1,j,QGAME)-ONE)

--- a/Source/Src_2d/trans_2d.F90
+++ b/Source/Src_2d/trans_2d.F90
@@ -2,13 +2,14 @@ module transverse_module
 
   use bl_constants_module
   use network, only : nspec, naux
-  use meth_params_module, only : NQ, QVAR, NVAR, QRHO, QU, QV, QW, QPRES, QREINT, QGAME, &
+  use meth_params_module, only : NQ, QVAR, NQAUX, &
+                                 NVAR, QRHO, QU, QV, QW, QPRES, QREINT, QGAME, &
                                  URHO, UMX, UMY, UEDEN, UEINT, QFS, QFX, &
                                  GDU, GDV, GDPRES, GDGAME, &
-                                 NGDNV, &
+                                 NGDNV, QGAMC, &
 #ifdef RADIATION
                                  qrad, qradhi, qptot, qreitot, &
-                                 GDERADS, &
+                                 GDERADS, QGAMCG, QLAMS, &
                                  fspace_type, comoving, &
 #endif
                                  small_pres, small_temp, &
@@ -63,7 +64,8 @@ contains
     double precision qmo(qd_l1:qd_h1,qd_l2:qd_h2,NQ)
     double precision qp(qd_l1:qd_h1,qd_l2:qd_h2,NQ)
     double precision qpo(qd_l1:qd_h1,qd_l2:qd_h2,NQ)
-    double precision qaux(ga_l1:ga_h1,ga_l2:ga_h2,NQAUX)
+
+    double precision qaux(qa_l1:qa_h1,qa_l2:qa_h2,NQAUX)
 
     double precision fx(fx_l1:fx_h1,fx_l2:fx_h2,NVAR)
     double precision qgdx(qgdx_l1:qgdx_h1,qgdx_l2:qgdx_h2,NGDNV)
@@ -511,6 +513,8 @@ contains
     double precision qmo(qd_l1:qd_h1,qd_l2:qd_h2,NQ)
     double precision qp(qd_l1:qd_h1,qd_l2:qd_h2,NQ)
     double precision qpo(qd_l1:qd_h1,qd_l2:qd_h2,NQ)
+
+    double precision qaux(qa_l1:qa_h1,qa_l2:qa_h2,NQAUX)
 
     double precision fy(fy_l1:fy_h1,fy_l2:fy_h2,NVAR)
     double precision qgdy(qgdy_l1:qgdy_h1,qgdy_l2:qgdy_h2,NGDNV)

--- a/Source/Src_2d/trans_2d.F90
+++ b/Source/Src_2d/trans_2d.F90
@@ -167,7 +167,7 @@ contains
 #ifdef RADIATION
           gamc = qaux(i,j,QGAMCG)
 #else
-          gamc = qaux(i,j,QGAMCG)
+          gamc = qaux(i,j,QGAMC)
 #endif
 
 #ifdef RADIATION
@@ -605,7 +605,7 @@ contains
 #ifdef RADIATION
           gamc = qaux(i,j,QGAMCG)
 #else
-          gamc = qaux(i,j,QGAMCG)
+          gamc = qaux(i,j,QGAMC)
 #endif
 
 

--- a/Source/Src_3d/Castro_3d.F90
+++ b/Source/Src_3d/Castro_3d.F90
@@ -86,7 +86,7 @@ subroutine ca_umdrv(is_finest_level, time, &
   double precision, intent(inout) :: Erout(Erout_l1:Erout_h1, Erout_l2:Erout_h2, Erout_l3:Erout_h3, 0:ngroups-1)
 #endif
   double precision, intent(inout) :: q(q_l1:q_h1, q_l2:q_h2, q_l3:q_h3, NQ)
-  double precision, intent(in) :: qaux(qa_l1:qa_h1, qa_l2:qa_h2, qa_l3:qa_h3, NQAUX)
+  double precision, intent(inout) :: qaux(qa_l1:qa_h1, qa_l2:qa_h2, qa_l3:qa_h3, NQAUX)
   double precision, intent(in) :: srcQ(srQ_l1:srQ_h1, srQ_l2:srQ_h2, srQ_l3:srQ_h3, QVAR)
   double precision, intent(inout) :: update(updt_l1:updt_h1, updt_l2:updt_h2, updt_l3:updt_h3, NVAR)
   double precision, intent(inout) :: flux1(flux1_l1:flux1_h1, flux1_l2:flux1_h2, flux1_l3:flux1_h3, NVAR)

--- a/Source/Src_3d/Castro_3d.F90
+++ b/Source/Src_3d/Castro_3d.F90
@@ -4,7 +4,6 @@ subroutine ca_umdrv(is_finest_level, time, &
                     uout, uout_l1, uout_l2, uout_l3, uout_h1, uout_h2, uout_h3, &
 #ifdef RADIATION
                     Erin, Erin_l1, Erin_l2, Erin_l3, Erin_h1, Erin_h2, Erin_h3, &
-                    lam, lam_l1, lam_l2, lam_l3, lam_h1, lam_h2, lam_h3, &
                     Erout, Erout_l1, Erout_l2, Erout_l3, Erout_h1, Erout_h2, Erout_h3, &
 #endif
                     q, q_l1, q_l2, q_l3, q_h1, q_h2, q_h3, &
@@ -62,7 +61,6 @@ subroutine ca_umdrv(is_finest_level, time, &
 #ifdef RADIATION
   integer, intent(in) :: Erin_l1, Erin_l2, Erin_l3, Erin_h1, Erin_h2, Erin_h3
   integer, intent(in) :: Erout_l1, Erout_l2, Erout_l3, Erout_h1, Erout_h2, Erout_h3
-  integer, intent(in) :: lam_l1, lam_l2, lam_l3, lam_h1, lam_h2, lam_h3
 #endif
   integer, intent(in) :: q_l1, q_l2, q_l3, q_h1, q_h2, q_h3
   integer, intent(in) :: qa_l1, qa_l2, qa_l3, qa_h1, qa_h2, qa_h3
@@ -86,7 +84,6 @@ subroutine ca_umdrv(is_finest_level, time, &
 #ifdef RADIATION
   double precision, intent(in) :: Erin(Erin_l1:Erin_h1, Erin_l2:Erin_h2, Erin_l3:Erin_h3, 0:ngroups-1)
   double precision, intent(inout) :: Erout(Erout_l1:Erout_h1, Erout_l2:Erout_h2, Erout_l3:Erout_h3, 0:ngroups-1)
-  double precision, intent(in) :: lam(lam_l1:lam_h1, lam_l2:lam_h2, lam_l3:lam_h3, 0:ngroups-1)
 #endif
   double precision, intent(inout) :: q(q_l1:q_h1, q_l2:q_h2, q_l3:q_h3, NQ)
   double precision, intent(in) :: qaux(qa_l1:qa_h1, qa_l2:qa_h2, qa_l3:qa_h3, NQAUX)
@@ -131,7 +128,6 @@ subroutine ca_umdrv(is_finest_level, time, &
 #ifdef RADIATION
   integer :: Erin_lo(3), Erin_hi(3)                                             
   integer :: Erout_lo(3), Erout_hi(3)                                           
-  integer :: lam_lo(3), lam_hi(3)
 #endif
   integer :: updt_lo(3), updt_hi(3)
   integer :: flux1_lo(3), flux1_hi(3)
@@ -170,9 +166,6 @@ subroutine ca_umdrv(is_finest_level, time, &
   uout_hi = [ uout_h1, uout_h2, uout_h3 ]
 
 #ifdef RADIATION
-  lam_lo(:) = [lam_l1, lam_l2, lam_l3]                                          
-  lam_hi(:) = [lam_h1, lam_h2, lam_h3]       
-
   Erin_lo = [Erin_l1, Erin_l2, Erin_l3]                                         
   Erin_hi = [Erin_h1, Erin_h2, Erin_h3]                                         
                                                                                 
@@ -266,7 +259,6 @@ subroutine ca_umdrv(is_finest_level, time, &
                flux2, flux2_lo, flux2_hi, &
                flux3, flux3_lo, flux3_hi, &
 #ifdef RADIATION
-               lam, lam_lo, lam_hi, &
                radflux1, radflux1_lo, radflux1_hi, &
                radflux2, radflux2_lo, radflux2_hi, &
                radflux3, radflux3_lo, radflux3_hi, &

--- a/Source/Src_3d/Castro_advection_3d.F90
+++ b/Source/Src_3d/Castro_advection_3d.F90
@@ -39,7 +39,6 @@ contains
                      flux2, fd2_lo, fd2_hi, &
                      flux3, fd3_lo, fd3_hi, &
 #ifdef RADIATION
-                     lam, lam_lo, lam_hi, &
                      rflux1, rfd1_lo, rfd1_hi, &
                      rflux2, rfd2_lo, rfd2_hi, &
                      rflux3, rfd3_lo, rfd3_hi, &
@@ -95,7 +94,6 @@ contains
     integer, intent(in) :: q3_lo(3), q3_hi(3)
     integer, intent(in) :: domlo(3), domhi(3)
 #ifdef RADIATION
-    integer, intent(in) :: lam_lo(3), lam_hi(3)
     integer, intent(in) :: rfd1_lo(3), rfd1_hi(3)
     integer, intent(in) :: rfd2_lo(3), rfd2_hi(3)
     integer, intent(in) :: rfd3_lo(3), rfd3_hi(3)
@@ -118,8 +116,6 @@ contains
     double precision, intent(in) :: dx(3), dt
 
 #ifdef RADIATION
-    double precision lam(lam_lo(1):lam_hi(1),lam_lo(2):lam_hi(2),lam_lo(3):lam_hi(3),0:ngroups-1)
-
     double precision rflux1(rfd1_lo(1):rfd1_hi(1),rfd1_lo(2):rfd1_hi(2),rfd1_lo(3):rfd1_hi(3),0:ngroups-1)
     double precision rflux2(rfd2_lo(1):rfd2_hi(1),rfd2_lo(2):rfd2_hi(2),rfd2_lo(3):rfd2_hi(3),0:ngroups-1)
     double precision rflux3(rfd3_lo(1):rfd3_hi(1),rfd3_lo(2):rfd3_hi(2),rfd3_lo(3):rfd3_hi(3),0:ngroups-1)
@@ -440,8 +436,7 @@ contains
           ! Compute U_x and U_y at kc (k3d)
 
 #ifdef RADIATION
-          call tracexy_ppm_rad(lam, lam_lo, lam_hi, &
-                               q, qaux(:,:,:,QC), qaux(:,:,:,QCG), flatn, qd_lo, qd_hi, &
+          call tracexy_ppm_rad(q, qaux(:,:,:,QC), qaux(:,:,:,QCG), flatn, qd_lo, qd_hi, &
                                Ip, Im, Ip_src, Im_src, &
                                qxm, qxp, qym, qyp, qt_lo, qt_hi, &
                                qaux(:,:,:,QGAMC), qaux(:,:,:,QGAMCG), qa_lo, qa_hi, &
@@ -486,7 +481,6 @@ contains
                    fx, fx_lo, fx_hi, &
                    qgdnvx, qt_lo, qt_hi, &
 #ifdef RADIATION
-                   lam, lam_lo, lam_hi, &
                    rfx, fx_lo, fx_hi, &
 #endif
                    qaux, qa_lo, qa_hi, &
@@ -498,7 +492,6 @@ contains
                    fy, fy_lo, fy_hi, &
                    qgdnvy, qt_lo, qt_hi, &
 #ifdef RADIATION
-                   lam, lam_lo, lam_hi, &
                    rfy, fy_lo, fy_hi, &
 #endif
                    qaux, qa_lo, qa_hi, &
@@ -506,11 +499,7 @@ contains
                    2, lo(1)-1, hi(1)+1, lo(2), hi(2)+1, kc, kc, k3d, domlo, domhi)
 
        ! Compute U'^y_x at kc (k3d)
-       call transy1(&
-#ifdef RADIATION
-                    lam, lam_lo, lam_hi, &
-#endif
-                    qxm, qmxy, qxp, qpxy, qt_lo, qt_hi, &
+       call transy1(qxm, qmxy, qxp, qpxy, qt_lo, qt_hi, &
                     fy, &
 #ifdef RADIATION
                     rfy, &
@@ -525,11 +514,7 @@ contains
                     cdtdy, lo(1)-1, hi(1)+1, lo(2), hi(2), kc, k3d)
 
        ! Compute U'^x_y at kc (k3d)
-       call transx1(&
-#ifdef RADIATION
-                    lam, lam_lo, lam_hi, &
-#endif
-                    qym, qmyx, qyp, qpyx, qt_lo, qt_hi, &
+       call transx1(qym, qmyx, qyp, qpyx, qt_lo, qt_hi, &
                     fx, &
 #ifdef RADIATION
                     rfx, &
@@ -548,7 +533,6 @@ contains
                    fxy, fx_lo, fx_hi, &
                    qgdnvtmpx, qt_lo, qt_hi, &
 #ifdef RADIATION
-                   lam, lam_lo, lam_hi, &
                    rfxy, fx_lo, fx_hi, &
 #endif
                    qaux, qa_lo, qa_hi, &
@@ -560,7 +544,6 @@ contains
                    fyx, fy_lo, fy_hi, &
                    qgdnvtmpy, qt_lo, qt_hi, &
 #ifdef RADIATION
-                   lam, lam_lo, lam_hi, &
                    rfyx, fy_lo, fy_hi, &
 #endif
                    qaux, qa_lo, qa_hi, &
@@ -572,8 +555,7 @@ contains
           ! Compute U_z at kc (k3d)
           if (ppm_type .gt. 0) then
 #ifdef RADIATION
-          call tracez_ppm_rad(lam, lam_lo, lam_hi, &
-                              q, qaux(:,:,:,QC), qaux(:,:,:,QCG), flatn, qd_lo, qd_hi, &
+          call tracez_ppm_rad(q, qaux(:,:,:,QC), qaux(:,:,:,QCG), flatn, qd_lo, qd_hi, &
                               Ip, Im, Ip_src, Im_src, &
                               qzm, qzp, qt_lo, qt_hi, &
                               qaux(:,:,:,QGAMC), qaux(:,:,:,QGAMCG), qa_lo, qa_hi, &
@@ -599,7 +581,6 @@ contains
                       fz,fz_lo,fz_hi, &
                       qgdnvz,qt_lo,qt_hi, &
 #ifdef RADIATION
-                      lam, lam_lo, lam_hi, &
                       rfz, fz_lo, fz_hi, &
 #endif
                       qaux, qa_lo, qa_hi, &
@@ -607,11 +588,7 @@ contains
                       3, lo(1)-1, hi(1)+1, lo(2)-1, hi(2)+1, kc, kc, k3d, domlo, domhi)
 
           ! Compute U'^y_z at kc (k3d)
-          call transy2(&
-#ifdef RADIATION
-                       lam, lam_lo, lam_hi, &
-#endif
-                       qzm, qmzy, qzp, qpzy, qt_lo, qt_hi, &
+          call transy2(qzm, qmzy, qzp, qpzy, qt_lo, qt_hi, &
                        fy, &
 #ifdef RADIATION
                        rfy, &
@@ -626,11 +603,7 @@ contains
                        cdtdy, lo(1)-1, hi(1)+1, lo(2), hi(2), kc, km, k3d)
 
           ! Compute U'^x_z at kc (k3d)
-          call transx2(&
-#ifdef RADIATION
-                       lam, lam_lo, lam_hi, &
-#endif
-                       qzm, qmzx, qzp, qpzx, qt_lo, qt_hi, &
+          call transx2(qzm, qmzx, qzp, qpzx, qt_lo, qt_hi, &
                        fx, &
 #ifdef RADIATION
                        rfx, &
@@ -649,7 +622,6 @@ contains
                       fzx, fz_lo, fz_hi, &
                       qgdnvtmpz1, qt_lo, qt_hi, &
 #ifdef RADIATION
-                      lam, lam_lo, lam_hi, &
                       rfzx, fz_lo, fz_hi, &
 #endif
                       qaux, qa_lo, qa_hi, &
@@ -661,7 +633,6 @@ contains
                       fzy, fz_lo, fz_hi, &
                       qgdnvtmpz2, qt_lo, qt_hi, &
 #ifdef RADIATION
-                      lam, lam_lo, lam_hi, &
                       rfzy, fz_lo, fz_hi, &
 #endif
                       qaux, qa_lo, qa_hi, &
@@ -669,11 +640,7 @@ contains
                       3, lo(1)-1, hi(1)+1, lo(2), hi(2), kc, kc, k3d, domlo, domhi)
 
           ! Compute U''_z at kc (k3d)
-          call transxy(&
-#ifdef RADIATION
-                       lam, lam_lo, lam_hi, &
-#endif
-                       qzm, qzl, qzp, qzr, qt_lo, qt_hi, &
+          call transxy(qzm, qzl, qzp, qzr, qt_lo, qt_hi, &
                        fxy, &
 #ifdef RADIATION
                        rfxy, &
@@ -699,7 +666,6 @@ contains
                       flux3, fd3_lo, fd3_hi, &
                       qgdnvzf, qt_lo, qt_hi, &
 #ifdef RADIATION
-                      lam, lam_lo, lam_hi, &
                       rflux3, rfd3_lo, rfd3_hi, &
 #endif
                       qaux, qa_lo, qa_hi, &
@@ -726,11 +692,7 @@ contains
           if (k3d.gt.lo(3)) then
 
              ! Compute U'^z_x and U'^z_y at km (k3d-1) -- note flux3 has physical index
-             call transz(&
-#ifdef RADIATION
-                         lam, lam_lo, lam_hi, &
-#endif
-                         qxm, qmxz, qxp, qpxz, qym, qmyz, qyp, qpyz, qt_lo, qt_hi, &
+             call transz(qxm, qmxz, qxp, qpxz, qym, qmyz, qyp, qpyz, qt_lo, qt_hi, &
                          fz, &
 #ifdef RADIATION
                          rfz, &
@@ -749,7 +711,6 @@ contains
                          fxz, fx_lo, fx_hi, &
                          qgdnvx, qt_lo, qt_hi, &
 #ifdef RADIATION
-                         lam, lam_lo, lam_hi, &
                          rfxz, fx_lo, fx_hi, &
 #endif
                          qaux, qa_lo, qa_hi, &
@@ -761,7 +722,6 @@ contains
                          fyz, fy_lo, fy_hi, &
                          qgdnvy, qt_lo, qt_hi, &
 #ifdef RADIATION
-                         lam, lam_lo, lam_hi, &
                          rfyz, fy_lo, fy_hi, &
 #endif
                          qaux, qa_lo, qa_hi, &
@@ -769,11 +729,7 @@ contains
                          2, lo(1)-1, hi(1)+1, lo(2), hi(2)+1, km, km, k3d-1, domlo, domhi)
 
              ! Compute U''_x at km (k3d-1)
-             call transyz(&
-#ifdef RADIATION
-                          lam, lam_lo, lam_hi, &
-#endif
-                          qxm, qxl, qxp, qxr, qt_lo, qt_hi, &
+             call transyz(qxm, qxl, qxp, qxr, qt_lo, qt_hi, &
                           fyz, &
 #ifdef RADIATION
                           rfyz, &
@@ -795,11 +751,7 @@ contains
                           hdt, hdtdy, hdtdz, lo(1)-1, hi(1)+1, lo(2), hi(2), km, kc, k3d-1)
 
              ! Compute U''_y at km (k3d-1)
-             call transxz(&
-#ifdef RADIATION
-                          lam, lam_lo, lam_hi, &
-#endif
-                          qym, qyl, qyp, qyr, qt_lo, qt_hi, &
+             call transxz(qym, qyl, qyp, qyr, qt_lo, qt_hi, &
                           fxz, &
 #ifdef RADIATION
                           rfxz, &
@@ -825,7 +777,6 @@ contains
                          flux1, fd1_lo, fd1_hi, &
                          qgdnvxf, qt_lo, qt_hi, &
 #ifdef RADIATION
-                         lam, lam_lo, lam_hi, &
                          rflux1, rfd1_lo, rfd1_hi, &
 #endif
                          qaux, qa_lo, qa_hi, &
@@ -843,7 +794,6 @@ contains
                          flux2, fd2_lo, fd2_hi, &
                          qgdnvyf, qt_lo, qt_hi, &
 #ifdef RADIATION
-                         lam, lam_lo, lam_hi, &
                          rflux2, rfd2_lo, rfd2_hi, &
 #endif
                          qaux, qa_lo, qa_hi, &

--- a/Source/Src_3d/Castro_advection_3d.F90
+++ b/Source/Src_3d/Castro_advection_3d.F90
@@ -100,7 +100,7 @@ contains
 #endif
 
     double precision, intent(in) ::     q(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),NQ)
-    double precision, intent(in) ::  qaux(qa_lo(1):qa_hi(1),qa_lo(2):qa_hi(2),qa_lo(3):qa_hi(3),NQAUX)
+    double precision, intent(inout) ::  qaux(qa_lo(1):qa_hi(1),qa_lo(2):qa_hi(2),qa_lo(3):qa_hi(3),NQAUX)
     double precision, intent(in) :: flatn(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3))
     double precision, intent(in) ::  srcQ(src_lo(1):src_hi(1),src_lo(2):src_hi(2),src_lo(3):src_hi(3),QVAR)
 

--- a/Source/Src_3d/Castro_advection_3d.F90
+++ b/Source/Src_3d/Castro_advection_3d.F90
@@ -436,10 +436,9 @@ contains
           ! Compute U_x and U_y at kc (k3d)
 
 #ifdef RADIATION
-          call tracexy_ppm_rad(q, qaux(:,:,:,QC), qaux(:,:,:,QCG), flatn, qd_lo, qd_hi, &
+          call tracexy_ppm_rad(q, qaux, flatn, qd_lo, qd_hi, &
                                Ip, Im, Ip_src, Im_src, &
                                qxm, qxp, qym, qyp, qt_lo, qt_hi, &
-                               qaux(:,:,:,QGAMC), qaux(:,:,:,QGAMCG), qa_lo, qa_hi, &
                                lo(1),lo(2),hi(1),hi(2),dt,kc,k3d)
 #else
           call tracexy_ppm(q,qaux(:,:,:,QC),flatn,qd_lo,qd_hi, &
@@ -555,10 +554,9 @@ contains
           ! Compute U_z at kc (k3d)
           if (ppm_type .gt. 0) then
 #ifdef RADIATION
-          call tracez_ppm_rad(q, qaux(:,:,:,QC), qaux(:,:,:,QCG), flatn, qd_lo, qd_hi, &
+          call tracez_ppm_rad(q, qaux, flatn, qd_lo, qd_hi, &
                               Ip, Im, Ip_src, Im_src, &
                               qzm, qzp, qt_lo, qt_hi, &
-                              qaux(:,:,:,QGAMC), qaux(:,:,:,QGAMCG), qa_lo, qa_hi, &
                               lo(1), lo(2), hi(1), hi(2), dt, km, kc, k3d)
 
 #else

--- a/Source/Src_3d/Castro_advection_3d.F90
+++ b/Source/Src_3d/Castro_advection_3d.F90
@@ -499,32 +499,24 @@ contains
 
        ! Compute U'^y_x at kc (k3d)
        call transy1(qxm, qmxy, qxp, qpxy, qt_lo, qt_hi, &
+                    qaux, qa_lo, qa_hi, &
                     fy, &
 #ifdef RADIATION
                     rfy, &
 #endif
                     fy_lo, fy_hi, &
                     qgdnvy, qt_lo, qt_hi, &
-#ifdef RADIATION
-                    qaux(:,:,:,QGAMCG), qa_lo, qa_hi, &
-#else
-                    qaux(:,:,:,QGAMC), qa_lo, qa_hi, &
-#endif
                     cdtdy, lo(1)-1, hi(1)+1, lo(2), hi(2), kc, k3d)
 
        ! Compute U'^x_y at kc (k3d)
        call transx1(qym, qmyx, qyp, qpyx, qt_lo, qt_hi, &
+                    qaux, qa_lo, qa_hi, &
                     fx, &
 #ifdef RADIATION
                     rfx, &
 #endif
                     fx_lo, fx_hi, &
                     qgdnvx, qt_lo, qt_hi, &
-#ifdef RADIATION
-                    qaux(:,:,:,QGAMCG), qa_lo, qa_hi, &
-#else
-                    qaux(:,:,:,QGAMC), qa_lo, qa_hi, &
-#endif
                     cdtdx, lo(1), hi(1), lo(2)-1, hi(2)+1,kc,k3d)
 
        ! Compute F^{x|y} at kc (k3d)
@@ -587,32 +579,24 @@ contains
 
           ! Compute U'^y_z at kc (k3d)
           call transy2(qzm, qmzy, qzp, qpzy, qt_lo, qt_hi, &
+                       qaux, qa_lo, qa_hi, &
                        fy, &
 #ifdef RADIATION
                        rfy, &
 #endif
                        fy_lo, fy_hi, &
                        qgdnvy, qt_lo, qt_hi, &
-#ifdef RADIATION
-                       qaux(:,:,:,QGAMCG), qa_lo, qa_hi, &
-#else
-                       qaux(:,:,:,QGAMC), qa_lo, qa_hi, &
-#endif
                        cdtdy, lo(1)-1, hi(1)+1, lo(2), hi(2), kc, km, k3d)
 
           ! Compute U'^x_z at kc (k3d)
           call transx2(qzm, qmzx, qzp, qpzx, qt_lo, qt_hi, &
+                       qaux, qa_lo, qa_hi, &
                        fx, &
 #ifdef RADIATION
                        rfx, &
 #endif
                        fx_lo, fx_hi, &
                        qgdnvx, qt_lo, qt_hi, &
-#ifdef RADIATION
-                       qaux(:,:,:,QGAMCG), qa_lo, qa_hi, &
-#else
-                       qaux(:,:,:,QGAMC), qa_lo, qa_hi, &
-#endif
                        cdtdx, lo(1), hi(1), lo(2)-1, hi(2)+1, kc, km, k3d)
 
           ! Compute F^{z|x} at kc (k3d)
@@ -639,6 +623,7 @@ contains
 
           ! Compute U''_z at kc (k3d)
           call transxy(qzm, qzl, qzp, qzr, qt_lo, qt_hi, &
+                       qaux, qa_lo, qa_hi, &
                        fxy, &
 #ifdef RADIATION
                        rfxy, &
@@ -651,11 +636,6 @@ contains
                        fy_lo, fy_hi, &
                        qgdnvtmpx, qt_lo, qt_hi, &
                        qgdnvtmpy, qt_lo, qt_hi, &
-#ifdef RADIATION
-                       qaux(:,:,:,QGAMCG), qa_lo, qa_hi, &
-#else
-                       qaux(:,:,:,QGAMC), qa_lo, qa_hi, &
-#endif
                        srcQ, src_lo, src_hi,&
                        hdt, hdtdx, hdtdy, lo(1), hi(1), lo(2), hi(2), kc, km, k3d)
 
@@ -691,17 +671,13 @@ contains
 
              ! Compute U'^z_x and U'^z_y at km (k3d-1) -- note flux3 has physical index
              call transz(qxm, qmxz, qxp, qpxz, qym, qmyz, qyp, qpyz, qt_lo, qt_hi, &
+                         qaux, qa_lo, qa_hi, &
                          fz, &
 #ifdef RADIATION
                          rfz, &
 #endif
                          fz_lo, fz_hi, &
                          qgdnvz,qt_lo,qt_hi, &
-#ifdef RADIATION
-                         qaux(:,:,:,QGAMCG), qa_lo, qa_hi, &
-#else
-                         qaux(:,:,:,QGAMC), qa_lo, qa_hi, &
-#endif
                          cdtdz,lo(1)-1,hi(1)+1,lo(2)-1,hi(2)+1,km,kc,k3d)
 
              ! Compute F^{x|z} at km (k3d-1)
@@ -728,6 +704,7 @@ contains
 
              ! Compute U''_x at km (k3d-1)
              call transyz(qxm, qxl, qxp, qxr, qt_lo, qt_hi, &
+                          qaux, qa_lo, qa_hi, &
                           fyz, &
 #ifdef RADIATION
                           rfyz, &
@@ -740,16 +717,12 @@ contains
                           fz_lo, fz_hi, &
                           qgdnvy, qt_lo, qt_hi, &
                           qgdnvtmpz2, qt_lo, qt_hi, &
-#ifdef RADIATION
-                          qaux(:,:,:,QGAMCG), qa_lo, qa_hi, &
-#else
-                          qaux(:,:,:,QGAMC), qa_lo, qa_hi, &
-#endif
                           srcQ, src_lo, src_hi, &
                           hdt, hdtdy, hdtdz, lo(1)-1, hi(1)+1, lo(2), hi(2), km, kc, k3d-1)
 
              ! Compute U''_y at km (k3d-1)
              call transxz(qym, qyl, qyp, qyr, qt_lo, qt_hi, &
+                          qaux, qa_lo, qa_hi, &
                           fxz, &
 #ifdef RADIATION
                           rfxz, &
@@ -762,11 +735,6 @@ contains
                           fz_lo, fz_hi, &
                           qgdnvx, qt_lo, qt_hi, &
                           qgdnvtmpz1, qt_lo, qt_hi, &
-#ifdef RADIATION
-                          qaux(:,:,:,QGAMCG), qa_lo, qa_hi, &
-#else
-                          qaux(:,:,:,QGAMC), qa_lo, qa_hi, &
-#endif
                           srcQ, src_lo, src_hi, &
                           hdt, hdtdx, hdtdz, lo(1), hi(1), lo(2)-1, hi(2)+1, km, kc, k3d-1)
 

--- a/Source/Src_3d/riemann_3d.F90
+++ b/Source/Src_3d/riemann_3d.F90
@@ -10,7 +10,7 @@ module riemann_module
                                  NGDNV, GDRHO, GDPRES, GDGAME, &
                                  QC, QCSML, QGAMC, &
 #ifdef RADIATION
-                                 GDERADS, GDLAMS, QGAMCG, &
+                                 GDERADS, GDLAMS, QGAMCG, QLAMS, &
                                  qrad, qradhi, qptot, qreitot, fspace_type, &
 #endif
                                  small_dens, small_pres, small_temp, &
@@ -42,7 +42,6 @@ contains
                     flx, flx_lo, flx_hi, &
                     qint, q_lo, q_hi, &
 #ifdef RADIATION
-                    lam, lam_lo, lam_hi, &
                     rflx, rflx_lo, rflx_hi, &
 #endif
                     qaux, qa_lo, qa_hi, &
@@ -60,7 +59,6 @@ contains
     integer, intent(in) :: s_lo(3), s_hi(3)
 
 #ifdef RADIATION
-    integer lam_lo(3), lam_hi(3)
     integer rflx_lo(3), rflx_hi(3)
 #endif
 
@@ -81,7 +79,6 @@ contains
     double precision, intent(inout) ::   qint(q_lo(1):q_hi(1),q_lo(2):q_hi(2),q_lo(3):q_hi(3),NGDNV)
 
 #ifdef RADIATION
-    double precision, intent(in) :: lam(lam_lo(1):lam_hi(1),lam_lo(2):lam_hi(2),lam_lo(3):lam_hi(3),0:ngroups-1)
     double precision, intent(inout) :: rflx(rflx_lo(1):rflx_hi(1), rflx_lo(2):rflx_hi(2), rflx_lo(3):rflx_hi(3),0:ngroups-1)
 #endif
 
@@ -100,6 +97,7 @@ contains
     double precision, pointer :: gamcm(:,:), gamcp(:,:)
 #ifdef RADIATION
     double precision, pointer :: gamcgm(:,:), gamcgp(:,:)
+    double precision, pointer :: lam(:,:,:,:)
 #endif
 
     integer :: is_shock
@@ -118,6 +116,7 @@ contains
 #ifdef RADIATION
     call bl_allocate ( gamcgm, gd_lo(1),gd_hi(1),gd_lo(2),gd_hi(2))
     call bl_allocate ( gamcgp, gd_lo(1),gd_hi(1),gd_lo(2),gd_hi(2))
+    call bl_allocate ( lam, qa_lo(1), qa_hi(1), qa_lo(2), qa_hi(2), qa_lo(3), qa_hi(3), 0, ngroups-1)
 #endif
 
     if (idir == 1) then
@@ -163,6 +162,10 @@ contains
           enddo
        enddo
     endif
+
+#ifdef RADIATION
+    lam(:,:,:,0:ngroups-1) = qaux(:,:,:,QLAMS:QLAMS+ngroups-1)
+#endif
 
     if (ppm_temp_fix == 2) then
        ! recompute the thermodynamics on the interface to make it
@@ -225,7 +228,7 @@ contains
                       flx, flx_lo, flx_hi, &
                       qint, q_lo, q_hi, &
 #ifdef RADIATION
-                      lam, lam_lo, lam_hi, &
+                      lam, qa_lo, qa_hi, &
                       gamcgm, gamcgp, &
                       rflx, rflx_lo, rflx_hi, &
 #endif
@@ -297,6 +300,7 @@ contains
 #ifdef RADIATION
     call bl_deallocate(gamcgm)
     call bl_deallocate(gamcgp)
+    call bl_deallocate(lam)
 #endif
 
   end subroutine cmpflx
@@ -1051,8 +1055,8 @@ contains
                        uflx,uflx_lo,uflx_hi, &
                        qint,q_lo,q_hi, &
 #ifdef RADIATION
-                       lam,lam_lo,lam_hi, &
-                       gamcgl,gamcgr, &
+                       lam, lam_lo, lam_hi, &
+                       gamcgl, gamcgr, &
                        rflx, rflx_lo,rflx_hi, &
 #endif
                        idir,ilo,ihi,jlo,jhi,kc,kflux,k3d,domlo,domhi)
@@ -1073,7 +1077,7 @@ contains
     integer :: domlo(3),domhi(3)
 
 #ifdef RADIATION
-    integer lam_lo(3),lam_hi(3)
+    integer lam_lo(3), lam_hi(3)
     integer rflx_lo(3),rflx_hi(3)
 #endif
 

--- a/Source/Src_3d/trans_3d.F90
+++ b/Source/Src_3d/trans_3d.F90
@@ -3,12 +3,14 @@ module transverse_module
   use bl_constants_module
 
   use network, only : nspec, naux
-  use meth_params_module, only : NQ, QVAR, NVAR, QRHO, QU, QV, QW, &
+  use meth_params_module, only : NQ, QVAR, NVAR, NQAUX, QRHO, QU, QV, QW, &
                                  QPRES, QREINT, QGAME, QFS, QFX, &
+                                 QC, QGAMC, &
 #ifdef RADIATION
                                  qrad, qradhi, qptot, qreitot, &
                                  fspace_type, comoving, &
                                  GDERADS, GDLAMS, &
+                                 QCG, QGAMCG, QLAMS, &
 #endif
                                  URHO, UMX, UMY, UMZ, UEDEN, UEINT, UFS, &
                                  NGDNV, GDPRES, GDU, GDV, GDW, GDGAME, &
@@ -499,6 +501,7 @@ contains
     double precision rhoekenrz, rhoekenlz
     double precision compn, compu
     double precision pggp, pggm, ugp, ugm, gegp, gegm, dup, pav, du, dge, uav, geav
+    double precision :: gamc
 
 #ifdef RADIATION
     double precision :: dre, dmom
@@ -1250,6 +1253,7 @@ contains
     double precision pnewrz, pnewlz
     double precision rhoekenrz, rhoekenlz
     double precision pggp, pggm, ugp, ugm, gegp, gegm, dup, pav, du, dge, uav, geav
+    double precision :: gamc
 
 #ifdef RADIATION
     double precision :: dre, dmom
@@ -1650,6 +1654,7 @@ contains
     double precision pnewrx, pnewry, pnewlx, pnewly
     double precision rhoekenrx, rhoekenry, rhoekenlx, rhoekenly
     double precision pggp, pggm, ugp, ugm, gegp, gegm, dup, pav, du, dge, uav, geav
+    double precision :: gamc
 
 #ifdef RADIATION
     double precision :: dmz, dre
@@ -2143,6 +2148,7 @@ contains
   ! transxy
   !===========================================================================
   subroutine transxy(qm,qmo,qp,qpo,qd_lo,qd_hi, &
+                     qaux, qa_lo, qa_hi, &
                      fxy, &
 #ifdef RADIATION
                      rfxy, &

--- a/Source/Src_3d/trans_3d.F90
+++ b/Source/Src_3d/trans_3d.F90
@@ -8,12 +8,10 @@ module transverse_module
 #ifdef RADIATION
                                  qrad, qradhi, qptot, qreitot, &
                                  fspace_type, comoving, &
+                                 GDERADS, GDLAMS, &
 #endif
                                  URHO, UMX, UMY, UMZ, UEDEN, UEINT, UFS, &
                                  NGDNV, GDPRES, GDU, GDV, GDW, GDGAME, &
-#ifdef RADIATION
-                                 GDERADS, GDLAMS, &
-#endif
                                  small_pres, small_temp, &
                                  npassive, upass_map, qpass_map, &
                                  ppm_predict_gammae, ppm_trace_sources, ppm_type, &

--- a/Source/Src_nd/Castro_nd.F90
+++ b/Source/Src_nd/Castro_nd.F90
@@ -345,6 +345,9 @@ subroutine set_method_params(dm,Density,Xmom,Eden,Eint,Temp, &
   use parallel, only : parallel_initialize
   use eos_module, only : eos_init, eos_get_small_dens, eos_get_small_temp
   use bl_constants_module, only : ZERO, ONE
+#ifdef RADIATION
+  use rad_params_module, only : ngroups
+#endif
 
   implicit none
 
@@ -480,10 +483,10 @@ subroutine set_method_params(dm,Density,Xmom,Eden,Eint,Temp, &
   ! The NQAUX here are auxiliary quantities (game, gamc, c, csml, dpdr, dpde)
   ! that we create in the primitive variable call but that do not need to
   ! participate in tracing.
-  ! Note: radiation adds cg, gamcg, lambda
+  ! Note: radiation adds cg, gamcg, lambda (ngroups components)
 
 #ifdef RADIATION
-  NQAUX = 8
+  NQAUX = 7 + ngroups
 #else
   NQAUX = 5
 #endif        
@@ -496,7 +499,7 @@ subroutine set_method_params(dm,Density,Xmom,Eden,Eint,Temp, &
 #ifdef RADIATION
   QGAMCG  = 6
   QCG     = 7
-  QLAM    = 8
+  QLAMS   = 8
 #endif
 
   ! easy indexing for the passively advected quantities.  This
@@ -606,7 +609,7 @@ subroutine set_method_params(dm,Density,Xmom,Eden,Eint,Temp, &
   !$acc device(QFA, QFS, QFX) &
   !$acc device(NQAUX, QGAMC, QC, QCSML, QDPDR, QDPDE) &
 #ifdef RADIATION
-  !$acc device(QGAMCG, QCG, QLAM) &
+  !$acc device(QGAMCG, QCG, QLAMS) &
 #endif
   !$acc device(small_dens, small_temp)
 

--- a/Source/Src_nd/Castro_nd.F90
+++ b/Source/Src_nd/Castro_nd.F90
@@ -480,9 +480,10 @@ subroutine set_method_params(dm,Density,Xmom,Eden,Eint,Temp, &
   ! The NQAUX here are auxiliary quantities (game, gamc, c, csml, dpdr, dpde)
   ! that we create in the primitive variable call but that do not need to
   ! participate in tracing.
+  ! Note: radiation adds cg, gamcg, lambda
 
 #ifdef RADIATION
-  NQAUX = 7
+  NQAUX = 8
 #else
   NQAUX = 5
 #endif        
@@ -495,6 +496,7 @@ subroutine set_method_params(dm,Density,Xmom,Eden,Eint,Temp, &
 #ifdef RADIATION
   QGAMCG  = 6
   QCG     = 7
+  QLAM    = 8
 #endif
 
   ! easy indexing for the passively advected quantities.  This
@@ -604,7 +606,7 @@ subroutine set_method_params(dm,Density,Xmom,Eden,Eint,Temp, &
   !$acc device(QFA, QFS, QFX) &
   !$acc device(NQAUX, QGAMC, QC, QCSML, QDPDR, QDPDE) &
 #ifdef RADIATION
-  !$acc device(QGAMCG, QCG) &
+  !$acc device(QGAMCG, QCG, QLAM) &
 #endif
   !$acc device(small_dens, small_temp)
 

--- a/Source/Src_nd/Castro_nd.F90
+++ b/Source/Src_nd/Castro_nd.F90
@@ -483,10 +483,12 @@ subroutine set_method_params(dm,Density,Xmom,Eden,Eint,Temp, &
   ! The NQAUX here are auxiliary quantities (game, gamc, c, csml, dpdr, dpde)
   ! that we create in the primitive variable call but that do not need to
   ! participate in tracing.
-  ! Note: radiation adds cg, gamcg, lambda (ngroups components)
-
+  ! Note: radiation adds cg, gamcg, lambda (ngroups components), but we don't
+  ! yet know the number of radiation groups, so we'll add that lambda count
+  ! to it later
+   
 #ifdef RADIATION
-  NQAUX = 7 + ngroups
+  NQAUX = 7 !+ ngroups to be added later
 #else
   NQAUX = 5
 #endif        

--- a/Source/Src_nd/advection_util_nd.F90
+++ b/Source/Src_nd/advection_util_nd.F90
@@ -457,7 +457,7 @@ contains
 
     double precision, parameter :: small = 1.d-8
 
-    integer          :: i, j, k
+    integer          :: i, j, k, g
     integer          :: n, iq, ipassive
     double precision :: kineng, rhoinv
     double precision :: vel(3)
@@ -573,7 +573,10 @@ contains
 
              qaux(i,j,k,QC)    = ctot
              qaux(i,j,k,QGAMC) = gamc_tot
-             qaux(i,j,k,QLAMS:QLAMS-1+ngroups) = lam(i,j,k,0:ngroups-1)
+
+             do g = 0, ngroups-1
+                qaux(i,j,k,QLAMS+g) = lam(i,j,k,g)
+             enddo
 
              q(i,j,k,qreitot) = q(i,j,k,QREINT) + sum(q(i,j,k,qrad:qradhi))
 #else

--- a/Source/Src_nd/advection_util_nd.F90
+++ b/Source/Src_nd/advection_util_nd.F90
@@ -418,7 +418,7 @@ contains
                                    QREINT, QPRES, QTEMP, QGAME, QFS, QFX, &
                                    NQ, QC, QCSML, QGAMC, QDPDR, QDPDE, NQAUX, &
 #ifdef RADIATION
-                                   QCG, QGAMCG, &
+                                   QCG, QGAMCG, QLAMS, &
                                    QPTOT, QRAD, QRADHI, QREITOT, &
 #endif
                                    npassive, upass_map, qpass_map, dual_energy_eta1, &

--- a/Source/Src_nd/advection_util_nd.F90
+++ b/Source/Src_nd/advection_util_nd.F90
@@ -573,6 +573,7 @@ contains
 
              qaux(i,j,k,QC)    = ctot
              qaux(i,j,k,QGAMC) = gamc_tot
+             qaux(i,j,k,QLAMS:QLAMS-1+ngroups) = lam(i,j,k,0:ngroups-1)
 
              q(i,j,k,qreitot) = q(i,j,k,QREINT) + sum(q(i,j,k,qrad:qradhi))
 #else

--- a/Source/Src_nd/meth_params.F90
+++ b/Source/Src_nd/meth_params.F90
@@ -29,7 +29,7 @@ module meth_params_module
   integer, save :: QRHO, QU, QV, QW, QPRES, QREINT, QTEMP, QGAME
   integer, save :: NQAUX, QGAMC, QC, QCSML, QDPDR, QDPDE
 #ifdef RADIATION
-  integer, save :: QGAMCG, QCG
+  integer, save :: QGAMCG, QCG, QLAM
 #endif
   integer, save :: QFA, QFS, QFX
 
@@ -90,7 +90,7 @@ module meth_params_module
   !$acc create(QGAMC, QGAME) &
   !$acc create(NQ) &
 #ifdef RADIATION
-  !$acc create(QGAMCG, QCG) &
+  !$acc create(QGAMCG, QCG, QLAM) &
   !$acc create(QRADVAR, QRAD, QRADHI, QPTOT, QREITOT) &
   !$acc create(fspace_type, do_inelastic_scattering, comoving) &
 #endif

--- a/Source/Src_nd/meth_params.F90
+++ b/Source/Src_nd/meth_params.F90
@@ -29,7 +29,7 @@ module meth_params_module
   integer, save :: QRHO, QU, QV, QW, QPRES, QREINT, QTEMP, QGAME
   integer, save :: NQAUX, QGAMC, QC, QCSML, QDPDR, QDPDE
 #ifdef RADIATION
-  integer, save :: QGAMCG, QCG, QLAM
+  integer, save :: QGAMCG, QCG, QLAMS
 #endif
   integer, save :: QFA, QFS, QFX
 
@@ -90,7 +90,7 @@ module meth_params_module
   !$acc create(QGAMC, QGAME) &
   !$acc create(NQ) &
 #ifdef RADIATION
-  !$acc create(QGAMCG, QCG, QLAM) &
+  !$acc create(QGAMCG, QCG, QLAMS) &
   !$acc create(QRADVAR, QRAD, QRADHI, QPTOT, QREITOT) &
   !$acc create(fspace_type, do_inelastic_scattering, comoving) &
 #endif

--- a/Source/Src_nd/meth_params.F90
+++ b/Source/Src_nd/meth_params.F90
@@ -500,6 +500,10 @@ contains
     ! update NQ -- it was already initialized in the hydro
     NQ = QRADVAR
 
+    ! NQAUX already knows about the hydro and the non-group-dependent
+    ! rad variables, update it here
+    NQAUX = NQAUX + ngroups
+
     if (ngroups .eq. 1) then
        fspace_type = 1
     else
@@ -523,7 +527,7 @@ contains
     flatten_pp_threshold = fppt
     
     !$acc update &
-    !$acc device(NQ) &
+    !$acc device(NQ,NQAUX) &
     !$acc device(QRADVAR, QRAD, QRADHI, QPTOT, QREITOT) &
     !$acc device(fspace_type) &
     !$acc device(do_inelastic_scattering) &

--- a/Source/Src_nd/meth_params.template
+++ b/Source/Src_nd/meth_params.template
@@ -24,7 +24,7 @@ module meth_params_module
   integer, save :: QRHO, QU, QV, QW, QPRES, QREINT, QTEMP, QGAME
   integer, save :: NQAUX, QGAMC, QC, QCSML, QDPDR, QDPDE
 #ifdef RADIATION
-  integer, save :: QGAMCG, QCG
+  integer, save :: QGAMCG, QCG, QLAM
 #endif
   integer, save :: QFA, QFS, QFX
 
@@ -85,7 +85,7 @@ module meth_params_module
   !$acc create(QGAMC, QGAME) &
   !$acc create(NQ) &
 #ifdef RADIATION
-  !$acc create(QGAMCG, QCG) &
+  !$acc create(QGAMCG, QCG, QLAM) &
   !$acc create(QRADVAR, QRAD, QRADHI, QPTOT, QREITOT) &
   !$acc create(fspace_type, do_inelastic_scattering, comoving) &
 #endif

--- a/Source/Src_nd/meth_params.template
+++ b/Source/Src_nd/meth_params.template
@@ -24,7 +24,7 @@ module meth_params_module
   integer, save :: QRHO, QU, QV, QW, QPRES, QREINT, QTEMP, QGAME
   integer, save :: NQAUX, QGAMC, QC, QCSML, QDPDR, QDPDE
 #ifdef RADIATION
-  integer, save :: QGAMCG, QCG, QLAM
+  integer, save :: QGAMCG, QCG, QLAMS
 #endif
   integer, save :: QFA, QFS, QFX
 
@@ -85,7 +85,7 @@ module meth_params_module
   !$acc create(QGAMC, QGAME) &
   !$acc create(NQ) &
 #ifdef RADIATION
-  !$acc create(QGAMCG, QCG, QLAM) &
+  !$acc create(QGAMCG, QCG, QLAMS) &
   !$acc create(QRADVAR, QRAD, QRADHI, QPTOT, QREITOT) &
   !$acc create(fspace_type, do_inelastic_scattering, comoving) &
 #endif

--- a/Source/Src_nd/meth_params.template
+++ b/Source/Src_nd/meth_params.template
@@ -205,6 +205,10 @@ contains
     ! update NQ -- it was already initialized in the hydro
     NQ = QRADVAR
 
+    ! NQAUX already knows about the hydro and the non-group-dependent
+    ! rad variables, update it here
+    NQAUX = NQAUX + ngroups
+
     if (ngroups .eq. 1) then
        fspace_type = 1
     else
@@ -228,7 +232,7 @@ contains
     flatten_pp_threshold = fppt
     
     !$acc update &
-    !$acc device(NQ) &
+    !$acc device(NQ,NQAUX) &
     !$acc device(QRADVAR, QRAD, QRADHI, QPTOT, QREITOT) &
     !$acc device(fspace_type) &
     !$acc device(do_inelastic_scattering) &


### PR DESCRIPTION
This is a cleanup -- it simplifies a lot of interfaces.  There should be no changes introduced.  The test suite confirms this:

http://bender.astro.sunysb.edu/Castro/test-suite/test-suite-gfortran/2016-12-30-001/index.html

Upon merge, we will squish these into a single commit