### PR TITLE
switch all double precision declarations and constants to c_real

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,12 @@
 # changes since the last release:
 
+  -- to support both single and double precision, all of the 
+     floating point declarations use the c_real type defined
+     in the bl_fort_module -- this is set to single or double
+     precision at compile time.  All constants also now use
+     this type.  For brevity, we rename it to 'rt' in the use
+     statement.  (issue #34)
+
 
 # previous changes:
 

--- a/Docs/Software/CastroSoftware.tex
+++ b/Docs/Software/CastroSoftware.tex
@@ -117,9 +117,21 @@ Floating point data in the \cpp\ \boxlib\ frame work is declared as
 {\tt Real}.  This is {\tt typedef} to either {\tt float} or {\tt
   double} depending on the make variable \makevar{PRECISION}.
 
-At present, single precision is not supported in \castro.  This is
-because the Fortran routines that we interact with are all written to
-accept double precision inputs.
+The corresponding type for Fortran is provided by the
+\code{bl\_fort\_module} as \variable{c\_real}.  We typically rename
+this to \variable{rt} when using it.  An example of a declaration of a
+parameter is:
+\begin{lstlisting}[language=fortran]
+  use bl_fort_module, only : rt => c_real                                       
+
+  real(rt) :: tol = 1.0e-10_rt
+\end{lstlisting}
+
+The {\tt bl\_constants\_module} provides common constants that can
+be used in the code, like {\tt ZERO}, {\tt THIRD}, {\tt ONE}, etc.
+
+Note: single precision support in \castro\ is not yet complete.  In
+particular, a lot of the supporting microphysics has not been updated.
 
 \subsection{\bbox\ and \farraybox}
 

--- a/Exec/gravity_tests/DustCollapse/Prob_1d.f90
+++ b/Exec/gravity_tests/DustCollapse/Prob_1d.f90
@@ -6,13 +6,14 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
   use meth_params_module, only: small_temp
   use prob_params_module, only : center
   use network, only : nspec
+  use bl_fort_module, only : rt => c_real
   implicit none 
 
   integer :: init,namlen,untin,i,k
   integer :: name(namlen)
 
-  double precision :: center_x, center_y, center_z
-  double precision :: problo(1), probhi(1)
+  real(rt)         :: center_x, center_y, center_z
+  real(rt)         :: problo(1), probhi(1)
 
   type (eos_t) :: eos_state
 
@@ -34,11 +35,11 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
          
 ! set namelist defaults
 
-  rho_0 = 1.d9
-  r_0 = 6.5d8
-  p_0 = 1.d10
-  rho_ambient = 1.d0
-  smooth_delta = 1.d-5
+  rho_0 = 1.e9_rt
+  r_0 = 6.5e8_rt
+  p_0 = 1.e10_rt
+  rho_ambient = 1.e0_rt
+  smooth_delta = 1.e-5_rt
 
 !     Read namelists in probin file
   untin = 9
@@ -47,10 +48,10 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
   close(unit=untin)
 
   ! in 1-d spherical, the lower domain boundary should be the origin
-  center(1) = 0.0d0
+  center(1) = 0.0e0_rt
 
   xmin = problo(1)
-  if (xmin /= 0.d0) call bl_error("ERROR: xmin should be 0!")
+  if (xmin /= 0.e0_rt) call bl_error("ERROR: xmin should be 0!")
 
 
   xmax = probhi(1)
@@ -112,17 +113,18 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
   use meth_params_module, only : NVAR, URHO, UMX, UMY, UMZ, UTEMP, UEDEN, UEINT, UFS, small_temp
   use prob_params_module, only : center
 
+  use bl_fort_module, only : rt => c_real
   implicit none
   
   integer          :: level, nscal
   integer          :: lo(1), hi(1)
   integer          :: state_l1,state_h1
-  double precision :: state(state_l1:state_h1,NVAR)
-  double precision :: time, delta(1)
-  double precision :: xlo(1), xhi(1)
+  real(rt)         :: state(state_l1:state_h1,NVAR)
+  real(rt)         :: time, delta(1)
+  real(rt)         :: xlo(1), xhi(1)
   
-  double precision :: xl,xx,dist,pres,eint,temp,avg_rho, rho_n
-  double precision :: dx_sub
+  real(rt)         :: xl,xx,dist,pres,eint,temp,avg_rho, rho_n
+  real(rt)         :: dx_sub
   integer          :: i,ii,n
 
   type (eos_t) :: eos_state
@@ -134,18 +136,18 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
   do i = lo(1), hi(1)
      xl = dble(i) * delta(1)
       
-     avg_rho = 0.d0
+     avg_rho = 0.e0_rt
 
      do ii = 0, nsub-1
 
-        xx = xl + (dble(ii) + 0.5d0) * dx_sub
+        xx = xl + (dble(ii) + 0.5e0_rt) * dx_sub
         
         dist = (xx-center(1))
         
         ! use a tanh profile to smooth the transition between rho_0                                    
         ! and rho_ambient                                                                              
         rho_n = rho_0 - (rho_0 - rho_ambient)* &
-             0.5d0 * (1.d0 + tanh((dist - r_0)/smooth_delta))
+             0.5e0_rt * (1.e0_rt + tanh((dist - r_0)/smooth_delta))
                 
         avg_rho = avg_rho + rho_n
         
@@ -164,7 +166,7 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
      eint = eos_state % e
      
      state(i,UTEMP) = temp
-     state(i,UMX) = 0.d0
+     state(i,UMX) = 0.e0_rt
      state(i,UEDEN) = state(i,URHO) * eint
      state(i,UEINT) = state(i,URHO) * eint
      state(i,UFS:UFS+nspec-1) = state(i,URHO) * X_0(1:nspec)

--- a/Exec/gravity_tests/DustCollapse/Prob_2d.f90
+++ b/Exec/gravity_tests/DustCollapse/Prob_2d.f90
@@ -6,13 +6,14 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
   use meth_params_module, only: small_temp
   use prob_params_module, only : center
   use network, only : nspec
+  use bl_fort_module, only : rt => c_real
   implicit none 
 
   integer :: init,namlen,untin,i,k
   integer :: name(namlen)
 
-  double precision :: center_x, center_y, center_z
-  double precision :: problo(2), probhi(2)
+  real(rt)         :: center_x, center_y, center_z
+  real(rt)         :: problo(2), probhi(2)
 
   type (eos_t) :: eos_state
 
@@ -34,12 +35,12 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
          
 ! set namelist defaults
 
-  rho_0 = 1.d9
-  r_0 = 6.5d8
+  rho_0 = 1.e9_rt
+  r_0 = 6.5e8_rt
   r_old = r_0
-  p_0 = 1.d10
-  rho_ambient = 1.d0
-  smooth_delta = 1.d-5
+  p_0 = 1.e10_rt
+  rho_ambient = 1.e0_rt
+  smooth_delta = 1.e-5_rt
 
 !     Read namelists in probin file
   untin = 9
@@ -54,12 +55,12 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
   center(2) = center_y
 
   xmin = problo(1)
-  if (xmin /= 0.d0) call bl_error("ERROR: xmin should be 0!")
+  if (xmin /= 0.e0_rt) call bl_error("ERROR: xmin should be 0!")
 
   xmax = probhi(1)
 
   ymin = problo(2)
-  if (ymin /= 0.d0) call bl_error("ERROR: ymin should be 0!")
+  if (ymin /= 0.e0_rt) call bl_error("ERROR: ymin should be 0!")
 
   ymax = probhi(2)
 
@@ -121,17 +122,18 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
   use meth_params_module, only : NVAR, URHO, UMX, UMY, UMZ, UTEMP, UEDEN, UEINT, UFS, small_temp
   use prob_params_module, only : center
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer          :: level, nscal
   integer          :: lo(2), hi(2)
   integer          :: state_l1,state_l2,state_h1,state_h2
-  double precision :: state(state_l1:state_h1,state_l2:state_h2,NVAR)
-  double precision :: time, delta(2)
-  double precision :: xlo(2), xhi(2)
+  real(rt)         :: state(state_l1:state_h1,state_l2:state_h2,NVAR)
+  real(rt)         :: time, delta(2)
+  real(rt)         :: xlo(2), xhi(2)
   
-  double precision :: xl,yl,xx,yy,dist,pres,eint,temp,avg_rho, rho_n
-  double precision :: dx_sub,dy_sub
+  real(rt)         :: xl,yl,xx,yy,dist,pres,eint,temp,avg_rho, rho_n
+  real(rt)         :: dx_sub,dy_sub
   integer          :: i,j,ii,jj,n
 
   type (eos_t) :: eos_state
@@ -147,20 +149,20 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
      do i = lo(1), hi(1)
         xl = xmin + dble(i) * delta(1)
 
-        avg_rho = 0.d0
+        avg_rho = 0.e0_rt
 
         do jj = 0, nsub-1
-           yy = yl + (dble(jj) + 0.5d0) * dy_sub
+           yy = yl + (dble(jj) + 0.5e0_rt) * dy_sub
 
            do ii = 0, nsub-1
-              xx = xl + (dble(ii) + 0.5d0) * dx_sub
+              xx = xl + (dble(ii) + 0.5e0_rt) * dx_sub
 
               dist = sqrt((xx-center(1))**2 + (yy-center(2))**2)
 
               ! use a tanh profile to smooth the transition between rho_0 
               ! and rho_ambient
-              rho_n = rho_0 - 0.5d0*(rho_0 - rho_ambient)* &
-                   (1.d0 + tanh((dist - r_0)/smooth_delta))
+              rho_n = rho_0 - 0.5e0_rt*(rho_0 - rho_ambient)* &
+                   (1.e0_rt + tanh((dist - r_0)/smooth_delta))
 
               avg_rho = avg_rho + rho_n
 
@@ -180,8 +182,8 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
         eint = eos_state % e
 
         state(i,j,UTEMP) = temp
-        state(i,j,UMX) = 0.d0
-        state(i,j,UMY) = 0.d0
+        state(i,j,UMX) = 0.e0_rt
+        state(i,j,UMY) = 0.e0_rt
         state(i,j,UEDEN) = state(i,j,URHO) * eint
         state(i,j,UEINT) = state(i,j,URHO) * eint
         state(i,j,UFS:UFS+nspec-1) = state(i,j,URHO) * X_0(1:nspec)

--- a/Exec/gravity_tests/DustCollapse/Prob_3d.f90
+++ b/Exec/gravity_tests/DustCollapse/Prob_3d.f90
@@ -7,13 +7,14 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
   use meth_params_module, only : small_temp
   use prob_params_module, only : center
 
+  use bl_fort_module, only : rt => c_real
   implicit none 
 
   integer :: init,namlen,untin,i,k
   integer :: name(namlen)
 
-  double precision :: center_x, center_y, center_z
-  double precision :: problo(3), probhi(3)
+  real(rt)         :: center_x, center_y, center_z
+  real(rt)         :: problo(3), probhi(3)
 
   type (eos_t) :: eos_state
 
@@ -35,12 +36,12 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
 
   is_3d_fullstar = .false.
 
-  rho_0 = 1.d9
-  r_0 = 6.5d8
+  rho_0 = 1.e9_rt
+  r_0 = 6.5e8_rt
   r_old = r_0
-  p_0 = 1.d10
-  rho_ambient = 1.d0
-  smooth_delta = 1.d-5
+  p_0 = 1.e10_rt
+  rho_ambient = 1.e0_rt
+  smooth_delta = 1.e-5_rt
 
   ! Read namelists in probin file
   untin = 9
@@ -122,24 +123,25 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
   use meth_params_module, only : NVAR, URHO, UMX, UMY, UMZ, UTEMP, UEDEN, UEINT, UFS, small_temp
   use prob_params_module, only : center
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer          :: level, nscal
   integer          :: lo(3), hi(3)
   integer          :: state_l1,state_l2,state_l3,state_h1,state_h2,state_h3
-  double precision :: state(state_l1:state_h1,state_l2:state_h2,state_l3:state_h3,NVAR)
-  double precision :: time, delta(3)
-  double precision :: xlo(3), xhi(3)
+  real(rt)         :: state(state_l1:state_h1,state_l2:state_h2,state_l3:state_h3,NVAR)
+  real(rt)         :: time, delta(3)
+  real(rt)         :: xlo(3), xhi(3)
   
-  double precision :: xl,yl,zl,xx,yy,zz,dist,pres,eint,temp,avg_rho,rho_n,volinv
-  double precision :: dx_sub,dy_sub,dz_sub
+  real(rt)         :: xl,yl,zl,xx,yy,zz,dist,pres,eint,temp,avg_rho,rho_n,volinv
+  real(rt)         :: dx_sub,dy_sub,dz_sub
   integer          :: i,j,k,ii,jj,kk,n
 
   type (eos_t) :: eos_state
 
   integer, parameter :: nsub = 5
 
-  volinv = 1.d0/dble(nsub*nsub*nsub)
+  volinv = 1.e0_rt/dble(nsub*nsub*nsub)
 
   dx_sub = delta(1)/dble(nsub)
   dy_sub = delta(2)/dble(nsub)
@@ -154,23 +156,23 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
         do i = lo(1), hi(1)
            xl = xmin + dble(i) * delta(1)
 
-           avg_rho = 0.d0
+           avg_rho = 0.e0_rt
            
            do kk = 0, nsub-1
-              zz = zl + (dble(kk) + 0.5d0) * dz_sub
+              zz = zl + (dble(kk) + 0.5e0_rt) * dz_sub
 
               do jj = 0, nsub-1
-                 yy = yl + (dble(jj) + 0.5d0) * dy_sub
+                 yy = yl + (dble(jj) + 0.5e0_rt) * dy_sub
 
                  do ii = 0, nsub-1
-                    xx = xl + (dble(ii) + 0.5d0) * dx_sub
+                    xx = xl + (dble(ii) + 0.5e0_rt) * dx_sub
                     
                     dist = sqrt((xx-center(1))**2 + (yy-center(2))**2 + (zz-center(3))**2)
                     
                     ! use a tanh profile to smooth the transition between rho_0 
                     ! and rho_ambient
-                    rho_n = rho_0 - 0.5d0*(rho_0 - rho_ambient)* &
-                         (1.d0 + tanh((dist - r_0)/smooth_delta))
+                    rho_n = rho_0 - 0.5e0_rt*(rho_0 - rho_ambient)* &
+                         (1.e0_rt + tanh((dist - r_0)/smooth_delta))
 
                     avg_rho = avg_rho + rho_n
                     
@@ -191,9 +193,9 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
            eint = eos_state % e
            
            state(i,j,k,UTEMP) = temp
-           state(i,j,k,UMX) = 0.d0
-           state(i,j,k,UMY) = 0.d0
-           state(i,j,k,UMZ) = 0.d0
+           state(i,j,k,UMX) = 0.e0_rt
+           state(i,j,k,UMY) = 0.e0_rt
+           state(i,j,k,UMZ) = 0.e0_rt
            state(i,j,k,UEDEN) = state(i,j,k,URHO) * eint
            state(i,j,k,UEINT) = state(i,j,k,URHO) * eint
            state(i,j,k,UFS:UFS+nspec-1) = state(i,j,k,URHO) * X_0(1:nspec)

--- a/Exec/gravity_tests/DustCollapse/bc_fill_3d.F90
+++ b/Exec/gravity_tests/DustCollapse/bc_fill_3d.F90
@@ -1,5 +1,6 @@
 module bc_fill_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   public
@@ -13,6 +14,7 @@ contains
     use meth_params_module, only : NVAR,UMX,UMY,UMZ
     use prob_params_module, only : center
 
+    use bl_fort_module, only : rt => c_real
     implicit none
     
     include 'bc_types.fi'
@@ -20,14 +22,14 @@ contains
     integer adv_l1,adv_l2,adv_l3,adv_h1,adv_h2,adv_h3
     integer bc(3,2,*)
     integer domlo(3), domhi(3)
-    double precision delta(3), xlo(3), time
-    double precision adv(adv_l1:adv_h1,adv_l2:adv_h2,adv_l3:adv_h3,NVAR)
+    real(rt)         delta(3), xlo(3), time
+    real(rt)         adv(adv_l1:adv_h1,adv_l2:adv_h2,adv_l3:adv_h3,NVAR)
 
     integer          :: i, j, k, n
     integer          :: ic,jc,kc
-    double precision :: x,y,z,r
-    double precision :: xc,yc,zc,rc
-    double precision :: mom,momc
+    real(rt)         :: x,y,z,r
+    real(rt)         :: xc,yc,zc,rc
+    real(rt)         :: mom,momc
 
     do n = 1,NVAR
        call filcc(adv(adv_l1,adv_l2,adv_l3,n), &
@@ -53,25 +55,25 @@ contains
        do k = adv_l3, adv_h3
           do j = adv_l2, adv_h2
 
-             y = (dble(j) + 0.5d0) * delta(2) - center(2)
-             z = (dble(k) + 0.5d0) * delta(3) - center(3)
+             y = (dble(j) + 0.5e0_rt) * delta(2) - center(2)
+             z = (dble(k) + 0.5e0_rt) * delta(3) - center(3)
 
              ic = domlo(1)
-             xc = (dble(ic) + 0.5d0) * delta(1) - center(1)
+             xc = (dble(ic) + 0.5e0_rt) * delta(1) - center(1)
              rc = sqrt(xc**2 + y**2 + z**2)
 
              momc = sqrt(adv(ic,j,k,UMX)**2 + adv(ic,j,k,UMY)**2 + adv(ic,j,k,UMZ)**2)
 
              do i = adv_l1, domlo(1)-1
-                x = (dble(i) + 0.5d0) * delta(1) - center(1)
+                x = (dble(i) + 0.5e0_rt) * delta(1) - center(1)
                 r = sqrt(x**2 + y**2 + z**2)
 
                 mom  = momc * (rc/r)**2
 
                 ! Project along the normal
-                adv(i,j,k,UMX) =  sign(1.d0,adv(ic,j,k,UMX)) * mom * (x/r)
-                adv(i,j,k,UMY) =  sign(1.d0,adv(ic,j,k,UMY)) * mom * (y/r)
-                adv(i,j,k,UMZ) =  sign(1.d0,adv(ic,j,k,UMZ)) * mom * (z/r)
+                adv(i,j,k,UMX) =  sign(1.e0_rt,adv(ic,j,k,UMX)) * mom * (x/r)
+                adv(i,j,k,UMY) =  sign(1.e0_rt,adv(ic,j,k,UMY)) * mom * (y/r)
+                adv(i,j,k,UMZ) =  sign(1.e0_rt,adv(ic,j,k,UMZ)) * mom * (z/r)
 
              end do
           end do
@@ -83,25 +85,25 @@ contains
        do k = adv_l3, adv_h3
           do j = adv_l2, adv_h2
 
-             y = (dble(j) + 0.5d0) * delta(2) - center(2)
-             z = (dble(k) + 0.5d0) * delta(3) - center(3)
+             y = (dble(j) + 0.5e0_rt) * delta(2) - center(2)
+             z = (dble(k) + 0.5e0_rt) * delta(3) - center(3)
 
              ic = domhi(1)
-             xc = (dble(ic) + 0.5d0) * delta(1) - center(1)
+             xc = (dble(ic) + 0.5e0_rt) * delta(1) - center(1)
              rc = sqrt(xc**2 + y**2 + z**2)
 
              momc = sqrt(adv(ic,j,k,UMX)**2 + adv(ic,j,k,UMY)**2 + adv(ic,j,k,UMZ)**2)
 
              do i = domhi(1)+1, adv_h1
-                x = (dble(i) + 0.5d0) * delta(1) - center(1)
+                x = (dble(i) + 0.5e0_rt) * delta(1) - center(1)
                 r = sqrt(x**2 + y**2 + z**2)
 
                 mom  = momc * (rc/r)**2
 
                 ! Project along the normal
-                adv(i,j,k,UMX) =  sign(1.d0,adv(ic,j,k,UMX)) * mom * (x/r)
-                adv(i,j,k,UMY) =  sign(1.d0,adv(ic,j,k,UMY)) * mom * (y/r)
-                adv(i,j,k,UMZ) =  sign(1.d0,adv(ic,j,k,UMZ)) * mom * (z/r)
+                adv(i,j,k,UMX) =  sign(1.e0_rt,adv(ic,j,k,UMX)) * mom * (x/r)
+                adv(i,j,k,UMY) =  sign(1.e0_rt,adv(ic,j,k,UMY)) * mom * (y/r)
+                adv(i,j,k,UMZ) =  sign(1.e0_rt,adv(ic,j,k,UMZ)) * mom * (z/r)
 
              end do
           end do
@@ -113,26 +115,26 @@ contains
        do k = adv_l3, adv_h3
           do i = adv_l1, adv_h1
 
-             x = (dble(i) + 0.5d0) * delta(1) - center(1)
-             z = (dble(k) + 0.5d0) * delta(3) - center(3)
+             x = (dble(i) + 0.5e0_rt) * delta(1) - center(1)
+             z = (dble(k) + 0.5e0_rt) * delta(3) - center(3)
 
              jc = domlo(2)
-             yc = (dble(jc) + 0.5d0) * delta(2) - center(2)
+             yc = (dble(jc) + 0.5e0_rt) * delta(2) - center(2)
              rc = sqrt(x**2 + yc**2 + z**2)
 
              momc = sqrt(adv(i,jc,k,UMX)**2 + adv(i,jc,k,UMY)**2 + adv(i,jc,k,UMZ)**2)
 
              do j = adv_l2, domlo(2)-1
 
-                y = (dble(j) + 0.5d0) * delta(2) - center(2)
+                y = (dble(j) + 0.5e0_rt) * delta(2) - center(2)
                 r = sqrt(x**2 + y**2 + z**2)
 
                 mom  = momc * (rc/r)**2
 
                 ! Project along the normal
-                adv(i,j,k,UMX) =  sign(1.d0,adv(i,jc,k,UMX)) * mom * (x/r)
-                adv(i,j,k,UMY) =  sign(1.d0,adv(i,jc,k,UMY)) * mom * (y/r)
-                adv(i,j,k,UMZ) =  sign(1.d0,adv(i,jc,k,UMZ)) * mom * (z/r)
+                adv(i,j,k,UMX) =  sign(1.e0_rt,adv(i,jc,k,UMX)) * mom * (x/r)
+                adv(i,j,k,UMY) =  sign(1.e0_rt,adv(i,jc,k,UMY)) * mom * (y/r)
+                adv(i,j,k,UMZ) =  sign(1.e0_rt,adv(i,jc,k,UMZ)) * mom * (z/r)
 
              end do
           end do
@@ -144,25 +146,25 @@ contains
        do k = adv_l3, adv_h3
           do i = adv_l1, adv_h1
 
-             x = (dble(i) + 0.5d0) * delta(1) - center(1)
-             z = (dble(k) + 0.5d0) * delta(3) - center(3)
+             x = (dble(i) + 0.5e0_rt) * delta(1) - center(1)
+             z = (dble(k) + 0.5e0_rt) * delta(3) - center(3)
 
              jc = domhi(2)
-             yc = (dble(jc) + 0.5d0) * delta(2) - center(2)
+             yc = (dble(jc) + 0.5e0_rt) * delta(2) - center(2)
              rc = sqrt(x**2 + yc**2 + z**2)
 
              momc = sqrt(adv(i,jc,k,UMX)**2 + adv(i,jc,k,UMY)**2 + adv(i,jc,k,UMZ)**2)
 
              do j = domhi(2)+1, adv_h2
-                y = (dble(j) + 0.5d0) * delta(2) - center(2)
+                y = (dble(j) + 0.5e0_rt) * delta(2) - center(2)
                 r = sqrt(x**2 + y**2 + z**2)
 
                 mom  = momc * (rc/r)**2
 
                 ! Project along the normal
-                adv(i,j,k,UMX) =  sign(1.d0,adv(i,jc,k,UMX)) * mom * (x/r)
-                adv(i,j,k,UMY) =  sign(1.d0,adv(i,jc,k,UMY)) * mom * (y/r)
-                adv(i,j,k,UMZ) =  sign(1.d0,adv(i,jc,k,UMZ)) * mom * (z/r)
+                adv(i,j,k,UMX) =  sign(1.e0_rt,adv(i,jc,k,UMX)) * mom * (x/r)
+                adv(i,j,k,UMY) =  sign(1.e0_rt,adv(i,jc,k,UMY)) * mom * (y/r)
+                adv(i,j,k,UMZ) =  sign(1.e0_rt,adv(i,jc,k,UMZ)) * mom * (z/r)
 
              end do
           end do
@@ -174,25 +176,25 @@ contains
        do j = adv_l2, adv_h2
           do i = adv_l1, adv_h1
 
-             x = (dble(i) + 0.5d0) * delta(1) - center(1)
-             y = (dble(j) + 0.5d0) * delta(2) - center(2)
+             x = (dble(i) + 0.5e0_rt) * delta(1) - center(1)
+             y = (dble(j) + 0.5e0_rt) * delta(2) - center(2)
 
              kc = domlo(3)
-             zc = (dble(kc) + 0.5d0) * delta(3) - center(3)
+             zc = (dble(kc) + 0.5e0_rt) * delta(3) - center(3)
              rc = sqrt(x**2 + y**2 + zc**2)
 
              momc = sqrt(adv(i,j,kc,UMX)**2 + adv(i,j,kc,UMY)**2 + adv(i,j,kc,UMZ)**2)
 
              do k = adv_l3, domlo(3)-1
-                z = (dble(k) + 0.5d0) * delta(3) - center(3)
+                z = (dble(k) + 0.5e0_rt) * delta(3) - center(3)
                 r = sqrt(x**2 + y**2 + z**2)
 
                 mom  = momc * (rc/r)**2
 
                 ! Project along the normal
-                adv(i,j,k,UMX) =  sign(1.d0,adv(i,j,kc,UMX)) * mom * (x/r)
-                adv(i,j,k,UMY) =  sign(1.d0,adv(i,j,kc,UMY)) * mom * (y/r)
-                adv(i,j,k,UMZ) =  sign(1.d0,adv(i,j,kc,UMZ)) * mom * (z/r)
+                adv(i,j,k,UMX) =  sign(1.e0_rt,adv(i,j,kc,UMX)) * mom * (x/r)
+                adv(i,j,k,UMY) =  sign(1.e0_rt,adv(i,j,kc,UMY)) * mom * (y/r)
+                adv(i,j,k,UMZ) =  sign(1.e0_rt,adv(i,j,kc,UMZ)) * mom * (z/r)
 
              end do
           end do
@@ -204,25 +206,25 @@ contains
        do j = adv_l2, adv_h2
           do i = adv_l1, adv_h1
 
-             x = (dble(i) + 0.5d0) * delta(1) - center(1)
-             y = (dble(j) + 0.5d0) * delta(2) - center(2)
+             x = (dble(i) + 0.5e0_rt) * delta(1) - center(1)
+             y = (dble(j) + 0.5e0_rt) * delta(2) - center(2)
 
              kc = domhi(3)
-             zc = (dble(kc) + 0.5d0) * delta(3) - center(3)
+             zc = (dble(kc) + 0.5e0_rt) * delta(3) - center(3)
              rc = sqrt(x**2 + y**2 + zc**2)
 
              momc = sqrt(adv(i,j,kc,UMX)**2 + adv(i,j,kc,UMY)**2 + adv(i,j,kc,UMZ)**2)
 
              do k = domhi(3)+1, adv_h3
-                z = (dble(k) + 0.5d0) * delta(3) - center(3)
+                z = (dble(k) + 0.5e0_rt) * delta(3) - center(3)
                 r = sqrt(x**2 + y**2 + z**2)
 
                 mom  = momc * (rc/r)**2
 
                 ! Project along the normal
-                adv(i,j,k,UMX) =  sign(1.d0,adv(i,j,kc,UMX)) * mom * (x/r)
-                adv(i,j,k,UMY) =  sign(1.d0,adv(i,j,kc,UMY)) * mom * (y/r)
-                adv(i,j,k,UMZ) =  sign(1.d0,adv(i,j,kc,UMZ)) * mom * (z/r)
+                adv(i,j,k,UMX) =  sign(1.e0_rt,adv(i,j,kc,UMX)) * mom * (x/r)
+                adv(i,j,k,UMY) =  sign(1.e0_rt,adv(i,j,kc,UMY)) * mom * (y/r)
+                adv(i,j,k,UMZ) =  sign(1.e0_rt,adv(i,j,kc,UMZ)) * mom * (z/r)
 
              end do
           end do
@@ -236,6 +238,7 @@ contains
   subroutine ca_denfill(adv,adv_l1,adv_l2,adv_l3,adv_h1,adv_h2, &
                         adv_h3,domlo,domhi,delta,xlo,time,bc) bind(C,name="ca_denfill")
     
+    use bl_fort_module, only : rt => c_real
     implicit none
     
     include 'bc_types.fi'
@@ -243,8 +246,8 @@ contains
     integer adv_l1,adv_l2,adv_l3,adv_h1,adv_h2,adv_h3
     integer bc(3,2,*)
     integer domlo(3), domhi(3)
-    double precision delta(3), xlo(3), time
-    double precision adv(adv_l1:adv_h1,adv_l2:adv_h2,adv_l3:adv_h3)
+    real(rt)         delta(3), xlo(3), time
+    real(rt)         adv(adv_l1:adv_h1,adv_l2:adv_h2,adv_l3:adv_h3)
     logical rho_only
     integer i,j,k
 
@@ -260,14 +263,15 @@ contains
 
     use probdata_module
     
+    use bl_fort_module, only : rt => c_real
     implicit none
     include 'bc_types.fi'
 
     integer :: grav_l1,grav_l2,grav_l3,grav_h1,grav_h2,grav_h3
     integer :: bc(3,2,*)
     integer :: domlo(3), domhi(3)
-    double precision delta(3), xlo(3), time
-    double precision grav(grav_l1:grav_h1,grav_l2:grav_h2,grav_l3:grav_h3)
+    real(rt)         delta(3), xlo(3), time
+    real(rt)         grav(grav_l1:grav_h1,grav_l2:grav_h2,grav_l3:grav_h3)
 
     call filcc(grav,grav_l1,grav_l2,grav_l3,grav_h1,grav_h2,grav_h3,domlo,domhi,delta,xlo,bc)
 
@@ -280,6 +284,7 @@ contains
 
     use probdata_module
     
+    use bl_fort_module, only : rt => c_real
     implicit none
     
     include 'bc_types.fi'
@@ -287,8 +292,8 @@ contains
     integer :: grav_l1,grav_l2,grav_l3,grav_h1,grav_h2,grav_h3
     integer :: bc(3,2,*)
     integer :: domlo(3), domhi(3)
-    double precision delta(3), xlo(3), time
-    double precision grav(grav_l1:grav_h1,grav_l2:grav_h2,grav_l3:grav_h3)
+    real(rt)         delta(3), xlo(3), time
+    real(rt)         grav(grav_l1:grav_h1,grav_l2:grav_h2,grav_l3:grav_h3)
 
     call filcc(grav,grav_l1,grav_l2,grav_l3,grav_h1,grav_h2,grav_h3,domlo,domhi,delta,xlo,bc)
 
@@ -301,6 +306,7 @@ contains
 
     use probdata_module
     
+    use bl_fort_module, only : rt => c_real
     implicit none
     
     include 'bc_types.fi'
@@ -308,8 +314,8 @@ contains
     integer :: grav_l1,grav_l2,grav_l3,grav_h1,grav_h2,grav_h3
     integer :: bc(3,2,*)
     integer :: domlo(3), domhi(3)
-    double precision delta(3), xlo(3), time
-    double precision grav(grav_l1:grav_h1,grav_l2:grav_h2,grav_l3:grav_h3)
+    real(rt)         delta(3), xlo(3), time
+    real(rt)         grav(grav_l1:grav_h1,grav_l2:grav_h2,grav_l3:grav_h3)
 
     call filcc(grav,grav_l1,grav_l2,grav_l3,grav_h1,grav_h2,grav_h3,domlo,domhi,delta,xlo,bc)
 
@@ -320,6 +326,7 @@ contains
   subroutine ca_phigravfill(phi,phi_l1,phi_l2,phi_l3, &
                             phi_h1,phi_h2,phi_h3,domlo,domhi,delta,xlo,time,bc) bind(C,name="ca_phigravfill")
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     include 'bc_types.fi'
@@ -327,8 +334,8 @@ contains
     integer          :: phi_l1,phi_l2,phi_l3,phi_h1,phi_h2,phi_h3
     integer          :: bc(3,2,*)
     integer          :: domlo(3), domhi(3)
-    double precision :: delta(3), xlo(3), time
-    double precision :: phi(phi_l1:phi_h1,phi_l2:phi_h2,phi_l3:phi_h3)
+    real(rt)         :: delta(3), xlo(3), time
+    real(rt)         :: phi(phi_l1:phi_h1,phi_l2:phi_h2,phi_l3:phi_h3)
 
     call filcc(phi,phi_l1,phi_l2,phi_l3,phi_h1,phi_h2,phi_h3, &
          domlo,domhi,delta,xlo,bc)

--- a/Exec/gravity_tests/DustCollapse/probdata.f90
+++ b/Exec/gravity_tests/DustCollapse/probdata.f90
@@ -2,11 +2,12 @@ module probdata_module
 
   ! hold the state at the top of the initial model for the boundary
   ! conditions
-  double precision, save :: r_old, r_old_s
-  double precision, save :: rho_0, rho_ambient, r_0, p_0, T_0, T_ambient, smooth_delta
-  double precision, allocatable, save :: X_0(:)
+  use bl_fort_module, only : rt => c_real
+  real(rt)        , save :: r_old, r_old_s
+  real(rt)        , save :: rho_0, rho_ambient, r_0, p_0, T_0, T_ambient, smooth_delta
+  real(rt)        , allocatable, save :: X_0(:)
   
-  double precision, save :: xmin, xmax, ymin, ymax, zmin, zmax
+  real(rt)        , save :: xmin, xmax, ymin, ymax, zmin, zmax
 
   logical         , save :: is_3d_fullstar
 end module probdata_module

--- a/Exec/gravity_tests/DustCollapse/update_sponge_params.f90
+++ b/Exec/gravity_tests/DustCollapse/update_sponge_params.f90
@@ -4,14 +4,15 @@ subroutine update_sponge_params(time) bind(C)
   use probdata_module, only: r_old_s
   use bl_error_module, only: bl_error
 
+  use bl_fort_module, only : rt => c_real
   implicit none    
   
-  double precision, intent(in) :: time
+  real(rt)        , intent(in) :: time
 
   logical          :: converged
-  double precision :: r, dr, r_guess, tol = 1.d-6
+  real(rt)         :: r, dr, r_guess, tol = 1.e-6_rt
   integer          :: n, max_iter = 25
-  double precision :: f, dfdr
+  real(rt)         :: f, dfdr
   
   ! Find the analytic solution of the radius of the collapsing
   ! object via Newton-Raphson iteration.
@@ -23,8 +24,8 @@ subroutine update_sponge_params(time) bind(C)
      dr = -f(r_guess,time) / dfdr(r_guess,time)
 
      ! We have lots of sqrt(1 - r/r_0), so r(t) has to be less than r_0.
-     if (r_guess + dr > 6.5d8) then
-        r_guess = 0.5d0*(r_guess + 6.5d8)
+     if (r_guess + dr > 6.5e8_rt) then
+        r_guess = 0.5e0_rt*(r_guess + 6.5e8_rt)
      else
         r_guess = r_guess + dr
      endif
@@ -42,41 +43,43 @@ subroutine update_sponge_params(time) bind(C)
      call bl_error("Newton iterations failed to converge in update_sponge_params.")
   endif
   
-  sponge_lower_radius = r + 2.5d7
-  sponge_upper_radius = r + 5.0d7
-  sponge_timescale    = 1.0d-3
+  sponge_lower_radius = r + 2.5e7_rt
+  sponge_upper_radius = r + 5.0e7_rt
+  sponge_timescale    = 1.0e-3_rt
   
 end subroutine update_sponge_params
 
 
 
 ! The analytic solution from Colgate and White, Eq. 5 (with everything moved
-! onto the LHS).  We use 1.d-20 to prevent against zeros in some places.
+! onto the LHS).  We use 1.e-20_rt to prevent against zeros in some places.
 
 double precision function f(r,t)
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
-  double precision, intent(in) :: r, t
+  real(rt)        , intent(in) :: r, t
 
-  f = sqrt(8.d0*3.14159265358979323846d0*6.67428d-8*1.d9/3.d0)*t - &
-      sqrt(1.d0 - r/6.5d8)*sqrt(r/6.5d8) - asin(sqrt(1.0 - r/6.5d8 + 1.d-20))
+  f = sqrt(8.e0_rt*3.14159265358979323846e0_rt*6.67428e-8_rt*1.e9_rt/3.e0_rt)*t - &
+      sqrt(1.e0_rt - r/6.5e8_rt)*sqrt(r/6.5e8_rt) - asin(sqrt(1.0 - r/6.5e8_rt + 1.e-20_rt))
 
 end function f
 
 
 
 ! The derivative (wrt x) of the analytic function f, defined above.
-! We use 1.d-20 to prevent against zeros in some places.
+! We use 1.e-20_rt to prevent against zeros in some places.
 
 double precision function dfdr(r,t)
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
-  double precision, intent(in) :: r, t
+  real(rt)        , intent(in) :: r, t
     
-  dfdr = (0.5d0/6.5d8)*(-sqrt(1.d0 - r/6.5d8 + 1.d-20)/sqrt(r/6.5d8) + &
-         sqrt(r/6.5d8)/sqrt(1 - r/6.5d8 + 1.d-20) + &
-         1.d0/(sqrt(r/6.5d8)*sqrt(1.d0 - r/6.5d8 + 1.d-20)))
+  dfdr = (0.5e0_rt/6.5e8_rt)*(-sqrt(1.e0_rt - r/6.5e8_rt + 1.e-20_rt)/sqrt(r/6.5e8_rt) + &
+         sqrt(r/6.5e8_rt)/sqrt(1 - r/6.5e8_rt + 1.e-20_rt) + &
+         1.e0_rt/(sqrt(r/6.5e8_rt)*sqrt(1.e0_rt - r/6.5e8_rt + 1.e-20_rt)))
 
 end function dfdr

--- a/Exec/gravity_tests/StarGrav/Prob_1d.f90
+++ b/Exec/gravity_tests/StarGrav/Prob_1d.f90
@@ -5,10 +5,11 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
   use bl_error_module
   use prob_params_module, only : center
 
+  use bl_fort_module, only : rt => c_real
   implicit none
   integer init, namlen
   integer name(namlen)
-  double precision problo(1), probhi(1)
+  real(rt)         problo(1), probhi(1)
 
   integer untin,i,j,k,dir
 
@@ -39,7 +40,7 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
   ! read initial model
   call read_model_file(model_name)
 
-  center(1) = 0.d0
+  center(1) = 0.e0_rt
 
 end subroutine PROBINIT
 
@@ -78,21 +79,22 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
   use eos_type_module
   use eos_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer level, nscal
   integer lo(1), hi(1)
   integer state_l1,state_h1
-  double precision xlo(1), xhi(1), time, delta(1)
-  double precision state(state_l1:state_h1,NVAR)
+  real(rt)         xlo(1), xhi(1), time, delta(1)
+  real(rt)         state(state_l1:state_h1,NVAR)
 
-  double precision xcen,dist,pres
+  real(rt)         xcen,dist,pres
   integer i,n
 
   type(eos_t) :: eos_state
 
   do i = lo(1), hi(1)   
-     dist = xlo(1) + delta(1)*(float(i-lo(1)) + 0.5d0)
+     dist = xlo(1) + delta(1)*(float(i-lo(1)) + 0.5e0_rt)
 
      state(i,URHO)  = interpolate(dist,npts_model,model_r,model_state(:,idens_model))
      state(i,UTEMP) = interpolate(dist,npts_model,model_r,model_state(:,itemp_model))
@@ -121,6 +123,6 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
   enddo
 
   ! Initial velocities = 0
-  state(:,UMX) = 0.d0
+  state(:,UMX) = 0.e0_rt
 
 end subroutine ca_initdata

--- a/Exec/gravity_tests/StarGrav/Prob_2d.f90
+++ b/Exec/gravity_tests/StarGrav/Prob_2d.f90
@@ -5,10 +5,11 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
   use bl_error_module
   use prob_params_module, only : center
 
+  use bl_fort_module, only : rt => c_real
   implicit none
   integer init, namlen
   integer name(namlen)
-  double precision problo(2), probhi(2)
+  real(rt)         problo(2), probhi(2)
 
   integer untin,i,j,k,dir
 
@@ -42,8 +43,8 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
   call read_model_file(model_name)
 
   ! assume axisymmetric
-  center(1) = 0.d0
-  center(2) = 0.5d0*(problo(2)+probhi(2))
+  center(1) = 0.e0_rt
+  center(2) = 0.5e0_rt*(problo(2)+probhi(2))
 
 end subroutine PROBINIT
 
@@ -83,24 +84,25 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
   use eos_type_module
   use eos_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer level, nscal
   integer lo(2), hi(2)
   integer state_l1,state_l2,state_h1,state_h2
-  double precision xlo(2), xhi(2), time, delta(2)
-  double precision state(state_l1:state_h1,state_l2:state_h2,NVAR)
+  real(rt)         xlo(2), xhi(2), time, delta(2)
+  real(rt)         state(state_l1:state_h1,state_l2:state_h2,NVAR)
 
-  double precision xcen,ycen,dist,pres
+  real(rt)         xcen,ycen,dist,pres
   integer i,j,n
 
   type(eos_t) :: eos_state
 
   do j = lo(2), hi(2)
-     ycen = xlo(2) + delta(2)*(float(j-lo(2)) + 0.5d0) - center(2)
+     ycen = xlo(2) + delta(2)*(float(j-lo(2)) + 0.5e0_rt) - center(2)
 
      do i = lo(1), hi(1)   
-        xcen = xlo(1) + delta(1)*(float(i-lo(1)) + 0.5d0) - center(1)
+        xcen = xlo(1) + delta(1)*(float(i-lo(1)) + 0.5e0_rt) - center(1)
 
         dist = sqrt(xcen**2 + ycen**2)
 
@@ -135,6 +137,6 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
   enddo
 
   ! Initial velocities = 0
-  state(:,:,UMX:UMY) = 0.d0
+  state(:,:,UMX:UMY) = 0.e0_rt
 
 end subroutine ca_initdata

--- a/Exec/gravity_tests/StarGrav/Prob_3d.f90
+++ b/Exec/gravity_tests/StarGrav/Prob_3d.f90
@@ -5,10 +5,11 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
   use bl_error_module
   use prob_params_module, only : center
 
+  use bl_fort_module, only : rt => c_real
   implicit none
   integer init, namlen
   integer name(namlen)
-  double precision problo(3), probhi(3)
+  real(rt)         problo(3), probhi(3)
 
   integer untin,i,j,k,dir
 
@@ -41,9 +42,9 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
   ! read initial model
   call read_model_file(model_name)
 
-  center(1) = 0.5d0*(problo(1)+probhi(1))
-  center(2) = 0.5d0*(problo(2)+probhi(2))
-  center(3) = 0.5d0*(problo(3)+probhi(3))
+  center(1) = 0.5e0_rt*(problo(1)+probhi(1))
+  center(2) = 0.5e0_rt*(problo(2)+probhi(2))
+  center(3) = 0.5e0_rt*(problo(3)+probhi(3))
 
 end subroutine PROBINIT
 
@@ -83,28 +84,29 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
   use eos_type_module
   use eos_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer level, nscal
   integer lo(3), hi(3)
   integer state_l1,state_l2,state_l3,state_h1,state_h2,state_h3
-  double precision xlo(3), xhi(3), time, delta(3)
-  double precision state(state_l1:state_h1,state_l2:state_h2, &
+  real(rt)         xlo(3), xhi(3), time, delta(3)
+  real(rt)         state(state_l1:state_h1,state_l2:state_h2, &
        state_l3:state_h3,NVAR)
 
-  double precision xcen,ycen,zcen,dist,pres
+  real(rt)         xcen,ycen,zcen,dist,pres
   integer i,j,k,n
 
   type(eos_t) :: eos_state
 
   do k = lo(3), hi(3)
-     zcen = xlo(3) + delta(3)*(float(k-lo(3)) + 0.5d0) - center(3)
+     zcen = xlo(3) + delta(3)*(float(k-lo(3)) + 0.5e0_rt) - center(3)
 
      do j = lo(2), hi(2)
-        ycen = xlo(2) + delta(2)*(float(j-lo(2)) + 0.5d0) - center(2)
+        ycen = xlo(2) + delta(2)*(float(j-lo(2)) + 0.5e0_rt) - center(2)
 
         do i = lo(1), hi(1)
-           xcen = xlo(1) + delta(1)*(float(i-lo(1)) + 0.5d0) - center(1)
+           xcen = xlo(1) + delta(1)*(float(i-lo(1)) + 0.5e0_rt) - center(1)
 
            dist = sqrt(xcen**2 + ycen**2 + zcen**2)
 
@@ -142,6 +144,6 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
   enddo
 
   ! Initial velocities = 0
-  state(:,:,:,UMX:UMZ) = 0.d0
+  state(:,:,:,UMX:UMZ) = 0.e0_rt
 
 end subroutine ca_initdata

--- a/Exec/gravity_tests/StarGrav/probdata.f90
+++ b/Exec/gravity_tests/StarGrav/probdata.f90
@@ -1,6 +1,7 @@
 module probdata_module
 
 !     These determine the refinement criteria
+      use bl_fort_module, only : rt => c_real
       character (len=80), save  :: model_name
 
 end module probdata_module

--- a/Exec/gravity_tests/evrard_collapse/Prob_3d.f90
+++ b/Exec/gravity_tests/evrard_collapse/Prob_3d.f90
@@ -2,11 +2,12 @@
      
      use probdata_module, only: initialize
 
+     use bl_fort_module, only : rt => c_real
      implicit none
 
      integer :: init, namlen
      integer :: name(namlen)
-     double precision :: problo(3), probhi(3)
+     real(rt)         :: problo(3), probhi(3)
 
      call initialize(name, namlen)
 
@@ -48,16 +49,17 @@
      use fundamental_constants_module, only: Gconst, M_solar
      use prob_params_module, only: center
 
+     use bl_fort_module, only : rt => c_real
      implicit none
 
      integer :: level, nscal
      integer :: lo(3), hi(3)
      integer :: state_l1,state_l2,state_l3,state_h1,state_h2,state_h3
-     double precision :: xlo(3), xhi(3), time, delta(3)
-     double precision :: state(state_l1:state_h1,state_l2:state_h2,state_l3:state_h3,NVAR)
+     real(rt)         :: xlo(3), xhi(3), time, delta(3)
+     real(rt)         :: state(state_l1:state_h1,state_l2:state_h2,state_l3:state_h3,NVAR)
 
-     double precision :: loc(3)
-     double precision :: radius
+     real(rt)         :: loc(3)
+     real(rt)         :: radius
 
      type (eos_t) :: zone_state
 

--- a/Exec/gravity_tests/evrard_collapse/probdata.f90
+++ b/Exec/gravity_tests/evrard_collapse/probdata.f90
@@ -1,22 +1,23 @@
 module probdata_module
 
   ! Probin file
+  use bl_fort_module, only : rt => c_real
   character (len=:), allocatable :: probin
 
   ! Determine if we are the I/O processor
   integer :: ioproc
 
   ! Mass and radius of the collapsing sphere
-  double precision :: sphere_mass, sphere_radius
+  real(rt)         :: sphere_mass, sphere_radius
 
   ! Smallest allowed mass fraction
-  double precision :: smallx
+  real(rt)         :: smallx
 
   ! Smallest allowed velocity on the grid
-  double precision :: smallu
+  real(rt)         :: smallu
   
   ! Density of ambient gas around the star
-  double precision :: ambient_density
+  real(rt)         :: ambient_density
   
 contains
 
@@ -28,6 +29,7 @@ contains
     use bl_constants_module, only: ZERO
     use bl_error_module, only: bl_error
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer :: namlen, i
@@ -59,6 +61,7 @@ contains
 
   subroutine read_namelist
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer :: untin
@@ -67,13 +70,13 @@ contains
 
     ! Set namelist defaults
 
-    sphere_mass   = 1.0d0
-    sphere_radius = 9.0d8
+    sphere_mass   = 1.0e0_rt
+    sphere_radius = 9.0e8_rt
 
-    ambient_density = 1.0d0
+    ambient_density = 1.0e0_rt
 
-    smallx = 1.d-10
-    smallu = 1.d-12
+    smallx = 1.e-10_rt
+    smallu = 1.e-12_rt
 
     ! Read namelist to override the defaults
 
@@ -90,6 +93,7 @@ contains
 
   subroutine get_ioproc
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     ! For outputting -- determine if we are the IO processor
@@ -108,16 +112,17 @@ contains
     use eos_module, only: eos_input_rt, eos
     use meth_params_module, only: small_temp, small_pres, small_dens, small_ener
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     type (eos_t) :: eos_state
 
     ! Given the inputs of small_dens and small_temp, figure out small_pres.
 
-    if (small_dens > 0.0d0 .and. small_temp > 0.0d0) then
+    if (small_dens > 0.0e0_rt .and. small_temp > 0.0e0_rt) then
        eos_state % rho = small_dens
        eos_state % T   = small_temp
-       eos_state % xn  = 1.0d0 / nspec
+       eos_state % xn  = 1.0e0_rt / nspec
  
        call eos(eos_input_rt, eos_state)
 

--- a/Exec/gravity_tests/hydrostatic_adjust/Prob_1d.f90
+++ b/Exec/gravity_tests/hydrostatic_adjust/Prob_1d.f90
@@ -8,12 +8,13 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
   use model_parser_module
 
   use network, only : nspec
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer :: init,namlen,untin,i,k
   integer :: name(namlen)
 
-  double precision problo(1), probhi(1)
+  real(rt)         problo(1), probhi(1)
 
   type (eos_t) :: eos_state
 
@@ -39,10 +40,10 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
 
   ! set namelist defaults
 
-  heating_time = 0.5d0
-  heating_rad = 0.0d0
-  heating_peak = 1.d16
-  heating_sigma = 1.d7
+  heating_time = 0.5e0_rt
+  heating_rad = 0.0e0_rt
+  heating_peak = 1.e16_rt
+  heating_sigma = 1.e7_rt
   prob_type = 1
 
 
@@ -70,10 +71,10 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
      hse_s(i,:) = model_state(:,ispec_model+i-1)
   enddo
 
-  center(1) = 0.0d0
+  center(1) = 0.0e0_rt
 
   xmin = problo(1)
-  if (xmin /= 0.d0) then
+  if (xmin /= 0.e0_rt) then
      call bl_error("ERROR: xmin should be 0!")
   endif
 
@@ -132,16 +133,17 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
   use model_parser_module, only: npts_model
   use meth_params_module, only : NVAR, URHO, UMX, UMY, UMZ, UTEMP, UEDEN, UEINT, UFS
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer          :: level, nscal
   integer          :: lo(1), hi(1)
   integer          :: state_l1,state_h1
-  double precision :: state(state_l1:state_h1,NVAR)
-  double precision :: time, delta(1)
-  double precision :: xlo(1), xhi(1)
+  real(rt)         :: state(state_l1:state_h1,NVAR)
+  real(rt)         :: time, delta(1)
+  real(rt)         :: xlo(1), xhi(1)
 
-  double precision :: x,dist
+  real(rt)         :: x,dist
   integer          :: i,n
 
   type (eos_t) :: eos_state
@@ -149,7 +151,7 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
   ! Interpolate rho, T and X
   do i = lo(1), hi(1)
 
-     dist = (dble(i) + 0.5d0) * delta(1)
+     dist = (dble(i) + 0.5e0_rt) * delta(1)
 
      state(i,URHO ) = interpolate(dist,npts_model,hse_r,hse_rho)
      state(i,UTEMP) = interpolate(dist,npts_model,hse_r,hse_t)
@@ -174,7 +176,7 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
   enddo
 
   do i = lo(1), hi(1)
-     state(i,UMX:UMZ) = 0.d0
+     state(i,UMX:UMZ) = 0.e0_rt
      state(i,UEINT) = state(i,URHO) * state(i,UEINT)
      state(i,UEDEN) = state(i,UEINT)
      state(i,UFS:UFS+nspec-1) = state(i,URHO) * state(i,UFS:UFS+nspec-1)

--- a/Exec/gravity_tests/hydrostatic_adjust/bc_fill_1d.F90
+++ b/Exec/gravity_tests/hydrostatic_adjust/bc_fill_1d.F90
@@ -1,5 +1,6 @@
 module bc_fill_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   public
@@ -15,6 +16,7 @@ contains
          hse_eint_top, hse_p_top
     use network, only: nspec
     
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     include 'bc_types.fi'
@@ -22,11 +24,11 @@ contains
     integer          :: adv_l1,adv_h1
     integer          :: bc(1,2,*)
     integer          :: domlo(1), domhi(1)
-    double precision :: delta(1), xlo(1), time
-    double precision :: adv(adv_l1:adv_h1,NVAR)
+    real(rt)         :: delta(1), xlo(1), time
+    real(rt)         :: adv(adv_l1:adv_h1,NVAR)
 
     integer n, i
-    double precision :: vel
+    real(rt)         :: vel
 
     ! call the generic ghostcell filling routine
     do n = 1,NVAR
@@ -40,7 +42,7 @@ contains
        if (bc(1,2,UMX).eq.FOEXTRAP) then
           do i = domhi(1)+1,adv_h1
              !adv(i,UMX) = adv(domhi(1),UMX)
-             vel = max(adv(i,UMX)/adv(i,URHO),0.d0)
+             vel = max(adv(i,UMX)/adv(i,URHO),0.e0_rt)
              adv(i,URHO)  = hse_rho_top
              adv(i,UMX)   = adv(i,URHO)*vel
              adv(i,UMY)   = ZERO
@@ -61,13 +63,14 @@ contains
   subroutine ca_denfill(adv,adv_l1,adv_h1, &
                         domlo,domhi,delta,xlo,time,bc) bind(C, name="ca_denfill")
     
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer          :: adv_l1,adv_h1
     integer          :: bc(1,2,*)
     integer          :: domlo(1), domhi(1)
-    double precision :: delta(1), xlo(1), time
-    double precision :: adv(adv_l1:adv_h1)
+    real(rt)         :: delta(1), xlo(1), time
+    real(rt)         :: adv(adv_l1:adv_h1)
     logical          :: rho_only
 
     call filcc(adv,adv_l1,adv_h1, &
@@ -83,13 +86,14 @@ contains
 
     use probdata_module
     
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer          :: grav_l1,grav_h1
     integer          :: bc(1,2,*)
     integer          :: domlo(1), domhi(1)
-    double precision :: delta(1), xlo(1), time
-    double precision :: grav(grav_l1:grav_h1)
+    real(rt)         :: delta(1), xlo(1), time
+    real(rt)         :: grav(grav_l1:grav_h1)
 
     call filcc(grav,grav_l1,grav_h1,domlo,domhi,delta,xlo,bc)
 
@@ -102,13 +106,14 @@ contains
 
     use probdata_module
     
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer          :: grav_l1,grav_h1
     integer          :: bc(1,2,*)
     integer          :: domlo(1), domhi(1)
-    double precision :: delta(1), xlo(1), time
-    double precision :: grav(grav_l1:grav_h1)
+    real(rt)         :: delta(1), xlo(1), time
+    real(rt)         :: grav(grav_l1:grav_h1)
 
     call filcc(grav,grav_l1,grav_h1,domlo,domhi,delta,xlo,bc)
 
@@ -121,13 +126,14 @@ contains
 
     use probdata_module
     
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer          :: grav_l1,grav_h1
     integer          :: bc(1,2,*)
     integer          :: domlo(1), domhi(1)
-    double precision :: delta(1), xlo(1), time
-    double precision :: grav(grav_l1:grav_h1)
+    real(rt)         :: delta(1), xlo(1), time
+    real(rt)         :: grav(grav_l1:grav_h1)
 
     call filcc(grav,grav_l1,grav_h1,domlo,domhi,delta,xlo,bc)
 
@@ -138,6 +144,7 @@ contains
   subroutine ca_phigravfill(phi,phi_l1,phi_h1, &
                             domlo,domhi,delta,xlo,time,bc) bind(C, name="ca_phigravfill")
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     include 'bc_types.fi'
@@ -145,8 +152,8 @@ contains
     integer          :: phi_l1,phi_h1
     integer          :: bc(1,2,*)
     integer          :: domlo(1), domhi(1)
-    double precision :: delta(1), xlo(1), time
-    double precision :: phi(phi_l1:phi_h1)
+    real(rt)         :: delta(1), xlo(1), time
+    real(rt)         :: phi(phi_l1:phi_h1)
 
     call filcc(phi,phi_l1,phi_h1, &
                domlo,domhi,delta,xlo,bc)
@@ -159,13 +166,14 @@ contains
   subroutine ca_reactfill(adv,adv_l1,adv_h1, &
                           domlo,domhi,delta,xlo,time,bc) bind(C, name="ca_reactfill")
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer          :: adv_l1,adv_h1
     integer          :: bc(1,2,*)
     integer          :: domlo(1), domhi(1)
-    double precision :: delta(1), xlo(1), time
-    double precision :: adv(adv_l1:adv_h1)
+    real(rt)         :: delta(1), xlo(1), time
+    real(rt)         :: adv(adv_l1:adv_h1)
     logical          :: rho_only
 
     call filcc(adv,adv_l1,adv_h1, &

--- a/Exec/gravity_tests/hydrostatic_adjust/ext_src_1d.f90
+++ b/Exec/gravity_tests/hydrostatic_adjust/ext_src_1d.f90
@@ -11,18 +11,19 @@
     use prob_params_module, only: center
     use network
     
+    use bl_fort_module, only : rt => c_real
     implicit none
     integer         ,intent(in   ) :: lo(1),hi(1)
     integer         ,intent(in   ) :: old_state_l1,old_state_h1
     integer         ,intent(in   ) :: new_state_l1,new_state_h1
     integer         ,intent(in   ) :: src_l1,src_h1
-    double precision,intent(in   ) :: old_state(old_state_l1:old_state_h1,NVAR)
-    double precision,intent(in   ) :: new_state(new_state_l1:new_state_h1,NVAR)
-    double precision,intent(  out) :: src(src_l1:src_h1,NVAR)
-    double precision,intent(in   ) :: problo(1),dx(1),time,dt
+    real(rt)        ,intent(in   ) :: old_state(old_state_l1:old_state_h1,NVAR)
+    real(rt)        ,intent(in   ) :: new_state(new_state_l1:new_state_h1,NVAR)
+    real(rt)        ,intent(  out) :: src(src_l1:src_h1,NVAR)
+    real(rt)        ,intent(in   ) :: problo(1),dx(1),time,dt
     
     integer          :: i
-    double precision :: x, r_0, H_0, W_0, Hext, t_stop
+    real(rt)         :: x, r_0, H_0, W_0, Hext, t_stop
 
     integer :: ihe4_p
 
@@ -40,7 +41,7 @@
           if (lo(1) .eq. 0) print *,'TIME vs TSTOP ',time, t_stop 
           do i = lo(1), hi(1)
 
-             x = problo(1) + ((dble(i)+0.5d0)*dx(1) + xmin) - center(1)
+             x = problo(1) + ((dble(i)+0.5e0_rt)*dx(1) + xmin) - center(1)
 
              Hext = H_0*exp(-((x-r_0)**2)/W_0**2)
 
@@ -50,8 +51,8 @@
           enddo
        else
 
-          src(lo(1):hi(1),UEINT) = 0.d0
-          src(lo(1):hi(1),UEDEN) = 0.d0
+          src(lo(1):hi(1),UEINT) = 0.e0_rt
+          src(lo(1):hi(1),UEDEN) = 0.e0_rt
 
        end if
 
@@ -64,7 +65,7 @@
           if (lo(1) .eq. 0) print *,'TIME vs TSTOP ',time, t_stop 
           do i = lo(1), hi(1)
 
-             x = problo(1) + ((dble(i)+0.5d0)*dx(1) + xmin) - center(1)
+             x = problo(1) + ((dble(i)+0.5e0_rt)*dx(1) + xmin) - center(1)
 
              Hext = H_0*exp(-((x-r_0)**2)/W_0**2)*old_state(i,UFS-1+ihe4_p)/old_state(i,URHO)
 
@@ -74,8 +75,8 @@
           enddo
        else
 
-          src(lo(1):hi(1),UEINT) = 0.d0
-          src(lo(1):hi(1),UEDEN) = 0.d0
+          src(lo(1):hi(1),UEINT) = 0.e0_rt
+          src(lo(1):hi(1),UEDEN) = 0.e0_rt
 
        end if
 

--- a/Exec/gravity_tests/hydrostatic_adjust/extra_derives.f90
+++ b/Exec/gravity_tests/hydrostatic_adjust/extra_derives.f90
@@ -9,18 +9,19 @@ subroutine ca_derpi(p,p_l1,p_h1,ncomp_p, &
                                  allow_negative_energy
   use probdata_module, only: hse_p
 
+  use bl_fort_module, only : rt => c_real
   implicit none
   
   integer p_l1,p_h1,ncomp_p
   integer u_l1,u_h1,ncomp_u
   integer lo(1), hi(1), domlo(1), domhi(1)
-  double precision p(p_l1:p_h1,ncomp_p)
-  double precision u(u_l1:u_h1,ncomp_u)
-  double precision dx(1), xlo(1), time, dt
+  real(rt)         p(p_l1:p_h1,ncomp_p)
+  real(rt)         u(u_l1:u_h1,ncomp_u)
+  real(rt)         dx(1), xlo(1), time, dt
   integer bc(1,2,ncomp_u), level, grid_no
   
-  double precision :: e, temp, X(nspec+naux)
-  double precision :: rhoInv
+  real(rt)         :: e, temp, X(nspec+naux)
+  real(rt)         :: rhoInv
   integer          :: i,n
 
   type (eos_t) :: eos_state
@@ -28,7 +29,7 @@ subroutine ca_derpi(p,p_l1,p_h1,ncomp_p, &
   !     Compute pressure from the EOS
   do i = lo(1),hi(1)
      
-     rhoInv = 1.d0/u(i,URHO)
+     rhoInv = 1.e0_rt/u(i,URHO)
      e  = u(i,UEINT)*rhoInv
      temp  = u(i,UTEMP)
      do n=1,nspec
@@ -39,7 +40,7 @@ subroutine ca_derpi(p,p_l1,p_h1,ncomp_p, &
      enddo
      
      ! Protect against negative internal energy
-     if (allow_negative_energy .eq. 0 .and. e .le. 0.d0) then
+     if (allow_negative_energy .eq. 0 .and. e .le. 0.e0_rt) then
         eos_state%rho = u(i,URHO)
         eos_state%T = temp
         eos_state%xn(:) = X
@@ -78,18 +79,19 @@ subroutine ca_derpioverp0(p,p_l1,p_h1,ncomp_p, &
                                  allow_negative_energy
   use probdata_module, only: hse_p
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer p_l1,p_h1,ncomp_p
   integer u_l1,u_h1,ncomp_u
   integer lo(1), hi(1), domlo(1), domhi(1)
-  double precision p(p_l1:p_h1,ncomp_p)
-  double precision u(u_l1:u_h1,ncomp_u)
-  double precision dx(1), xlo(1), time, dt
+  real(rt)         p(p_l1:p_h1,ncomp_p)
+  real(rt)         u(u_l1:u_h1,ncomp_u)
+  real(rt)         dx(1), xlo(1), time, dt
   integer bc(1,2,ncomp_u), level, grid_no
   
-  double precision :: e, temp, X(nspec+naux)
-  double precision :: rhoInv
+  real(rt)         :: e, temp, X(nspec+naux)
+  real(rt)         :: rhoInv
   integer          :: i,n
 
   type (eos_t) :: eos_state
@@ -97,7 +99,7 @@ subroutine ca_derpioverp0(p,p_l1,p_h1,ncomp_p, &
   !     Compute pressure from the EOS
   do i = lo(1),hi(1)
 
-     rhoInv = 1.d0/u(i,URHO)
+     rhoInv = 1.e0_rt/u(i,URHO)
      e  = u(i,UEINT)*rhoInv
      temp  = u(i,UTEMP)
      do n=1,nspec
@@ -108,7 +110,7 @@ subroutine ca_derpioverp0(p,p_l1,p_h1,ncomp_p, &
      enddo
      
      ! Protect against negative internal energy
-     if (allow_negative_energy .eq. 0 .and. e .le. 0.d0) then
+     if (allow_negative_energy .eq. 0 .and. e .le. 0.e0_rt) then
         eos_state%rho = u(i,URHO)
         eos_state%T = temp
         eos_state%xn(:) = X

--- a/Exec/gravity_tests/hydrostatic_adjust/probdata.f90
+++ b/Exec/gravity_tests/hydrostatic_adjust/probdata.f90
@@ -1,23 +1,24 @@
 module probdata_module
 
   ! make the model name enter through the probin file
+  use bl_fort_module, only : rt => c_real
   character (len=80), save  :: model_name
 
   ! arrange storage for read_in model-- not worrying about efficiency, 
   ! since this will only be called once
-  double precision, allocatable, save ::  hse_r(:), hse_rho(:)
-  double precision, allocatable, save ::  hse_t(:), hse_p(:)
-  double precision, allocatable, save ::  hse_s(:,:)
+  real(rt)        , allocatable, save ::  hse_r(:), hse_rho(:)
+  real(rt)        , allocatable, save ::  hse_t(:), hse_p(:)
+  real(rt)        , allocatable, save ::  hse_s(:,:)
   
   ! hold the state at the top of the initial model for the boundary
   ! conditions
-  double precision, save              :: hse_rho_top, hse_T_top
-  double precision, save              :: hse_p_top, hse_eint_top
-  double precision, allocatable, save :: hse_X_top(:)
+  real(rt)        , save              :: hse_rho_top, hse_T_top
+  real(rt)        , save              :: hse_p_top, hse_eint_top
+  real(rt)        , allocatable, save :: hse_X_top(:)
   
-  double precision, save :: xmin, xmax, ymin, ymax, zmin, zmax
+  real(rt)        , save :: xmin, xmax, ymin, ymax, zmin, zmax
   
-  double precision, save :: heating_time, heating_rad, &
+  real(rt)        , save :: heating_time, heating_rad, &
                             heating_peak, heating_sigma
 
 

--- a/Exec/gravity_tests/uniform_cube_sphere/Prob_3d.f90
+++ b/Exec/gravity_tests/uniform_cube_sphere/Prob_3d.f90
@@ -5,11 +5,12 @@
      use fundamental_constants_module
      use eos_module
 
+     use bl_fort_module, only : rt => c_real
      implicit none
 
      integer :: init, namlen
      integer :: name(namlen)
-     double precision :: problo(3), probhi(3)
+     real(rt)         :: problo(3), probhi(3)
 
      integer :: untin
      integer :: i
@@ -30,10 +31,10 @@
         probin(i:i) = char(name(i))
      end do
 
-     density  = 1.0d0
-     diameter = 1.0d0
+     density  = 1.0e0_rt
+     diameter = 1.0e0_rt
 
-     ambient_dens = 1.0d-8
+     ambient_dens = 1.0e-8_rt
 
      problem = 1
 
@@ -79,15 +80,16 @@
      use bl_constants_module
      use prob_params_module, only: problo, probhi, center
 
+     use bl_fort_module, only : rt => c_real
      implicit none
 
      integer :: level, nscal
      integer :: lo(3), hi(3)
      integer :: state_l1,state_l2,state_l3,state_h1,state_h2,state_h3
-     double precision :: xlo(3), xhi(3), time, delta(3)
-     double precision :: state(state_l1:state_h1,state_l2:state_h2,state_l3:state_h3,NVAR)
+     real(rt)         :: xlo(3), xhi(3), time, delta(3)
+     real(rt)         :: state(state_l1:state_h1,state_l2:state_h2,state_l3:state_h3,NVAR)
 
-     double precision :: xx, yy, zz
+     real(rt)         :: xx, yy, zz
 
      integer :: i, j, k
 
@@ -128,9 +130,9 @@
               ! Establish the thermodynamic quantities. They don't have to be
               ! valid because this test will never do a hydro step.
 
-              state(i,j,k,UTEMP) = 1.0d0
-              state(i,j,k,UEINT) = 1.0d0
-              state(i,j,k,UEDEN) = 1.0d0
+              state(i,j,k,UTEMP) = 1.0e0_rt
+              state(i,j,k,UEINT) = 1.0e0_rt
+              state(i,j,k,UEDEN) = 1.0e0_rt
 
               state(i,j,k,UFS:UFS-1+nspec) = state(i,j,k,URHO) / nspec
 

--- a/Exec/gravity_tests/uniform_cube_sphere/Problem.f90
+++ b/Exec/gravity_tests/uniform_cube_sphere/Problem.f90
@@ -4,6 +4,7 @@ subroutine problem_checkpoint(int_dir_name, len) bind(c)
 
   ! called by the IO processor during checkpoint
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer :: len
@@ -17,6 +18,7 @@ subroutine problem_restart(int_dir_name, len) bind(c)
 
   ! called by ALL processors during restart 
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer :: len
@@ -32,6 +34,7 @@ subroutine get_problem_number(problem_out) bind(C,name='get_problem_number')
 
   use probdata_module, only: problem
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer :: problem_out
@@ -48,9 +51,10 @@ subroutine get_diameter(diameter_out) bind(C,name='get_diameter')
 
   use probdata_module, only: diameter
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
-  double precision :: diameter_out
+  real(rt)         :: diameter_out
 
   diameter_out = diameter
 
@@ -64,9 +68,10 @@ subroutine get_density(density_out) bind(C,name='get_density')
 
   use probdata_module, only: density
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
-  double precision :: density_out
+  real(rt)         :: density_out
 
   density_out = density
 
@@ -88,18 +93,19 @@ subroutine update_density(lo, hi, dx, &
   use prob_params_module, only: problo, center
   use probdata_module, only: problem, diameter
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer         , intent(in   ) :: lo(3), hi(3)
   integer         , intent(in   ) :: s_lo(3), s_hi(3)
 
-  double precision, intent(inout) :: state(s_lo(1):s_hi(1),s_lo(2):s_hi(2),s_lo(3):s_hi(3),NVAR)
+  real(rt)        , intent(inout) :: state(s_lo(1):s_hi(1),s_lo(2):s_hi(2),s_lo(3):s_hi(3),NVAR)
 
-  double precision, intent(in   ) :: dx(3)
-  double precision, intent(in   ) :: update_factor
+  real(rt)        , intent(in   ) :: dx(3)
+  real(rt)        , intent(in   ) :: update_factor
 
   integer          :: i, j, k
-  double precision :: xx, yy, zz
+  real(rt)         :: xx, yy, zz
   
   if (problem .eq. 2) then
 

--- a/Exec/gravity_tests/uniform_cube_sphere/probdata.f90
+++ b/Exec/gravity_tests/uniform_cube_sphere/probdata.f90
@@ -1,7 +1,8 @@
 module probdata_module
 
-  double precision, save :: ambient_dens
-  double precision, save :: density, diameter
-  double precision, save :: problem
+  use bl_fort_module, only : rt => c_real
+  real(rt)        , save :: ambient_dens
+  real(rt)        , save :: density, diameter
+  real(rt)        , save :: problem
 
 end module probdata_module

--- a/Exec/hydro_tests/HCBubble/Prob_3d.f90
+++ b/Exec/hydro_tests/HCBubble/Prob_3d.f90
@@ -6,12 +6,13 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
   use network
   use probdata_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer init, namlen
   integer name(namlen)
-  double precision problo(3), probhi(3)
-  double precision xn(nspec)
+  real(rt)         problo(3), probhi(3)
+  real(rt)         xn(nspec)
 
   integer untin,i
 
@@ -67,8 +68,8 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
   split(3) = frac*(problo(3)+probhi(3))
   
   ! compute the internal energy (erg/cc) for the left and right state
-  xn(:) = 0.0d0
-  xn(1) = 1.0d0
+  xn(:) = 0.0e0_rt
+  xn(1) = 1.0e0_rt
 
   if (use_Tinit) then
 
@@ -94,7 +95,7 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
 
      eos_state%rho = rho_l
      eos_state%p = p_l
-     eos_state%T = 100000.d0  ! initial guess
+     eos_state%T = 100000.e0_rt  ! initial guess
      eos_state%xn(:) = xn(:)
 
      call eos(eos_input_rp, eos_state)
@@ -104,7 +105,7 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
 
      eos_state%rho = rho_r
      eos_state%p = p_r
-     eos_state%T = 100000.d0  ! initial guess
+     eos_state%T = 100000.e0_rt  ! initial guess
      eos_state%xn(:) = xn(:)
 
      call eos(eos_input_rp, eos_state)
@@ -145,19 +146,20 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
   use network, only: nspec
   use probdata_module
   use meth_params_module, only : NVAR, URHO, UMX, UMY, UMZ, UEDEN, UEINT, UTEMP, UFS
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer level, nscal
   integer lo(3), hi(3)
   integer state_l1,state_l2,state_l3,state_h1,state_h2,state_h3
-  double precision xlo(3), xhi(3), time, delta(3)
-  double precision state(state_l1:state_h1,state_l2:state_h2, &
+  real(rt)         xlo(3), xhi(3), time, delta(3)
+  real(rt)         state(state_l1:state_h1,state_l2:state_h2, &
                          state_l3:state_h3,NVAR)
 
-  double precision xcen,ycen,zcen
+  real(rt)         xcen,ycen,zcen
   integer i,j,k
 
-  double precision rsq, dist, ycloud, zcloud, ecent, denfact, rhocld
+  real(rt)         rsq, dist, ycloud, zcloud, ecent, denfact, rhocld
 
   ycloud = 0.0
   zcloud = 0.0
@@ -167,20 +169,20 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
   rhocld  = rho_r * denfact
 
   do k = lo(3), hi(3)
-     zcen = xlo(3) + delta(3)*(float(k-lo(3)) + 0.5d0)
+     zcen = xlo(3) + delta(3)*(float(k-lo(3)) + 0.5e0_rt)
      
      do j = lo(2), hi(2)
-        ycen = xlo(2) + delta(2)*(float(j-lo(2)) + 0.5d0)
+        ycen = xlo(2) + delta(2)*(float(j-lo(2)) + 0.5e0_rt)
 
         do i = lo(1), hi(1)
-           xcen = xlo(1) + delta(1)*(float(i-lo(1)) + 0.5d0)
+           xcen = xlo(1) + delta(1)*(float(i-lo(1)) + 0.5e0_rt)
 
            if (idir == 1) then
               if (xcen <= split(1)) then      !! left of shock
                  state(i,j,k,URHO) = rho_l
                  state(i,j,k,UMX) = rho_l*u_l
-                 state(i,j,k,UMY) = 0.d0
-                 state(i,j,k,UMZ) = 0.d0
+                 state(i,j,k,UMY) = 0.e0_rt
+                 state(i,j,k,UMZ) = 0.e0_rt
                  state(i,j,k,UEDEN) = rhoe_l + 0.5*rho_l*u_l*u_l
                  state(i,j,k,UEINT) = rhoe_l
                  state(i,j,k,UTEMP) = T_l
@@ -191,17 +193,17 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
                dist = sqrt(rsq)
                if (dist .le. cldradius) then   !! inside bubble
                  state(i,j,k,URHO) = rhocld
-                 state(i,j,k,UMX) = 0.d0
-                 state(i,j,k,UMY) = 0.d0
-                 state(i,j,k,UMZ) = 0.d0
+                 state(i,j,k,UMX) = 0.e0_rt
+                 state(i,j,k,UMY) = 0.e0_rt
+                 state(i,j,k,UMZ) = 0.e0_rt
                  state(i,j,k,UEDEN) = rhoe_r + 0.5*rho_r*u_r*u_r
                  state(i,j,k,UEINT) = rhoe_r
                  state(i,j,k,UTEMP) = T_r
                else                            !! right of shock
                  state(i,j,k,URHO) = rho_r
                  state(i,j,k,UMX) = rho_r*u_r
-                 state(i,j,k,UMY) = 0.d0
-                 state(i,j,k,UMZ) = 0.d0
+                 state(i,j,k,UMY) = 0.e0_rt
+                 state(i,j,k,UMZ) = 0.e0_rt
                  state(i,j,k,UEDEN) = rhoe_r + 0.5*rho_r*u_r*u_r
                  state(i,j,k,UEINT) = rhoe_r
                  state(i,j,k,UTEMP) = T_r
@@ -212,7 +214,7 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
               call bl_abort('invalid idir')
            endif
  
-           state(i,j,k,UFS:UFS-1+nspec) = 0.0d0
+           state(i,j,k,UFS:UFS-1+nspec) = 0.0e0_rt
            state(i,j,k,UFS  ) = state(i,j,k,URHO)
 
            

--- a/Exec/hydro_tests/HCBubble/probdata.f90
+++ b/Exec/hydro_tests/HCBubble/probdata.f90
@@ -1,15 +1,16 @@
 module probdata_module
 
 !     Sod variables
-      double precision, save ::  p_l, u_l, rho_l, p_r, u_r, rho_r, rhoe_l, rhoe_r, frac
-      double precision, save :: T_l, T_r
-      double precision, save :: cldradius, xcloud
+      use bl_fort_module, only : rt => c_real
+      real(rt)        , save ::  p_l, u_l, rho_l, p_r, u_r, rho_r, rhoe_l, rhoe_r, frac
+      real(rt)        , save :: T_l, T_r
+      real(rt)        , save :: cldradius, xcloud
 
       logical, save :: use_Tinit
 
 !     These help specify which specific problem
       integer        , save ::  probtype,idir
 
-      double precision, save ::  split(3)
+      real(rt)        , save ::  split(3)
       
 end module probdata_module

--- a/Exec/hydro_tests/KH/Prob_nd.F90
+++ b/Exec/hydro_tests/KH/Prob_nd.F90
@@ -6,11 +6,12 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
    use meth_params_module, only: small_temp, small_pres, small_dens
    use eos_module
    
+   use bl_fort_module, only : rt => c_real
    implicit none
 
    integer :: init, namlen
    integer :: name(namlen)
-   double precision :: problo(3), probhi(3)
+   real(rt)         :: problo(3), probhi(3)
 
    integer :: untin
    integer :: i
@@ -98,25 +99,26 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
   use bl_constants_module
   use prob_params_module, only: problo, center, probhi
   
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer :: level, nscal
   integer :: lo(3), hi(3)
   integer :: state_lo(3), state_hi(3)
-  double precision :: xlo(3), xhi(3), time, delta(3)
-  double precision :: state(state_lo(1):state_hi(1),state_lo(2):state_hi(2),state_lo(3):state_hi(3),NVAR)
+  real(rt)         :: xlo(3), xhi(3), time, delta(3)
+  real(rt)         :: state(state_lo(1):state_hi(1),state_lo(2):state_hi(2),state_lo(3):state_hi(3),NVAR)
 
-  double precision :: xx, yy, zz
+  real(rt)         :: xx, yy, zz
 
   type (eos_t) :: eos_state
 
   integer :: i, j, k, n
 
-  double precision :: dens, velx, vely, velz
-  double precision :: w0, sigma, ramp, delta_y
-  double precision :: vel1, vel2
-  double precision :: y1, y2
-  double precision :: dye
+  real(rt)         :: dens, velx, vely, velz
+  real(rt)         :: w0, sigma, ramp, delta_y
+  real(rt)         :: vel1, vel2
+  real(rt)         :: y1, y2
+  real(rt)         :: dye
   
   integer :: sine_n
 
@@ -148,8 +150,8 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
      vel2 = ONE
   endif
 
-  y1 = center(2) - (probhi(2) - problo(2)) * 0.25d0
-  y2 = center(2) + (probhi(2) - problo(2)) * 0.25d0  
+  y1 = center(2) - (probhi(2) - problo(2)) * 0.25e0_rt
+  y2 = center(2) + (probhi(2) - problo(2)) * 0.25e0_rt  
   
   velz = 0.0
   

--- a/Exec/hydro_tests/KH/probdata.f90
+++ b/Exec/hydro_tests/KH/probdata.f90
@@ -1,12 +1,13 @@
 module probdata_module
 
  ! Problem setup data
-  double precision :: rho1, rho2, pressure
+  use bl_fort_module, only : rt => c_real
+  real(rt)         :: rho1, rho2, pressure
 
   ! Problem number
   integer :: problem
 
   ! Uniform flow speed
-  double precision :: bulk_velocity
+  real(rt)         :: bulk_velocity
 
 end module probdata_module

--- a/Exec/hydro_tests/Noh/Prob_nd.F90
+++ b/Exec/hydro_tests/Noh/Prob_nd.F90
@@ -1,10 +1,11 @@
    subroutine PROBINIT (init,name,namlen,problo,probhi)
 
+     use bl_fort_module, only : rt => c_real
      implicit none
 
      integer :: init, namlen
      integer :: name(namlen)
-     double precision :: problo(3), probhi(3)
+     real(rt)         :: problo(3), probhi(3)
 
    end subroutine PROBINIT
 
@@ -43,15 +44,16 @@
      use fundamental_constants_module, only: Gconst, M_solar
      use prob_params_module, only: center, dim
 
+     use bl_fort_module, only : rt => c_real
      implicit none
 
      integer :: level, nscal
      integer :: lo(3), hi(3)
      integer :: state_lo(3), state_hi(3)
-     double precision :: xlo(3), xhi(3), time, delta(3)
-     double precision :: state(state_lo(1):state_hi(1),state_lo(2):state_hi(2),state_lo(3):state_hi(3),NVAR)
+     real(rt)         :: xlo(3), xhi(3), time, delta(3)
+     real(rt)         :: state(state_lo(1):state_hi(1),state_lo(2):state_hi(2),state_lo(3):state_hi(3),NVAR)
 
-     double precision :: loc(3), r, vel(3)
+     real(rt)         :: loc(3), r, vel(3)
 
      type (eos_t) :: zone_state
 
@@ -69,8 +71,8 @@
 
               ! Uniform density, negligible pressure.
 
-              zone_state % rho = 1.0d0
-              zone_state % P   = 1.0d-6
+              zone_state % rho = 1.0e0_rt
+              zone_state % P   = 1.0e-6_rt
               zone_state % xn(:) = ONE / nspec
 
               call eos(eos_input_rp, zone_state)

--- a/Exec/hydro_tests/Noh/bc_fill_nd.F90
+++ b/Exec/hydro_tests/Noh/bc_fill_nd.F90
@@ -1,5 +1,6 @@
 module bc_fill_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   public
@@ -20,6 +21,7 @@ contains
     use eos_type_module, only: eos_t
     use network, only: nspec
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     include 'bc_types.fi'
@@ -27,15 +29,15 @@ contains
     integer          :: adv_lo(3),adv_hi(3)
     integer          :: bc(dim,2,*)
     integer          :: domlo(3), domhi(3)
-    double precision :: delta(3), xlo(3), time
-    double precision :: adv(adv_lo(1):adv_hi(1),adv_lo(2):adv_hi(2),adv_lo(3):adv_hi(3),NVAR)
+    real(rt)         :: delta(3), xlo(3), time
+    real(rt)         :: adv(adv_lo(1):adv_hi(1),adv_lo(2):adv_hi(2),adv_lo(3):adv_hi(3),NVAR)
 
     integer          :: i, j, k, n
-    double precision :: loc(3), vel(3), r
+    real(rt)         :: loc(3), vel(3), r
     type (eos_t)     :: zone_state
 
-    double precision :: pres_init = 1.0d-6
-    double precision :: rho_init = 1.0d0
+    real(rt)         :: pres_init = 1.0e-6_rt
+    real(rt)         :: rho_init = 1.0e0_rt
 
     do n = 1,NVAR
        call filcc_nd(adv(:,:,:,n),adv_lo,adv_hi,domlo,domhi,delta,xlo,bc(:,:,n))
@@ -84,6 +86,7 @@ contains
 
     use prob_params_module, only: dim  
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     include 'bc_types.fi'
@@ -91,8 +94,8 @@ contains
     integer          :: adv_lo(3),adv_hi(3)
     integer          :: bc(dim,2,*)
     integer          :: domlo(3), domhi(3)
-    double precision :: delta(3), xlo(3), time
-    double precision :: adv(adv_lo(1):adv_hi(1),adv_lo(2):adv_hi(2),adv_lo(3):adv_hi(3))
+    real(rt)         :: delta(3), xlo(3), time
+    real(rt)         :: adv(adv_lo(1):adv_hi(1),adv_lo(2):adv_hi(2),adv_lo(3):adv_hi(3))
 
     call filcc_nd(adv,adv_lo,adv_hi,domlo,domhi,delta,xlo,bc)
 

--- a/Exec/hydro_tests/RT/Prob_2d.f90
+++ b/Exec/hydro_tests/RT/Prob_2d.f90
@@ -3,11 +3,12 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
   use probdata_module
   use eos_module, only : gamma_const
   use bl_error_module
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer :: init, namlen
   integer :: name(namlen)
-  double precision :: problo(2), probhi(2)
+  real(rt)         :: problo(2), probhi(2)
 
   integer untin,i
 
@@ -27,10 +28,10 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
   end do
 
   ! set namelist defaults here
-  frac = 0.5d0
-  rho_1 = 1.0d0
-  rho_2 = 2.0d0
-  p0_base = 5.0d0
+  frac = 0.5e0_rt
+  rho_1 = 1.0e0_rt
+  rho_2 = 2.0e0_rt
+  p0_base = 5.0e0_rt
 
   ! Read namelists
   untin = 9
@@ -79,16 +80,17 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
   use bl_constants_module, only: ZERO, HALF, M_PI
   use eos_module, only : gamma_const
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer :: level, nscal
   integer :: lo(2), hi(2)
   integer :: state_l1,state_l2,state_h1,state_h2
-  double precision :: xlo(2), xhi(2), time, delta(2)
-  double precision :: state(state_l1:state_h1,state_l2:state_h2,NVAR)
+  real(rt)         :: xlo(2), xhi(2), time, delta(2)
+  real(rt)         :: state(state_l1:state_h1,state_l2:state_h2,NVAR)
 
   integer :: i,j
-  double precision :: x,y,pres,presmid,pertheight
+  real(rt)         :: x,y,pres,presmid,pertheight
 
   presmid  = p0_base - rho_1*split(2)
 
@@ -103,12 +105,12 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
 
         if (y .lt. split(2)) then
            pres = p0_base - rho_1*y
-           state(i,j,UEDEN) = pres / (gamma_const - 1.0d0)
-           state(i,j,UEINT) = pres / (gamma_const - 1.0d0)
+           state(i,j,UEDEN) = pres / (gamma_const - 1.0e0_rt)
+           state(i,j,UEINT) = pres / (gamma_const - 1.0e0_rt)
         else
            pres = presmid - rho_2*(y-split(2))
-           state(i,j,UEDEN) = pres / (gamma_const - 1.0d0)
-           state(i,j,UEINT) = pres / (gamma_const - 1.0d0)
+           state(i,j,UEDEN) = pres / (gamma_const - 1.0e0_rt)
+           state(i,j,UEINT) = pres / (gamma_const - 1.0e0_rt)
         end if
 
      enddo
@@ -122,10 +124,10 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
 
         ! we explicitly make the perturbation symmetric here
         ! -- this prevents the RT from bending.
-        pertheight = 0.01d0*HALF*(cos(2.0d0*M_PI*x/L_x) + &
-                                  cos(2.0d0*M_PI*(L_x-x)/L_x)) + 0.5d0
-        state(i,j,URHO) = rho_1 + ((rho_2-rho_1)/2.0d0)* &
-             (1+tanh((y-pertheight)/0.005d0))
+        pertheight = 0.01e0_rt*HALF*(cos(2.0e0_rt*M_PI*x/L_x) + &
+                                  cos(2.0e0_rt*M_PI*(L_x-x)/L_x)) + 0.5e0_rt
+        state(i,j,URHO) = rho_1 + ((rho_2-rho_1)/2.0e0_rt)* &
+             (1+tanh((y-pertheight)/0.005e0_rt))
         state(i,j,UFS) = state(i,j,URHO)
 
      enddo

--- a/Exec/hydro_tests/RT/Prob_3d.f90
+++ b/Exec/hydro_tests/RT/Prob_3d.f90
@@ -3,11 +3,12 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
   use probdata_module
   use eos_module, only : gamma_const
   use bl_error_module
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer :: init, namlen
   integer :: name(namlen)
-  double precision :: problo(3), probhi(3)
+  real(rt)         :: problo(3), probhi(3)
 
   integer untin,i
 
@@ -27,10 +28,10 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
   end do
          
   ! set namelist defaults here
-  frac = 0.5d0
-  rho_1 = 1.0d0
-  rho_2 = 2.0d0
-  p0_base = 5.0d0
+  frac = 0.5e0_rt
+  rho_1 = 1.0e0_rt
+  rho_2 = 2.0e0_rt
+  p0_base = 5.0e0_rt
 
   ! Read namelists
   untin = 9
@@ -80,16 +81,17 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
   use bl_constants_module, only: ZERO, HALF, M_PI
   use eos_module, only : gamma_const
   
+  use bl_fort_module, only : rt => c_real
   implicit none
         
   integer :: level, nscal
   integer :: lo(3), hi(3)
   integer :: state_l1,state_l2,state_l3,state_h1,state_h2,state_h3
-  double precision :: xlo(3), xhi(3), time, delta(3)
-  double precision :: state(state_l1:state_h1,state_l2:state_h2,state_l3:state_h3,NVAR)
+  real(rt)         :: xlo(3), xhi(3), time, delta(3)
+  real(rt)         :: state(state_l1:state_h1,state_l2:state_h2,state_l3:state_h3,NVAR)
   
   integer :: i,j,k
-  double precision :: x,y,z,r2d,pres,presmid,pertheight
+  real(rt)         :: x,y,z,r2d,pres,presmid,pertheight
   
   presmid  = p0_base - rho_1*split(3)
         
@@ -106,12 +108,12 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
            
            if (z .lt. split(3)) then
               pres = p0_base - rho_1*z
-              state(i,j,k,UEDEN) = pres / (gamma_const - 1.0d0)
-              state(i,j,k,UEINT) = pres / (gamma_const - 1.0d0)
+              state(i,j,k,UEDEN) = pres / (gamma_const - 1.0e0_rt)
+              state(i,j,k,UEINT) = pres / (gamma_const - 1.0e0_rt)
            else
               pres = presmid - rho_2*(z-split(3))
-              state(i,j,k,UEDEN) = pres / (gamma_const - 1.0d0)
-              state(i,j,k,UEINT) = pres / (gamma_const - 1.0d0)
+              state(i,j,k,UEDEN) = pres / (gamma_const - 1.0e0_rt)
+              state(i,j,k,UEINT) = pres / (gamma_const - 1.0e0_rt)
            end if
            
         enddo
@@ -127,10 +129,10 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
         do i = lo(1), hi(1)
            x = (i+HALF)*delta(1)
      
-           r2d = min(sqrt((x-split(1))**2+(y-split(2))**2), 0.5d0*L_x)
-           pertheight = 0.5d0 - 0.01d0*cos(2.0d0*M_PI*r2d/L_x)
-           state(i,j,k,URHO) = rho_1 + ((rho_2-rho_1)/2.0d0)* &
-                (1+tanh((z-pertheight)/0.005d0))
+           r2d = min(sqrt((x-split(1))**2+(y-split(2))**2), 0.5e0_rt*L_x)
+           pertheight = 0.5e0_rt - 0.01e0_rt*cos(2.0e0_rt*M_PI*r2d/L_x)
+           state(i,j,k,URHO) = rho_1 + ((rho_2-rho_1)/2.0e0_rt)* &
+                (1+tanh((z-pertheight)/0.005e0_rt))
            state(i,j,k,UFS) = state(i,j,k,URHO)
            
         enddo

--- a/Exec/hydro_tests/RT/probdata.f90
+++ b/Exec/hydro_tests/RT/probdata.f90
@@ -1,12 +1,13 @@
 module probdata_module
 
-  double precision , save :: frac
+  use bl_fort_module, only : rt => c_real
+  real(rt)         , save :: frac
 
-  double precision , save :: split(3)
+  real(rt)         , save :: split(3)
 
   ! RT parameters
-  double precision, save :: rho_1, rho_2
-  double precision, save :: p0_base
-  double precision, save :: L_x
+  real(rt)        , save :: rho_1, rho_2
+  real(rt)        , save :: p0_base
+  real(rt)        , save :: L_x
 
 end module probdata_module

--- a/Exec/hydro_tests/RT_particles/Prob_2d.f90
+++ b/Exec/hydro_tests/RT_particles/Prob_2d.f90
@@ -3,11 +3,12 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
   use probdata_module
   use eos_module, only : gamma_const
   use bl_error_module
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer :: init, namlen
   integer :: name(namlen)
-  double precision :: problo(2), probhi(2)
+  real(rt)         :: problo(2), probhi(2)
 
   integer untin,i
 
@@ -27,10 +28,10 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
   end do
          
   ! set namelist defaults here
-  frac = 0.5d0
-  rho_1 = 1.0d0
-  rho_2 = 2.0d0
-  p0_base = 5.0d0
+  frac = 0.5e0_rt
+  rho_1 = 1.0e0_rt
+  rho_2 = 2.0e0_rt
+  p0_base = 5.0e0_rt
 
   ! Read namelists
   untin = 9
@@ -79,16 +80,17 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
   use bl_constants_module, only: ZERO, HALF, M_PI
   use eos_module, only : gamma_const
   
+  use bl_fort_module, only : rt => c_real
   implicit none
         
   integer :: level, nscal
   integer :: lo(2), hi(2)
   integer :: state_l1,state_l2,state_h1,state_h2
-  double precision :: xlo(2), xhi(2), time, delta(2)
-  double precision :: state(state_l1:state_h1,state_l2:state_h2,NVAR)
+  real(rt)         :: xlo(2), xhi(2), time, delta(2)
+  real(rt)         :: state(state_l1:state_h1,state_l2:state_h2,NVAR)
   
   integer :: i,j
-  double precision :: x,y,pres,presmid,pertheight
+  real(rt)         :: x,y,pres,presmid,pertheight
   
   presmid  = p0_base - rho_1*split(2)
         
@@ -103,12 +105,12 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
         
         if (y .lt. split(2)) then
            pres = p0_base - rho_1*y
-           state(i,j,UEDEN) = pres / (gamma_const - 1.0d0)
-           state(i,j,UEINT) = pres / (gamma_const - 1.0d0)
+           state(i,j,UEDEN) = pres / (gamma_const - 1.0e0_rt)
+           state(i,j,UEINT) = pres / (gamma_const - 1.0e0_rt)
         else
            pres = presmid - rho_2*(y-split(2))
-           state(i,j,UEDEN) = pres / (gamma_const - 1.0d0)
-           state(i,j,UEINT) = pres / (gamma_const - 1.0d0)
+           state(i,j,UEDEN) = pres / (gamma_const - 1.0e0_rt)
+           state(i,j,UEINT) = pres / (gamma_const - 1.0e0_rt)
         end if
         
      enddo
@@ -122,10 +124,10 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
 
         ! we explicitly make the perturbation symmetric here
         ! -- this prevents the RT from bending.
-        pertheight = 0.01d0*HALF*(cos(2.0d0*M_PI*x/L_x) + &
-                                  cos(2.0d0*M_PI*(L_x-x)/L_x)) + 0.5d0
-        state(i,j,URHO) = rho_1 + ((rho_2-rho_1)/2.0d0)* &
-             (1+tanh((y-pertheight)/0.005d0))
+        pertheight = 0.01e0_rt*HALF*(cos(2.0e0_rt*M_PI*x/L_x) + &
+                                  cos(2.0e0_rt*M_PI*(L_x-x)/L_x)) + 0.5e0_rt
+        state(i,j,URHO) = rho_1 + ((rho_2-rho_1)/2.0e0_rt)* &
+             (1+tanh((y-pertheight)/0.005e0_rt))
         state(i,j,UFS) = state(i,j,URHO)
         
      enddo

--- a/Exec/hydro_tests/RT_particles/bc_fill_2d.F90
+++ b/Exec/hydro_tests/RT_particles/bc_fill_2d.F90
@@ -1,5 +1,6 @@
 module bc_fill_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   public
@@ -13,6 +14,7 @@ contains
     use eos_module, only : gamma_const
     use probdata_module, only: p0_base
 
+    use bl_fort_module, only : rt => c_real
     implicit none
     
     include 'bc_types.fi'
@@ -20,11 +22,11 @@ contains
     integer :: adv_l1,adv_l2,adv_h1,adv_h2
     integer :: bc(2,2,*)
     integer :: domlo(2), domhi(2)
-    double precision :: delta(2), xlo(2), time
-    double precision :: adv(adv_l1:adv_h1,adv_l2:adv_h2,NVAR)
+    real(rt)         :: delta(2), xlo(2), time
+    real(rt)         :: adv(adv_l1:adv_h1,adv_l2:adv_h2,NVAR)
 
     integer :: i,j,n
-    double precision :: y,pres
+    real(rt)         :: y,pres
 
     do n = 1,NVAR
        call filcc(adv(adv_l1,adv_l2,n),adv_l1,adv_l2,adv_h1,adv_h2, &
@@ -45,14 +47,14 @@ contains
        !        YLO
        if ( bc(2,1,n).eq.EXT_DIR .and. adv_l2.lt.domlo(2)) then
           do j=adv_l2,domlo(2)-1
-             y = (j+0.5d0)*delta(2)
+             y = (j+0.5e0_rt)*delta(2)
              do i=adv_l1,adv_h1
                 if (n .eq. URHO)  adv(i,j,n) = 1.0
                 if (n .eq. UMX)   adv(i,j,n) = 0.0
                 if (n .eq. UMY)   adv(i,j,n) = 0.0
                 if (n .eq. UEDEN .or. n .eq. UEINT) then
                    pres = p0_base - y
-                   adv(i,j,n) = pres / (gamma_const - 1.0d0)
+                   adv(i,j,n) = pres / (gamma_const - 1.0e0_rt)
                 end if
 
                 if (n .eq. UFS)   adv(i,j,n) = 1.0
@@ -75,6 +77,7 @@ contains
   subroutine ca_denfill(adv,adv_l1,adv_l2,adv_h1,adv_h2, &
                         domlo,domhi,delta,xlo,time,bc) bind(C)
 
+    use bl_fort_module, only : rt => c_real
     implicit none
     
     include 'bc_types.fi'
@@ -82,8 +85,8 @@ contains
     integer :: adv_l1,adv_l2,adv_h1,adv_h2
     integer :: bc(2,2,*)
     integer :: domlo(2), domhi(2)
-    double precision :: delta(2), xlo(2), time
-    double precision :: adv(adv_l1:adv_h1,adv_l2:adv_h2)
+    real(rt)         :: delta(2), xlo(2), time
+    real(rt)         :: adv(adv_l1:adv_h1,adv_l2:adv_h2)
 
     !     Note: this function should not be needed, technically, but is provided
     !     to filpatch because there are many times in the algorithm when just
@@ -121,6 +124,7 @@ contains
 
     use probdata_module
     
+    use bl_fort_module, only : rt => c_real
     implicit none
     
     include 'bc_types.fi'
@@ -128,8 +132,8 @@ contains
     integer :: grav_l1,grav_l2,grav_h1,grav_h2
     integer :: bc(2,2,*)
     integer :: domlo(2), domhi(2)
-    double precision :: delta(2), xlo(2), time
-    double precision :: grav(grav_l1:grav_h1,grav_l2:grav_h2)
+    real(rt)         :: delta(2), xlo(2), time
+    real(rt)         :: grav(grav_l1:grav_h1,grav_l2:grav_h2)
 
     call filcc(grav,grav_l1,grav_l2,grav_h1,grav_h2,domlo,domhi,delta,xlo,bc)
 
@@ -142,6 +146,7 @@ contains
 
     use probdata_module
     
+    use bl_fort_module, only : rt => c_real
     implicit none
     
     include 'bc_types.fi'
@@ -149,8 +154,8 @@ contains
     integer :: grav_l1,grav_l2,grav_h1,grav_h2
     integer :: bc(2,2,*)
     integer :: domlo(2), domhi(2)
-    double precision :: delta(2), xlo(2), time
-    double precision :: grav(grav_l1:grav_h1,grav_l2:grav_h2)
+    real(rt)         :: delta(2), xlo(2), time
+    real(rt)         :: grav(grav_l1:grav_h1,grav_l2:grav_h2)
 
     call filcc(grav,grav_l1,grav_l2,grav_h1,grav_h2,domlo,domhi,delta,xlo,bc)
 
@@ -163,6 +168,7 @@ contains
 
     use probdata_module
     
+    use bl_fort_module, only : rt => c_real
     implicit none
     
     include 'bc_types.fi'
@@ -170,8 +176,8 @@ contains
     integer :: grav_l1,grav_l2,grav_h1,grav_h2
     integer :: bc(2,2,*)
     integer :: domlo(2), domhi(2)
-    double precision :: delta(2), xlo(2), time
-    double precision :: grav(grav_l1:grav_h1,grav_l2:grav_h2)
+    real(rt)         :: delta(2), xlo(2), time
+    real(rt)         :: grav(grav_l1:grav_h1,grav_l2:grav_h2)
 
     call filcc(grav,grav_l1,grav_l2,grav_h1,grav_h2,domlo,domhi,delta,xlo,bc)
 
@@ -184,6 +190,7 @@ contains
 
     use probdata_module
     
+    use bl_fort_module, only : rt => c_real
     implicit none
     
     include 'bc_types.fi'
@@ -191,8 +198,8 @@ contains
     integer :: phi_l1,phi_l2,phi_h1,phi_h2
     integer :: bc(2,2,*)
     integer :: domlo(2), domhi(2)
-    double precision :: delta(2), xlo(2), time
-    double precision :: phi(phi_l1:phi_h1,phi_l2:phi_h2)
+    real(rt)         :: delta(2), xlo(2), time
+    real(rt)         :: phi(phi_l1:phi_h1,phi_l2:phi_h2)
 
     call filcc(phi,phi_l1,phi_l2,phi_h1,phi_h2,domlo,domhi,delta,xlo,bc)
 

--- a/Exec/hydro_tests/RT_particles/probdata.f90
+++ b/Exec/hydro_tests/RT_particles/probdata.f90
@@ -1,12 +1,13 @@
 module probdata_module
 
-  double precision , save :: frac
+  use bl_fort_module, only : rt => c_real
+  real(rt)         , save :: frac
 
-  double precision , save :: split(3)
+  real(rt)         , save :: split(3)
 
   ! RT parameters
-  double precision, save :: rho_1, rho_2
-  double precision, save :: p0_base
-  double precision, save :: L_x
+  real(rt)        , save :: rho_1, rho_2
+  real(rt)        , save :: p0_base
+  real(rt)        , save :: L_x
 
 end module probdata_module

--- a/Exec/hydro_tests/Sedov/Prob_1d.f90
+++ b/Exec/hydro_tests/Sedov/Prob_1d.f90
@@ -2,11 +2,12 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
 
   use probdata_module
   use prob_params_module, only : center
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer :: init, namlen
   integer :: name(namlen)
-  double precision :: problo(1), probhi(1)
+  real(rt)         :: problo(1), probhi(1)
   
   integer :: untin,i
 
@@ -27,10 +28,10 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
          
   ! set namelist defaults
 
-  p_ambient = 1.d-5        ! ambient pressure (in erg/cc)
-  dens_ambient = 1.d0      ! ambient density (in g/cc)
-  exp_energy = 1.d0        ! absolute energy of the explosion (in erg)
-  r_init = 0.05d0          ! initial radius of the explosion (in cm)
+  p_ambient = 1.e-5_rt        ! ambient pressure (in erg/cc)
+  dens_ambient = 1.e0_rt      ! ambient density (in g/cc)
+  exp_energy = 1.e0_rt        ! absolute energy of the explosion (in erg)
+  r_init = 0.05e0_rt          ! initial radius of the explosion (in cm)
   nsub = 4
 
   ! Read namelists
@@ -39,7 +40,7 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
   read(untin,fortin)
   close(unit=untin)
 
-  center(1) = 0.d0
+  center(1) = 0.e0_rt
 
 end subroutine PROBINIT
 
@@ -74,22 +75,23 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
   use bl_constants_module, only: M_PI, FOUR3RD
   use meth_params_module , only: NVAR, URHO, UMX, UMZ, UEDEN, UEINT, UFS
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer :: level, nscal
   integer :: lo(1), hi(1)
   integer :: state_l1,state_h1
-  double precision :: xlo(1), xhi(1), time, delta(1)
-  double precision :: state(state_l1:state_h1,NVAR)
+  real(rt)         :: xlo(1), xhi(1), time, delta(1)
+  real(rt)         :: state(state_l1:state_h1,NVAR)
   
-  double precision :: xmin
-  double precision :: xx, xl, xr
-  double precision :: dx_sub,dist
-  double precision :: eint, p_zone
-  double precision :: vctr, p_exp
+  real(rt)         :: xmin
+  real(rt)         :: xx, xl, xr
+  real(rt)         :: dx_sub,dist
+  real(rt)         :: eint, p_zone
+  real(rt)         :: vctr, p_exp
 
   integer :: i,ii
-  double precision :: vol_pert, vol_ambient
+  real(rt)         :: vol_pert, vol_ambient
 
   dx_sub = delta(1)/dble(nsub)
 
@@ -99,14 +101,14 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
      ! set explosion pressure -- we will convert the point-explosion energy into
      ! a corresponding pressure distributed throughout the perturbed volume
      vctr = M_PI*r_init**2
-     p_exp = (gamma_const - 1.d0)*exp_energy/vctr
+     p_exp = (gamma_const - 1.e0_rt)*exp_energy/vctr
 
      do i = lo(1), hi(1)
         xmin = xlo(1) + delta(1)*dble(i-lo(1))
-        vol_pert    = 0.d0
-        vol_ambient = 0.d0
+        vol_pert    = 0.e0_rt
+        vol_ambient = 0.e0_rt
         do ii = 0, nsub-1
-           xx = xmin + (dble(ii) + 0.5d0) * dx_sub
+           xx = xmin + (dble(ii) + 0.5e0_rt) * dx_sub
            dist = xx
            if(dist <= r_init) then
               vol_pert = vol_pert + dist
@@ -117,12 +119,12 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
 
         p_zone = (vol_pert*p_exp + vol_ambient*p_ambient)/(vol_pert+vol_ambient)
   
-        eint = p_zone/(gamma_const - 1.d0)
+        eint = p_zone/(gamma_const - 1.e0_rt)
    
         state(i,URHO) = dens_ambient
-        state(i,UMX:UMZ) = 0.d0
+        state(i,UMX:UMZ) = 0.e0_rt
   
-        state(i,UEDEN) = eint + 0.5d0 * state(i,UMX)**2 / state(i,URHO)
+        state(i,UEDEN) = eint + 0.5e0_rt * state(i,UMX)**2 / state(i,URHO)
         state(i,UEINT) = eint
 
         state(i,UFS) = state(i,URHO)
@@ -135,16 +137,16 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
      ! set explosion pressure -- we will convert the point-explosion energy into
      ! a corresponding pressure distributed throughout the perturbed volume
      vctr = FOUR3RD*M_PI*r_init**3
-     p_exp = (gamma_const - 1.d0)*exp_energy/vctr
+     p_exp = (gamma_const - 1.e0_rt)*exp_energy/vctr
      
      do i = lo(1), hi(1)
         xmin = xlo(1) + delta(1)*dble(i-lo(1))
-        vol_pert    = 0.d0
-        vol_ambient = 0.d0
+        vol_pert    = 0.e0_rt
+        vol_ambient = 0.e0_rt
         do ii = 0, nsub-1
            xl = xmin + (dble(ii)        ) * dx_sub
-           xr = xmin + (dble(ii) + 1.0d0) * dx_sub
-           xx = 0.5d0*(xl + xr)
+           xr = xmin + (dble(ii) + 1.0e0_rt) * dx_sub
+           xx = 0.5e0_rt*(xl + xr)
            
            ! the volume of a subzone is (4/3) pi (xr^3 - xl^3).
            ! we can factor this as: (4/3) pi dr (xr^2 + xl*xr + xl^2)
@@ -158,12 +160,12 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
         
         p_zone = (vol_pert*p_exp + vol_ambient*p_ambient)/(vol_pert+vol_ambient)
   
-        eint = p_zone/(gamma_const - 1.d0)
+        eint = p_zone/(gamma_const - 1.e0_rt)
    
         state(i,URHO) = dens_ambient
-        state(i,UMX:UMZ) = 0.d0
+        state(i,UMX:UMZ) = 0.e0_rt
         
-        state(i,UEDEN) = eint + 0.5d0 * state(i,UMX)**2 / state(i,URHO)
+        state(i,UEDEN) = eint + 0.5e0_rt * state(i,UMX)**2 / state(i,URHO)
         state(i,UEINT) = eint
 
         state(i,UFS) = state(i,URHO)

--- a/Exec/hydro_tests/Sedov/Prob_2d.f90
+++ b/Exec/hydro_tests/Sedov/Prob_2d.f90
@@ -4,11 +4,12 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
   use prob_params_module, only : center
   use bl_error_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer :: init, namlen
   integer :: name(namlen)
-  double precision :: problo(2), probhi(2)
+  real(rt)         :: problo(2), probhi(2)
 
   integer :: untin,i
 
@@ -29,15 +30,15 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
 
   ! Set namelist defaults
 
-  p_ambient = 1.d-5        ! ambient pressure (in erg/cc)
-  dens_ambient = 1.d0      ! ambient density (in g/cc)
-  exp_energy = 1.d0        ! absolute energy of the explosion (in erg)
-  r_init = 0.05d0          ! initial radius of the explosion (in cm)
+  p_ambient = 1.e-5_rt        ! ambient pressure (in erg/cc)
+  dens_ambient = 1.e0_rt      ! ambient density (in g/cc)
+  exp_energy = 1.e0_rt        ! absolute energy of the explosion (in erg)
+  r_init = 0.05e0_rt          ! initial radius of the explosion (in cm)
   nsub = 4
 
   !     Set explosion center
-  center(1) = (problo(1)+probhi(1))/2.d0
-  center(2) = (problo(2)+probhi(2))/2.d0
+  center(1) = (problo(1)+probhi(1))/2.e0_rt
+  center(2) = (problo(2)+probhi(2))/2.e0_rt
 
   !     Read namelists
   untin = 9
@@ -78,22 +79,23 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
   use bl_constants_module, only: M_PI, FOUR3RD
   use meth_params_module , only: NVAR, URHO, UMX, UMZ, UEDEN, UEINT, UFS
   use prob_params_module, only : center
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer :: level, nscal
   integer :: lo(2), hi(2)
   integer :: state_l1,state_l2,state_h1,state_h2
-  double precision :: xlo(2), xhi(2), time, delta(2)
-  double precision :: state(state_l1:state_h1,state_l2:state_h2,NVAR)
+  real(rt)         :: xlo(2), xhi(2), time, delta(2)
+  real(rt)         :: state(state_l1:state_h1,state_l2:state_h2,NVAR)
 
-  double precision :: xmin,ymin
-  double precision :: xx, yy
-  double precision :: dist
-  double precision :: eint, p_zone
-  double precision :: vctr, p_exp
+  real(rt)         :: xmin,ymin
+  real(rt)         :: xx, yy
+  real(rt)         :: dist
+  real(rt)         :: eint, p_zone
+  real(rt)         :: vctr, p_exp
 
   integer :: i,j, ii, jj
-  double precision :: vol_pert, vol_ambient
+  real(rt)         :: vol_pert, vol_ambient
 
   ! Cylindrical problem in Cartesian coordinates
   if (probtype .eq. 21) then
@@ -102,7 +104,7 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
      ! energy into a corresponding pressure distributed throughout the
      ! perturbed volume
      vctr = M_PI*r_init**2
-     p_exp = (gamma_const - 1.d0)*exp_energy/vctr
+     p_exp = (gamma_const - 1.e0_rt)*exp_energy/vctr
 
      do j = lo(2), hi(2)
         ymin = xlo(2) + delta(2)*dble(j-lo(2))
@@ -110,21 +112,21 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
         do i = lo(1), hi(1)
            xmin = xlo(1) + delta(1)*dble(i-lo(1))
 
-           vol_pert    = 0.d0
-           vol_ambient = 0.d0
+           vol_pert    = 0.e0_rt
+           vol_ambient = 0.e0_rt
 
            do jj = 0, nsub-1
-              yy = ymin + (delta(2)/dble(nsub))*(jj + 0.5d0)
+              yy = ymin + (delta(2)/dble(nsub))*(jj + 0.5e0_rt)
 
               do ii = 0, nsub-1
-                 xx = xmin + (delta(1)/dble(nsub))*(ii + 0.5d0)
+                 xx = xmin + (delta(1)/dble(nsub))*(ii + 0.5e0_rt)
 
                  dist = (center(1)-xx)**2 + (center(2)-yy)**2
 
                  if(dist <= r_init**2) then
-                    vol_pert    = vol_pert    + 1.d0
+                    vol_pert    = vol_pert    + 1.e0_rt
                  else
-                    vol_ambient = vol_ambient + 1.d0
+                    vol_ambient = vol_ambient + 1.e0_rt
                  endif
 
               enddo
@@ -132,13 +134,13 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
 
            p_zone = (vol_pert*p_exp + vol_ambient*p_ambient)/ (vol_pert + vol_ambient)
 
-           eint = p_zone/(gamma_const - 1.d0)
+           eint = p_zone/(gamma_const - 1.e0_rt)
 
            state(i,j,URHO) = dens_ambient
-           state(i,j,UMX:UMZ) = 0.d0
+           state(i,j,UMX:UMZ) = 0.e0_rt
 
            state(i,j,UEDEN) = eint +  &
-                0.5d0*(sum(state(i,j,UMX:UMZ)**2)/state(i,j,URHO))
+                0.5e0_rt*(sum(state(i,j,UMX:UMZ)**2)/state(i,j,URHO))
 
            state(i,j,UEINT) = eint
 
@@ -155,18 +157,18 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
      !  energy into a corresponding pressure distributed throughout
      !  the perturbed volume
      vctr = M_PI*r_init**2
-     p_exp = (gamma_const - 1.d0)*exp_energy/vctr
+     p_exp = (gamma_const - 1.e0_rt)*exp_energy/vctr
 
      j = lo(2)
 
      do i = lo(1), hi(1)
         xmin = xlo(1) + delta(1)*dble(i-lo(1))
 
-        vol_pert    = 0.d0
-        vol_ambient = 0.d0
+        vol_pert    = 0.e0_rt
+        vol_ambient = 0.e0_rt
 
         do ii = 0, nsub-1
-           xx = xmin + (delta(1)/dble(nsub))*(ii + 0.5d0)
+           xx = xmin + (delta(1)/dble(nsub))*(ii + 0.5e0_rt)
 
            dist = xx
 
@@ -180,13 +182,13 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
 
         p_zone = (vol_pert*p_exp + vol_ambient*p_ambient)/ (vol_pert + vol_ambient)
 
-        eint = p_zone/(gamma_const - 1.d0)
+        eint = p_zone/(gamma_const - 1.e0_rt)
 
         state(i,j,URHO) = dens_ambient
-        state(i,j,UMX:UMZ) = 0.d0
+        state(i,j,UMX:UMZ) = 0.e0_rt
 
         state(i,j,UEDEN) = eint + &
-             0.5d0*(sum(state(i,j,UMX:UMZ)**2)/state(i,j,URHO))
+             0.5e0_rt*(sum(state(i,j,UMX:UMZ)**2)/state(i,j,URHO))
 
         state(i,j,UEINT) = eint
 
@@ -197,7 +199,7 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
      do j = lo(2), hi(2)
         do i = lo(1), hi(1)
            state(i,j,URHO ) = state(i,lo(2),URHO)
-           state(i,j,UMX:UMZ) = 0.d0
+           state(i,j,UMX:UMZ) = 0.e0_rt
            state(i,j,UEDEN) = state(i,lo(2),UEDEN)
            state(i,j,UEINT) = state(i,lo(2),UEINT)
            state(i,j,UFS  ) = state(i,lo(2),UFS)
@@ -212,7 +214,7 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
      ! energy into a corresponding pressure distributed throughout the
      ! perturbed volume
      vctr = FOUR3RD*M_PI*r_init**3
-     p_exp = (gamma_const - 1.d0)*exp_energy/vctr
+     p_exp = (gamma_const - 1.e0_rt)*exp_energy/vctr
 
      do j = lo(2), hi(2)
         ymin = xlo(2) + delta(2)*dble(j-lo(2))
@@ -220,14 +222,14 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
         do i = lo(1), hi(1)
            xmin = xlo(1) + delta(1)*dble(i-lo(1))
 
-           vol_pert    = 0.d0
-           vol_ambient = 0.d0
+           vol_pert    = 0.e0_rt
+           vol_ambient = 0.e0_rt
 
            do jj = 0, nsub-1
-              yy = ymin + (delta(2)/dble(nsub))*(dble(jj) + 0.5d0)
+              yy = ymin + (delta(2)/dble(nsub))*(dble(jj) + 0.5e0_rt)
 
               do ii = 0, nsub-1
-                 xx = xmin + (delta(1)/dble(nsub))*(dble(ii) + 0.5d0)
+                 xx = xmin + (delta(1)/dble(nsub))*(dble(ii) + 0.5e0_rt)
 
                  dist = sqrt(xx**2 + yy**2)
 
@@ -251,13 +253,13 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
 
            p_zone = (vol_pert*p_exp + vol_ambient*p_ambient)/ (vol_pert + vol_ambient)
 
-           eint = p_zone/(gamma_const - 1.d0)
+           eint = p_zone/(gamma_const - 1.e0_rt)
 
            state(i,j,URHO) = dens_ambient
-           state(i,j,UMX:UMZ) = 0.d0
+           state(i,j,UMX:UMZ) = 0.e0_rt
 
            state(i,j,UEDEN) = eint + &
-                0.5d0*(sum(state(i,j,UMX:UMZ)**2)/state(i,j,URHO))
+                0.5e0_rt*(sum(state(i,j,UMX:UMZ)**2)/state(i,j,URHO))
 
            state(i,j,UEINT) = eint
 

--- a/Exec/hydro_tests/Sedov/Prob_3d.f90
+++ b/Exec/hydro_tests/Sedov/Prob_3d.f90
@@ -4,10 +4,11 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
   use prob_params_module, only : center
   use bl_error_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
   integer :: init, namlen
   integer :: name(namlen)
-  double precision :: problo(3), probhi(3)
+  real(rt)         :: problo(3), probhi(3)
 
   integer :: untin,i
 
@@ -28,10 +29,10 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
          
   ! set namelist defaults
 
-  p_ambient = 1.d-5        ! ambient pressure (in erg/cc)
-  dens_ambient = 1.d0      ! ambient density (in g/cc)
-  exp_energy = 1.d0        ! absolute energy of the explosion (in erg)
-  r_init = 0.05d0          ! initial radius of the explosion (in cm)
+  p_ambient = 1.e-5_rt        ! ambient pressure (in erg/cc)
+  dens_ambient = 1.e0_rt      ! ambient density (in g/cc)
+  exp_energy = 1.e0_rt        ! absolute energy of the explosion (in erg)
+  r_init = 0.05e0_rt          ! initial radius of the explosion (in cm)
   nsub = 4
 
   ! Read namelists
@@ -41,9 +42,9 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
   close(unit=untin)
 
   ! set local variable defaults
-  center(1) = (problo(1)+probhi(1))/2.d0
-  center(2) = (problo(2)+probhi(2))/2.d0
-  center(3) = (problo(3)+probhi(3))/2.d0
+  center(1) = (problo(1)+probhi(1))/2.e0_rt
+  center(2) = (problo(2)+probhi(2))/2.e0_rt
+  center(3) = (problo(3)+probhi(3))/2.e0_rt
   
 end subroutine PROBINIT
 
@@ -79,20 +80,21 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
   use meth_params_module , only: NVAR, URHO, UMX, UMY, UMZ, UEDEN, UEINT, UFS
   use prob_params_module, only : center
 
+  use bl_fort_module, only : rt => c_real
   implicit none
   integer :: level, nscal
   integer :: lo(3), hi(3)
   integer :: state_l1,state_l2,state_l3,state_h1,state_h2,state_h3
-  double precision :: xlo(3), xhi(3), time, delta(3)
-  double precision :: state(state_l1:state_h1, &
+  real(rt)         :: xlo(3), xhi(3), time, delta(3)
+  real(rt)         :: state(state_l1:state_h1, &
                             state_l2:state_h2, &
                             state_l3:state_h3,NVAR)
 
-  double precision :: xmin,ymin,zmin
-  double precision :: xx, yy, zz
-  double precision :: dist
-  double precision :: eint, p_zone
-  double precision :: vctr, p_exp
+  real(rt)         :: xmin,ymin,zmin
+  real(rt)         :: xx, yy, zz
+  real(rt)         :: dist
+  real(rt)         :: eint, p_zone
+  real(rt)         :: vctr, p_exp
 
   integer :: i,j,k, ii, jj, kk
   integer :: npert, nambient
@@ -103,7 +105,7 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
      ! energy into a corresponding pressure distributed throughout the
      ! perturbed volume
      vctr  = M_PI*r_init**2
-     p_exp = (gamma_const - 1.d0)*exp_energy/vctr
+     p_exp = (gamma_const - 1.e0_rt)*exp_energy/vctr
      
      do k = lo(3), hi(3)
         zmin = xlo(3) + delta(3)*dble(k-lo(3)) 
@@ -118,10 +120,10 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
               nambient = 0
               
               do jj = 0, nsub-1
-                 yy = ymin + (delta(2)/dble(nsub))*(jj + 0.5d0)
+                 yy = ymin + (delta(2)/dble(nsub))*(jj + 0.5e0_rt)
                  
                  do ii = 0, nsub-1
-                    xx = xmin + (delta(1)/dble(nsub))*(ii + 0.5d0)
+                    xx = xmin + (delta(1)/dble(nsub))*(ii + 0.5e0_rt)
                     
                     dist = (center(1)-xx)**2 + (center(2)-yy)**2
                     
@@ -137,15 +139,15 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
               p_zone = (dble(npert)*p_exp + dble(nambient)*p_ambient) / &
                        (dble(npert) + dble(nambient))
 
-              eint = p_zone/(gamma_const - 1.d0)
+              eint = p_zone/(gamma_const - 1.e0_rt)
 
               state(i,j,k,URHO) = dens_ambient
-              state(i,j,k,UMX) = 0.d0
-              state(i,j,k,UMY) = 0.d0
-              state(i,j,k,UMZ) = 0.d0
+              state(i,j,k,UMX) = 0.e0_rt
+              state(i,j,k,UMY) = 0.e0_rt
+              state(i,j,k,UMZ) = 0.e0_rt
               
               state(i,j,k,UEDEN) = eint +  &
-                   0.5d0*(state(i,j,k,UMX)**2/state(i,j,k,URHO) + &
+                   0.5e0_rt*(state(i,j,k,UMX)**2/state(i,j,k,URHO) + &
                           state(i,j,k,UMY)**2/state(i,j,k,URHO) + &
                           state(i,j,k,UMZ)**2/state(i,j,k,URHO))
 
@@ -162,7 +164,7 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
      ! set explosion pressure -- we will convert the point-explosion energy into
      ! a corresponding pressure distributed throughout the perturbed volume
      vctr  = FOUR3RD*M_PI*r_init**3
-     p_exp = (gamma_const - 1.d0)*exp_energy/vctr
+     p_exp = (gamma_const - 1.e0_rt)*exp_energy/vctr
 
      do k = lo(3), hi(3)
         zmin = xlo(3) + delta(3)*dble(k-lo(3)) 
@@ -177,13 +179,13 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
               nambient = 0
 
               do kk = 0, nsub-1
-                 zz = zmin + (delta(3)/dble(nsub))*(kk + 0.5d0)
+                 zz = zmin + (delta(3)/dble(nsub))*(kk + 0.5e0_rt)
                  
                  do jj = 0, nsub-1
-                    yy = ymin + (delta(2)/dble(nsub))*(jj + 0.5d0)
+                    yy = ymin + (delta(2)/dble(nsub))*(jj + 0.5e0_rt)
                     
                     do ii = 0, nsub-1
-                       xx = xmin + (delta(1)/dble(nsub))*(ii + 0.5d0)
+                       xx = xmin + (delta(1)/dble(nsub))*(ii + 0.5e0_rt)
                        
                        dist = (center(1)-xx)**2 + (center(2)-yy)**2 + (center(3)-zz)**2
                        
@@ -200,15 +202,15 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
               p_zone = (dble(npert)*p_exp + dble(nambient)*p_ambient)/  &
                    dble(nsub*nsub*nsub)
 
-              eint = p_zone/(gamma_const - 1.d0)
+              eint = p_zone/(gamma_const - 1.e0_rt)
 
               state(i,j,k,URHO) = dens_ambient
-              state(i,j,k,UMX) = 0.d0
-              state(i,j,k,UMY) = 0.d0
-              state(i,j,k,UMZ) = 0.d0
+              state(i,j,k,UMX) = 0.e0_rt
+              state(i,j,k,UMY) = 0.e0_rt
+              state(i,j,k,UMZ) = 0.e0_rt
               
               state(i,j,k,UEDEN) = eint + &
-                   0.5d0*(state(i,j,k,UMX)**2/state(i,j,k,URHO) + &
+                   0.5e0_rt*(state(i,j,k,UMX)**2/state(i,j,k,URHO) + &
                           state(i,j,k,UMY)**2/state(i,j,k,URHO) + &
                           state(i,j,k,UMZ)**2/state(i,j,k,URHO))
 

--- a/Exec/hydro_tests/Sedov/bc_fill_1d.F90
+++ b/Exec/hydro_tests/Sedov/bc_fill_1d.F90
@@ -1,5 +1,6 @@
 module bc_fill_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   public
@@ -11,6 +12,7 @@ contains
 
     use meth_params_module, only : NVAR
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     include 'bc_types.fi'
@@ -18,11 +20,11 @@ contains
     integer :: adv_l1,adv_h1
     integer :: bc(1,2,*)
     integer :: domlo(1), domhi(1)
-    double precision :: delta(1), xlo(1), time
-    double precision :: adv(adv_l1:adv_h1,NVAR)
+    real(rt)         :: delta(1), xlo(1), time
+    real(rt)         :: adv(adv_l1:adv_h1,NVAR)
 
-    double precision :: state(NVAR)
-    double precision :: staten(NVAR)
+    real(rt)         :: state(NVAR)
+    real(rt)         :: staten(NVAR)
 
     integer :: i, n
     logical rho_only
@@ -74,6 +76,7 @@ contains
   subroutine ca_denfill(adv,adv_l1,adv_h1, &
                         domlo,domhi,delta,xlo,time,bc) bind(C, name="ca_denfill")
     
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     include 'bc_types.fi'
@@ -81,8 +84,8 @@ contains
     integer :: adv_l1,adv_h1
     integer :: bc(1,2,*)
     integer :: domlo(1), domhi(1)
-    double precision :: delta(1), xlo(1), time
-    double precision :: adv(adv_l1:adv_h1)
+    real(rt)         :: delta(1), xlo(1), time
+    real(rt)         :: adv(adv_l1:adv_h1)
     logical rho_only
     integer :: i
 
@@ -120,10 +123,11 @@ contains
     use eos_module, only: gamma_const
     use meth_params_module, only : NVAR, URHO, UMX, UEDEN, UEINT
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
-    double precision, intent(in   ) ::  u_int(*)
-    double precision, intent(  out) ::  u_ext(*)
+    real(rt)        , intent(in   ) ::  u_int(*)
+    real(rt)        , intent(  out) ::  u_ext(*)
     logical         , intent(in   ) :: rho_only
 
     ! Local variables
@@ -146,8 +150,8 @@ contains
        enddo
 
        u_ext(URHO ) = dens_ambient
-       u_ext(UMX  ) = 0.d0
-       u_ext(UEDEN) = p_ambient/(gamma_const-1.d0)
+       u_ext(UMX  ) = 0.e0_rt
+       u_ext(UEDEN) = p_ambient/(gamma_const-1.e0_rt)
        u_ext(UEINT) = u_ext(UEDEN)
 
     endif

--- a/Exec/hydro_tests/Sedov/bc_fill_2d.F90
+++ b/Exec/hydro_tests/Sedov/bc_fill_2d.F90
@@ -1,5 +1,6 @@
 module bc_fill_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   public
@@ -11,6 +12,7 @@ contains
 
     use meth_params_module, only : NVAR
 
+    use bl_fort_module, only : rt => c_real
     implicit none
     
     include 'bc_types.fi'
@@ -18,11 +20,11 @@ contains
     integer :: adv_l1,adv_l2,adv_h1,adv_h2
     integer :: bc(2,2,*)
     integer :: domlo(2), domhi(2)
-    double precision :: delta(2), xlo(2), time
-    double precision :: adv(adv_l1:adv_h1,adv_l2:adv_h2,NVAR)
+    real(rt)         :: delta(2), xlo(2), time
+    real(rt)         :: adv(adv_l1:adv_h1,adv_l2:adv_h2,NVAR)
 
-    double precision :: state(NVAR)
-    double precision :: staten(NVAR)
+    real(rt)         :: state(NVAR)
+    real(rt)         :: staten(NVAR)
 
     integer :: i, j, n
     logical rho_only
@@ -114,6 +116,7 @@ contains
   subroutine ca_denfill(adv,adv_l1,adv_l2,adv_h1,adv_h2, &
                         domlo,domhi,delta,xlo,time,bc) bind(C, name="ca_denfill")
 
+    use bl_fort_module, only : rt => c_real
     implicit none
     
     include 'bc_types.fi'
@@ -121,8 +124,8 @@ contains
     integer :: adv_l1,adv_l2,adv_h1,adv_h2
     integer :: bc(2,2,*)
     integer :: domlo(2), domhi(2)
-    double precision :: delta(2), xlo(2), time
-    double precision :: adv(adv_l1:adv_h1,adv_l2:adv_h2)
+    real(rt)         :: delta(2), xlo(2), time
+    real(rt)         :: adv(adv_l1:adv_h1,adv_l2:adv_h2)
     logical rho_only
     integer :: i,j
 
@@ -181,12 +184,13 @@ contains
     use eos_module, only : gamma_const
     use meth_params_module, only : NVAR, URHO, UMX, UMY, UEDEN, UEINT
     
+    use bl_fort_module, only : rt => c_real
     implicit none
 
-    double precision :: u_int(*),u_ext(*)
+    real(rt)         :: u_int(*),u_ext(*)
     logical rho_only
     integer :: dir,sgn
-    double precision :: rho, rhou(2), eden, T
+    real(rt)         :: rho, rhou(2), eden, T
     integer :: n,t1,i
 
     ! for the Sedov problem, we will always set the state to the ambient conditions
@@ -205,9 +209,9 @@ contains
        enddo
 
        u_ext(URHO)   = dens_ambient
-       u_ext(UMX)    = 0.d0
-       u_ext(UMY)    = 0.d0
-       u_ext(UEDEN)  = p_ambient/(gamma_const-1.d0)
+       u_ext(UMX)    = 0.e0_rt
+       u_ext(UMY)    = 0.e0_rt
+       u_ext(UEDEN)  = p_ambient/(gamma_const-1.e0_rt)
        u_ext(UEINT)  = u_ext(UEDEN)
 
     endif

--- a/Exec/hydro_tests/Sedov/bc_fill_3d.F90
+++ b/Exec/hydro_tests/Sedov/bc_fill_3d.F90
@@ -1,5 +1,6 @@
 module bc_fill_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   public
@@ -11,6 +12,7 @@ contains
 
     use meth_params_module, only : NVAR
 
+    use bl_fort_module, only : rt => c_real
     implicit none
     
     include 'bc_types.fi'
@@ -18,14 +20,14 @@ contains
     integer :: adv_l1,adv_l2,adv_l3,adv_h1,adv_h2,adv_h3
     integer :: bc(3,2,*)
     integer :: domlo(3), domhi(3)
-    double precision :: delta(3), xlo(3), time
-    double precision :: adv(adv_l1:adv_h1,adv_l2:adv_h2,adv_l3:adv_h3,NVAR)
+    real(rt)         :: delta(3), xlo(3), time
+    real(rt)         :: adv(adv_l1:adv_h1,adv_l2:adv_h2,adv_l3:adv_h3,NVAR)
 
-    double precision :: state(NVAR)
-    double precision :: staten(NVAR)
+    real(rt)         :: state(NVAR)
+    real(rt)         :: staten(NVAR)
 
     integer :: i, j, k, n, lo(3), hi(3)
-    double precision :: x, y, z
+    real(rt)         :: x, y, z
     logical rho_only
 
     lo(1) = adv_l1
@@ -160,6 +162,7 @@ contains
   subroutine ca_denfill(adv,adv_l1,adv_l2,adv_l3,adv_h1,adv_h2, &
                         adv_h3,domlo,domhi,delta,xlo,time,bc) bind(C, name="ca_denfill")
 
+    use bl_fort_module, only : rt => c_real
     implicit none
     
     include 'bc_types.fi'
@@ -167,8 +170,8 @@ contains
     integer :: adv_l1,adv_l2,adv_l3,adv_h1,adv_h2,adv_h3
     integer :: bc(3,2,*)
     integer :: domlo(3), domhi(3)
-    double precision :: delta(3), xlo(3), time
-    double precision :: adv(adv_l1:adv_h1,adv_l2:adv_h2,adv_l3:adv_h3)
+    real(rt)         :: delta(3), xlo(3), time
+    real(rt)         :: adv(adv_l1:adv_h1,adv_l2:adv_h2,adv_l3:adv_h3)
     logical rho_only
     integer :: i,j,k
 
@@ -258,12 +261,13 @@ contains
     use eos_module, only : gamma_const
     use meth_params_module, only : NVAR, URHO, UMX, UMY, UMZ, UEDEN, UEINT
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
-    double precision :: u_int(*),u_ext(*)
+    real(rt)         :: u_int(*),u_ext(*)
     logical rho_only
     integer :: dir,sgn
-    double precision :: rho, rhou(3), eden, T, Y
+    real(rt)         :: rho, rhou(3), eden, T, Y
     integer :: n,t1,t2,i
 
     ! for the Sedov problem, we will always set the state to the ambient conditions
@@ -283,10 +287,10 @@ contains
        enddo
 
        u_ext(URHO)   = dens_ambient
-       u_ext(UMX)    = 0.d0
-       u_ext(UMY)    = 0.d0
-       u_ext(UMZ)    = 0.d0
-       u_ext(UEDEN)  = p_ambient/(gamma_const-1.d0)
+       u_ext(UMX)    = 0.e0_rt
+       u_ext(UMY)    = 0.e0_rt
+       u_ext(UMZ)    = 0.e0_rt
+       u_ext(UEDEN)  = p_ambient/(gamma_const-1.e0_rt)
        u_ext(UEINT)  = u_ext(UEDEN)
 
     endif

--- a/Exec/hydro_tests/Sedov/probdata.f90
+++ b/Exec/hydro_tests/Sedov/probdata.f90
@@ -1,8 +1,9 @@
 module probdata_module
 
 !     Sod variables
-      double precision, save ::  p_ambient, dens_ambient, exp_energy
-      double precision, save ::  r_init
+      use bl_fort_module, only : rt => c_real
+      real(rt)        , save ::  p_ambient, dens_ambient, exp_energy
+      real(rt)        , save ::  r_init
       integer         , save ::  nsub
 
 !     These help specify which specific problem

--- a/Exec/hydro_tests/Sod/Prob_1d.f90
+++ b/Exec/hydro_tests/Sod/Prob_1d.f90
@@ -6,12 +6,13 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
   use network
   use probdata_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer init, namlen
   integer name(namlen)
-  double precision problo(1), probhi(1)
-  double precision xn(nspec)
+  real(rt)         problo(1), probhi(1)
+  real(rt)         xn(nspec)
   
   integer untin,i
 
@@ -61,8 +62,8 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
   split(1) = frac*(problo(1)+probhi(1))
 
   !     compute the internal energy (erg/cc) for the left and right state
-  xn(:) = 0.0d0
-  xn(1) = 1.0d0
+  xn(:) = 0.0e0_rt
+  xn(1) = 1.0e0_rt
 
   if (use_Tinit) then
 
@@ -88,7 +89,7 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
 
      eos_state%rho = rho_l
      eos_state%p = p_l
-     eos_state%T = 100000.d0   ! initial guess
+     eos_state%T = 100000.e0_rt   ! initial guess
      eos_state%xn(:) = xn(:)
 
      call eos(eos_input_rp, eos_state)
@@ -98,7 +99,7 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
 
      eos_state%rho = rho_r
      eos_state%p = p_r
-     eos_state%T = 100000.d0   ! initial guess
+     eos_state%T = 100000.e0_rt   ! initial guess
      eos_state%xn(:) = xn(:)
 
      call eos(eos_input_rp, eos_state)
@@ -139,19 +140,20 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
   use probdata_module
   use meth_params_module, only : NVAR, URHO, UMX, UEDEN, UEINT, UTEMP, UFS
 
+  use bl_fort_module, only : rt => c_real
   implicit none
   integer level, nscal
   integer lo(1), hi(1)
   integer state_l1,state_h1
-  double precision state(state_l1:state_h1,NVAR)
-  double precision time, delta(1)
-  double precision xlo(1), xhi(1)
+  real(rt)         state(state_l1:state_h1,NVAR)
+  real(rt)         time, delta(1)
+  real(rt)         xlo(1), xhi(1)
   
-  double precision xcen
+  real(rt)         xcen
   integer i
 
   do i = lo(1), hi(1)
-     xcen = xlo(1) + delta(1)*(float(i-lo(1)) + 0.5d0)
+     xcen = xlo(1) + delta(1)*(float(i-lo(1)) + 0.5e0_rt)
      
      if (xcen <= split(1)) then
         state(i,URHO ) = rho_l
@@ -167,7 +169,7 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
         state(i,UTEMP) = T_r
      endif
 
-     state(i,UFS:UFS-1+nspec) = 0.0d0
+     state(i,UFS:UFS-1+nspec) = 0.0e0_rt
      state(i,UFS  ) = state(i,URHO)
 
 

--- a/Exec/hydro_tests/Sod/Prob_2d.f90
+++ b/Exec/hydro_tests/Sod/Prob_2d.f90
@@ -6,12 +6,13 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
   use network
   use probdata_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer init, namlen
   integer name(namlen)
-  double precision problo(2), probhi(2)
-  double precision xn(nspec)
+  real(rt)         problo(2), probhi(2)
+  real(rt)         xn(nspec)
 
   integer untin,i
 
@@ -64,8 +65,8 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
   split(2) = frac*(problo(2)+probhi(2))
 
   !     compute the internal energy (erg/cc) for the left and right state
-  xn(:) = 0.0d0
-  xn(1) = 1.0d0
+  xn(:) = 0.0e0_rt
+  xn(1) = 1.0e0_rt
 
   if (use_Tinit) then
 
@@ -91,7 +92,7 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
 
      eos_state%rho = rho_l
      eos_state%p = p_l
-     eos_state%T = 100000.d0  ! initial guess
+     eos_state%T = 100000.e0_rt  ! initial guess
      eos_state%xn(:) = xn(:)
 
      call eos(eos_input_rp, eos_state)
@@ -101,7 +102,7 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
 
      eos_state%rho = rho_r
      eos_state%p = p_r
-     eos_state%T = 100000.d0  ! initial guess
+     eos_state%T = 100000.e0_rt  ! initial guess
      eos_state%xn(:) = xn(:)
 
      call eos(eos_input_rp, eos_state)
@@ -143,28 +144,29 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
   use probdata_module
   use meth_params_module, only : NVAR, URHO, UMX, UMY, UEDEN, UEINT, UTEMP, UFS
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer level, nscal
   integer lo(2), hi(2)
   integer state_l1,state_l2,state_h1,state_h2
-  double precision xlo(2), xhi(2), time, delta(2)
-  double precision state(state_l1:state_h1,state_l2:state_h2,NVAR)
+  real(rt)         xlo(2), xhi(2), time, delta(2)
+  real(rt)         state(state_l1:state_h1,state_l2:state_h2,NVAR)
 
-  double precision xcen,ycen
+  real(rt)         xcen,ycen
   integer i,j
 
   do j = lo(2), hi(2)
-     ycen = xlo(2) + delta(2)*(float(j-lo(2)) + 0.5d0)
+     ycen = xlo(2) + delta(2)*(float(j-lo(2)) + 0.5e0_rt)
      
      do i = lo(1), hi(1)
-        xcen = xlo(1) + delta(1)*(float(i-lo(1)) + 0.5d0)
+        xcen = xlo(1) + delta(1)*(float(i-lo(1)) + 0.5e0_rt)
         
         if (idir == 1) then
            if (xcen <= split(1)) then
               state(i,j,URHO) = rho_l
               state(i,j,UMX) = rho_l*u_l
-              state(i,j,UMY) = 0.d0
+              state(i,j,UMY) = 0.e0_rt
 
               state(i,j,UEDEN) = rhoe_l + 0.5*rho_l*u_l*u_l
               state(i,j,UEINT) = rhoe_l 
@@ -172,7 +174,7 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
            else
               state(i,j,URHO) = rho_r
               state(i,j,UMX) = rho_r*u_r
-              state(i,j,UMY) = 0.d0
+              state(i,j,UMY) = 0.e0_rt
 
               state(i,j,UEDEN) = rhoe_r + 0.5*rho_r*u_r*u_r
               state(i,j,UEINT) = rhoe_r 
@@ -182,7 +184,7 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
         else if (idir == 2) then
            if (ycen <= split(2)) then
               state(i,j,URHO) = rho_l
-              state(i,j,UMX) = 0.d0
+              state(i,j,UMX) = 0.e0_rt
               state(i,j,UMY) = rho_l*u_l
 
               state(i,j,UEDEN) = rhoe_l + 0.5*rho_l*u_l*u_l
@@ -190,7 +192,7 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
               state(i,j,UTEMP) = T_l
            else
               state(i,j,URHO) = rho_r
-              state(i,j,UMX) = 0.d0
+              state(i,j,UMX) = 0.e0_rt
               state(i,j,UMY) = rho_r*u_r
 
               state(i,j,UEDEN) = rhoe_r + 0.5*rho_r*u_r*u_r
@@ -202,7 +204,7 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
            call bl_abort('invalid idir')
         endif
 
-        state(i,j,UFS:UFS-1+nspec) = 0.0d0
+        state(i,j,UFS:UFS-1+nspec) = 0.0e0_rt
         state(i,j,UFS  ) = state(i,j,URHO)
         
      enddo

--- a/Exec/hydro_tests/Sod/Prob_3d.f90
+++ b/Exec/hydro_tests/Sod/Prob_3d.f90
@@ -6,12 +6,13 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
   use network
   use probdata_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer init, namlen
   integer name(namlen)
-  double precision problo(3), probhi(3)
-  double precision xn(nspec)
+  real(rt)         problo(3), probhi(3)
+  real(rt)         xn(nspec)
 
   integer untin,i
 
@@ -63,8 +64,8 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
   split(3) = frac*(problo(3)+probhi(3))
   
   ! compute the internal energy (erg/cc) for the left and right state
-  xn(:) = 0.0d0
-  xn(1) = 1.0d0
+  xn(:) = 0.0e0_rt
+  xn(1) = 1.0e0_rt
 
   if (use_Tinit) then
 
@@ -90,7 +91,7 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
 
      eos_state%rho = rho_l
      eos_state%p = p_l
-     eos_state%T = 100000.d0  ! initial guess
+     eos_state%T = 100000.e0_rt  ! initial guess
      eos_state%xn(:) = xn(:)
 
      call eos(eos_input_rp, eos_state)
@@ -100,7 +101,7 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
 
      eos_state%rho = rho_r
      eos_state%p = p_r
-     eos_state%T = 100000.d0  ! initial guess
+     eos_state%T = 100000.e0_rt  ! initial guess
      eos_state%xn(:) = xn(:)
 
      call eos(eos_input_rp, eos_state)
@@ -141,41 +142,42 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
   use network, only: nspec
   use probdata_module
   use meth_params_module, only : NVAR, URHO, UMX, UMY, UMZ, UEDEN, UEINT, UTEMP, UFS
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer level, nscal
   integer lo(3), hi(3)
   integer state_l1,state_l2,state_l3,state_h1,state_h2,state_h3
-  double precision xlo(3), xhi(3), time, delta(3)
-  double precision state(state_l1:state_h1,state_l2:state_h2, &
+  real(rt)         xlo(3), xhi(3), time, delta(3)
+  real(rt)         state(state_l1:state_h1,state_l2:state_h2, &
                          state_l3:state_h3,NVAR)
 
-  double precision xcen,ycen,zcen
+  real(rt)         xcen,ycen,zcen
   integer i,j,k
 
   do k = lo(3), hi(3)
-     zcen = xlo(3) + delta(3)*(float(k-lo(3)) + 0.5d0)
+     zcen = xlo(3) + delta(3)*(float(k-lo(3)) + 0.5e0_rt)
      
      do j = lo(2), hi(2)
-        ycen = xlo(2) + delta(2)*(float(j-lo(2)) + 0.5d0)
+        ycen = xlo(2) + delta(2)*(float(j-lo(2)) + 0.5e0_rt)
 
         do i = lo(1), hi(1)
-           xcen = xlo(1) + delta(1)*(float(i-lo(1)) + 0.5d0)
+           xcen = xlo(1) + delta(1)*(float(i-lo(1)) + 0.5e0_rt)
 
            if (idir == 1) then
               if (xcen <= split(1)) then
                  state(i,j,k,URHO) = rho_l
                  state(i,j,k,UMX) = rho_l*u_l
-                 state(i,j,k,UMY) = 0.d0
-                 state(i,j,k,UMZ) = 0.d0
+                 state(i,j,k,UMY) = 0.e0_rt
+                 state(i,j,k,UMZ) = 0.e0_rt
                  state(i,j,k,UEDEN) = rhoe_l + 0.5*rho_l*u_l*u_l
                  state(i,j,k,UEINT) = rhoe_l
                  state(i,j,k,UTEMP) = T_l
               else
                  state(i,j,k,URHO) = rho_r
                  state(i,j,k,UMX) = rho_r*u_r
-                 state(i,j,k,UMY) = 0.d0
-                 state(i,j,k,UMZ) = 0.d0
+                 state(i,j,k,UMY) = 0.e0_rt
+                 state(i,j,k,UMZ) = 0.e0_rt
                  state(i,j,k,UEDEN) = rhoe_r + 0.5*rho_r*u_r*u_r
                  state(i,j,k,UEINT) = rhoe_r
                  state(i,j,k,UTEMP) = T_r
@@ -184,17 +186,17 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
            else if (idir == 2) then
               if (ycen <= split(2)) then
                  state(i,j,k,URHO) = rho_l
-                 state(i,j,k,UMX) = 0.d0
+                 state(i,j,k,UMX) = 0.e0_rt
                  state(i,j,k,UMY) = rho_l*u_l
-                 state(i,j,k,UMZ) = 0.d0
+                 state(i,j,k,UMZ) = 0.e0_rt
                  state(i,j,k,UEDEN) = rhoe_l + 0.5*rho_l*u_l*u_l
                  state(i,j,k,UEINT) = rhoe_l
                  state(i,j,k,UTEMP) = T_l
               else
                  state(i,j,k,URHO) = rho_r
-                 state(i,j,k,UMX) = 0.d0
+                 state(i,j,k,UMX) = 0.e0_rt
                  state(i,j,k,UMY) = rho_r*u_r
-                 state(i,j,k,UMZ) = 0.d0
+                 state(i,j,k,UMZ) = 0.e0_rt
                  state(i,j,k,UEDEN) = rhoe_r + 0.5*rho_r*u_r*u_r
                  state(i,j,k,UEINT) = rhoe_r
                  state(i,j,k,UTEMP) = T_r
@@ -203,16 +205,16 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
            else if (idir == 3) then
               if (zcen <= split(3)) then
                  state(i,j,k,URHO) = rho_l
-                 state(i,j,k,UMX) = 0.d0
-                 state(i,j,k,UMY) = 0.d0
+                 state(i,j,k,UMX) = 0.e0_rt
+                 state(i,j,k,UMY) = 0.e0_rt
                  state(i,j,k,UMZ) = rho_l*u_l
                  state(i,j,k,UEDEN) = rhoe_l + 0.5*rho_l*u_l*u_l
                  state(i,j,k,UEINT) = rhoe_l
                  state(i,j,k,UTEMP) = T_l
               else
                  state(i,j,k,URHO) = rho_r
-                 state(i,j,k,UMX) = 0.d0
-                 state(i,j,k,UMY) = 0.d0
+                 state(i,j,k,UMX) = 0.e0_rt
+                 state(i,j,k,UMY) = 0.e0_rt
                  state(i,j,k,UMZ) = rho_r*u_r
                  state(i,j,k,UEDEN) = rhoe_r + 0.5*rho_r*u_r*u_r
                  state(i,j,k,UEINT) = rhoe_r
@@ -223,7 +225,7 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
               call bl_abort('invalid idir')
            endif
  
-           state(i,j,k,UFS:UFS-1+nspec) = 0.0d0
+           state(i,j,k,UFS:UFS-1+nspec) = 0.0e0_rt
            state(i,j,k,UFS  ) = state(i,j,k,URHO)
 
            

--- a/Exec/hydro_tests/Sod/probdata.f90
+++ b/Exec/hydro_tests/Sod/probdata.f90
@@ -1,14 +1,15 @@
 module probdata_module
 
 !     Sod variables
-      double precision, save ::  p_l, u_l, rho_l, p_r, u_r, rho_r, rhoe_l, rhoe_r, frac
-      double precision, save :: T_l, T_r
+      use bl_fort_module, only : rt => c_real
+      real(rt)        , save ::  p_l, u_l, rho_l, p_r, u_r, rho_r, rhoe_l, rhoe_r, frac
+      real(rt)        , save :: T_l, T_r
 
       logical, save :: use_Tinit
 
 !     These help specify which specific problem
       integer        , save ::  probtype,idir
 
-      double precision, save :: split(3)
+      real(rt)        , save :: split(3)
       
 end module probdata_module

--- a/Exec/hydro_tests/Sod_stellar/Prob_1d.f90
+++ b/Exec/hydro_tests/Sod_stellar/Prob_1d.f90
@@ -6,12 +6,13 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
   use network
   use probdata_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer init, namlen
   integer name(namlen)
-  double precision problo(1), probhi(1)
-  double precision xn(nspec)
+  real(rt)         problo(1), probhi(1)
+  real(rt)         xn(nspec)
   
   integer untin,i
 
@@ -61,8 +62,8 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
   split(1) = frac*(problo(1)+probhi(1))
 
   !     compute the internal energy (erg/cc) for the left and right state
-  xn(:) = 0.0d0
-  xn(1) = 1.0d0
+  xn(:) = 0.0e0_rt
+  xn(1) = 1.0e0_rt
 
   if (use_Tinit) then
 
@@ -88,7 +89,7 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
 
      eos_state%rho = rho_l
      eos_state%p = p_l
-     eos_state%T = 100000.d0   ! initial guess
+     eos_state%T = 100000.e0_rt   ! initial guess
      eos_state%xn(:) = xn(:)
 
      call eos(eos_input_rp, eos_state, .false.)
@@ -98,7 +99,7 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
 
      eos_state%rho = rho_r
      eos_state%p = p_r
-     eos_state%T = 100000.d0   ! initial guess
+     eos_state%T = 100000.e0_rt   ! initial guess
      eos_state%xn(:) = xn(:)
 
      call eos(eos_input_rp, eos_state, .false.)
@@ -139,19 +140,20 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
   use probdata_module
   use meth_params_module, only : NVAR, URHO, UMX, UEDEN, UEINT, UTEMP, UFS
 
+  use bl_fort_module, only : rt => c_real
   implicit none
   integer level, nscal
   integer lo(1), hi(1)
   integer state_l1,state_h1
-  double precision state(state_l1:state_h1,NVAR)
-  double precision time, delta(1)
-  double precision xlo(1), xhi(1)
+  real(rt)         state(state_l1:state_h1,NVAR)
+  real(rt)         time, delta(1)
+  real(rt)         xlo(1), xhi(1)
   
-  double precision xcen
+  real(rt)         xcen
   integer i
 
   do i = lo(1), hi(1)
-     xcen = xlo(1) + delta(1)*(float(i-lo(1)) + 0.5d0)
+     xcen = xlo(1) + delta(1)*(float(i-lo(1)) + 0.5e0_rt)
      
      if (xcen <= split(1)) then
         state(i,URHO ) = rho_l
@@ -167,7 +169,7 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
         state(i,UTEMP) = T_r
      endif
 
-     state(i,UFS:UFS-1+nspec) = 0.0d0
+     state(i,UFS:UFS-1+nspec) = 0.0e0_rt
      state(i,UFS  ) = state(i,URHO)
 
 

--- a/Exec/hydro_tests/Sod_stellar/Prob_2d.f90
+++ b/Exec/hydro_tests/Sod_stellar/Prob_2d.f90
@@ -6,12 +6,13 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
   use network
   use probdata_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer init, namlen
   integer name(namlen)
-  double precision problo(2), probhi(2)
-  double precision xn(nspec)
+  real(rt)         problo(2), probhi(2)
+  real(rt)         xn(nspec)
 
   integer untin,i
 
@@ -64,8 +65,8 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
   split(2) = frac*(problo(2)+probhi(2))
 
   !     compute the internal energy (erg/cc) for the left and right state
-  xn(:) = 0.0d0
-  xn(1) = 1.0d0
+  xn(:) = 0.0e0_rt
+  xn(1) = 1.0e0_rt
 
   if (use_Tinit) then
 
@@ -91,7 +92,7 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
 
      eos_state%rho = rho_l
      eos_state%p = p_l
-     eos_state%T = 100000.d0  ! initial guess
+     eos_state%T = 100000.e0_rt  ! initial guess
      eos_state%xn(:) = xn(:)
 
      call eos(eos_input_rp, eos_state)
@@ -101,7 +102,7 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
 
      eos_state%rho = rho_r
      eos_state%p = p_r
-     eos_state%T = 100000.d0  ! initial guess
+     eos_state%T = 100000.e0_rt  ! initial guess
      eos_state%xn(:) = xn(:)
 
      call eos(eos_input_rp, eos_state)
@@ -143,28 +144,29 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
   use probdata_module
   use meth_params_module, only : NVAR, URHO, UMX, UMY, UEDEN, UEINT, UTEMP, UFS
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer level, nscal
   integer lo(2), hi(2)
   integer state_l1,state_l2,state_h1,state_h2
-  double precision xlo(2), xhi(2), time, delta(2)
-  double precision state(state_l1:state_h1,state_l2:state_h2,NVAR)
+  real(rt)         xlo(2), xhi(2), time, delta(2)
+  real(rt)         state(state_l1:state_h1,state_l2:state_h2,NVAR)
 
-  double precision xcen,ycen
+  real(rt)         xcen,ycen
   integer i,j
 
   do j = lo(2), hi(2)
-     ycen = xlo(2) + delta(2)*(float(j-lo(2)) + 0.5d0)
+     ycen = xlo(2) + delta(2)*(float(j-lo(2)) + 0.5e0_rt)
      
      do i = lo(1), hi(1)
-        xcen = xlo(1) + delta(1)*(float(i-lo(1)) + 0.5d0)
+        xcen = xlo(1) + delta(1)*(float(i-lo(1)) + 0.5e0_rt)
         
         if (idir == 1) then
            if (xcen <= split(1)) then
               state(i,j,URHO) = rho_l
               state(i,j,UMX) = rho_l*u_l
-              state(i,j,UMY) = 0.d0
+              state(i,j,UMY) = 0.e0_rt
 
               state(i,j,UEDEN) = rhoe_l + 0.5*rho_l*u_l*u_l
               state(i,j,UEINT) = rhoe_l 
@@ -172,7 +174,7 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
            else
               state(i,j,URHO) = rho_r
               state(i,j,UMX) = rho_r*u_r
-              state(i,j,UMY) = 0.d0
+              state(i,j,UMY) = 0.e0_rt
 
               state(i,j,UEDEN) = rhoe_r + 0.5*rho_r*u_r*u_r
               state(i,j,UEINT) = rhoe_r 
@@ -182,7 +184,7 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
         else if (idir == 2) then
            if (ycen <= split(2)) then
               state(i,j,URHO) = rho_l
-              state(i,j,UMX) = 0.d0
+              state(i,j,UMX) = 0.e0_rt
               state(i,j,UMY) = rho_l*u_l
 
               state(i,j,UEDEN) = rhoe_l + 0.5*rho_l*u_l*u_l
@@ -190,7 +192,7 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
               state(i,j,UTEMP) = T_l
            else
               state(i,j,URHO) = rho_r
-              state(i,j,UMX) = 0.d0
+              state(i,j,UMX) = 0.e0_rt
               state(i,j,UMY) = rho_r*u_r
 
               state(i,j,UEDEN) = rhoe_r + 0.5*rho_r*u_r*u_r
@@ -202,7 +204,7 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
            call bl_abort('invalid idir')
         endif
 
-        state(i,j,UFS:UFS-1+nspec) = 0.0d0
+        state(i,j,UFS:UFS-1+nspec) = 0.0e0_rt
         state(i,j,UFS  ) = state(i,j,URHO)
         
      enddo

--- a/Exec/hydro_tests/Sod_stellar/Prob_3d.f90
+++ b/Exec/hydro_tests/Sod_stellar/Prob_3d.f90
@@ -6,12 +6,13 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
   use network
   use probdata_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer init, namlen
   integer name(namlen)
-  double precision problo(3), probhi(3)
-  double precision xn(nspec)
+  real(rt)         problo(3), probhi(3)
+  real(rt)         xn(nspec)
 
   integer untin,i
 
@@ -63,8 +64,8 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
   split(3) = frac*(problo(3)+probhi(3))
   
   ! compute the internal energy (erg/cc) for the left and right state
-  xn(:) = 0.0d0
-  xn(1) = 1.0d0
+  xn(:) = 0.0e0_rt
+  xn(1) = 1.0e0_rt
 
   if (use_Tinit) then
 
@@ -90,7 +91,7 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
 
      eos_state%rho = rho_l
      eos_state%p = p_l
-     eos_state%T = 100000.d0  ! initial guess
+     eos_state%T = 100000.e0_rt  ! initial guess
      eos_state%xn(:) = xn(:)
 
      call eos(eos_input_rp, eos_state, .false.)
@@ -100,7 +101,7 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
 
      eos_state%rho = rho_r
      eos_state%p = p_r
-     eos_state%T = 100000.d0  ! initial guess
+     eos_state%T = 100000.e0_rt  ! initial guess
      eos_state%xn(:) = xn(:)
 
      call eos(eos_input_rp, eos_state, .false.)
@@ -141,41 +142,42 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
   use network, only: nspec
   use probdata_module
   use meth_params_module, only : NVAR, URHO, UMX, UMY, UMZ, UEDEN, UEINT, UTEMP, UFS
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer level, nscal
   integer lo(3), hi(3)
   integer state_l1,state_l2,state_l3,state_h1,state_h2,state_h3
-  double precision xlo(3), xhi(3), time, delta(3)
-  double precision state(state_l1:state_h1,state_l2:state_h2, &
+  real(rt)         xlo(3), xhi(3), time, delta(3)
+  real(rt)         state(state_l1:state_h1,state_l2:state_h2, &
                          state_l3:state_h3,NVAR)
 
-  double precision xcen,ycen,zcen
+  real(rt)         xcen,ycen,zcen
   integer i,j,k
 
   do k = lo(3), hi(3)
-     zcen = xlo(3) + delta(3)*(float(k-lo(3)) + 0.5d0)
+     zcen = xlo(3) + delta(3)*(float(k-lo(3)) + 0.5e0_rt)
      
      do j = lo(2), hi(2)
-        ycen = xlo(2) + delta(2)*(float(j-lo(2)) + 0.5d0)
+        ycen = xlo(2) + delta(2)*(float(j-lo(2)) + 0.5e0_rt)
 
         do i = lo(1), hi(1)
-           xcen = xlo(1) + delta(1)*(float(i-lo(1)) + 0.5d0)
+           xcen = xlo(1) + delta(1)*(float(i-lo(1)) + 0.5e0_rt)
 
            if (idir == 1) then
               if (xcen <= split(1)) then
                  state(i,j,k,URHO) = rho_l
                  state(i,j,k,UMX) = rho_l*u_l
-                 state(i,j,k,UMY) = 0.d0
-                 state(i,j,k,UMZ) = 0.d0
+                 state(i,j,k,UMY) = 0.e0_rt
+                 state(i,j,k,UMZ) = 0.e0_rt
                  state(i,j,k,UEDEN) = rhoe_l + 0.5*rho_l*u_l*u_l
                  state(i,j,k,UEINT) = rhoe_l
                  state(i,j,k,UTEMP) = T_l
               else
                  state(i,j,k,URHO) = rho_r
                  state(i,j,k,UMX) = rho_r*u_r
-                 state(i,j,k,UMY) = 0.d0
-                 state(i,j,k,UMZ) = 0.d0
+                 state(i,j,k,UMY) = 0.e0_rt
+                 state(i,j,k,UMZ) = 0.e0_rt
                  state(i,j,k,UEDEN) = rhoe_r + 0.5*rho_r*u_r*u_r
                  state(i,j,k,UEINT) = rhoe_r
                  state(i,j,k,UTEMP) = T_r
@@ -184,17 +186,17 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
            else if (idir == 2) then
               if (ycen <= split(2)) then
                  state(i,j,k,URHO) = rho_l
-                 state(i,j,k,UMX) = 0.d0
+                 state(i,j,k,UMX) = 0.e0_rt
                  state(i,j,k,UMY) = rho_l*u_l
-                 state(i,j,k,UMZ) = 0.d0
+                 state(i,j,k,UMZ) = 0.e0_rt
                  state(i,j,k,UEDEN) = rhoe_l + 0.5*rho_l*u_l*u_l
                  state(i,j,k,UEINT) = rhoe_l
                  state(i,j,k,UTEMP) = T_l
               else
                  state(i,j,k,URHO) = rho_r
-                 state(i,j,k,UMX) = 0.d0
+                 state(i,j,k,UMX) = 0.e0_rt
                  state(i,j,k,UMY) = rho_r*u_r
-                 state(i,j,k,UMZ) = 0.d0
+                 state(i,j,k,UMZ) = 0.e0_rt
                  state(i,j,k,UEDEN) = rhoe_r + 0.5*rho_r*u_r*u_r
                  state(i,j,k,UEINT) = rhoe_r
                  state(i,j,k,UTEMP) = T_r
@@ -203,16 +205,16 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
            else if (idir == 3) then
               if (zcen <= split(3)) then
                  state(i,j,k,URHO) = rho_l
-                 state(i,j,k,UMX) = 0.d0
-                 state(i,j,k,UMY) = 0.d0
+                 state(i,j,k,UMX) = 0.e0_rt
+                 state(i,j,k,UMY) = 0.e0_rt
                  state(i,j,k,UMZ) = rho_l*u_l
                  state(i,j,k,UEDEN) = rhoe_l + 0.5*rho_l*u_l*u_l
                  state(i,j,k,UEINT) = rhoe_l
                  state(i,j,k,UTEMP) = T_l
               else
                  state(i,j,k,URHO) = rho_r
-                 state(i,j,k,UMX) = 0.d0
-                 state(i,j,k,UMY) = 0.d0
+                 state(i,j,k,UMX) = 0.e0_rt
+                 state(i,j,k,UMY) = 0.e0_rt
                  state(i,j,k,UMZ) = rho_r*u_r
                  state(i,j,k,UEDEN) = rhoe_r + 0.5*rho_r*u_r*u_r
                  state(i,j,k,UEINT) = rhoe_r
@@ -223,7 +225,7 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
               call bl_abort('invalid idir')
            endif
  
-           state(i,j,k,UFS:UFS-1+nspec) = 0.0d0
+           state(i,j,k,UFS:UFS-1+nspec) = 0.0e0_rt
            state(i,j,k,UFS  ) = state(i,j,k,URHO)
 
            

--- a/Exec/hydro_tests/Sod_stellar/probdata.f90
+++ b/Exec/hydro_tests/Sod_stellar/probdata.f90
@@ -1,15 +1,16 @@
 module probdata_module
 
 !     Sod variables
-      double precision, save ::  p_l, u_l, rho_l, p_r, u_r, rho_r, rhoe_l, rhoe_r, frac
-      double precision, save :: T_l, T_r
+      use bl_fort_module, only : rt => c_real
+      real(rt)        , save ::  p_l, u_l, rho_l, p_r, u_r, rho_r, rhoe_l, rhoe_r, frac
+      real(rt)        , save :: T_l, T_r
 
       logical, save :: use_Tinit
 
 !     These help specify which specific problem
       integer        , save ::  probtype,idir
 
-      double precision, save ::  split(3)
+      real(rt)        , save ::  split(3)
 
       
 end module probdata_module

--- a/Exec/hydro_tests/Sod_stellar/trace_ppm_2d.f90
+++ b/Exec/hydro_tests/Sod_stellar/trace_ppm_2d.f90
@@ -1,5 +1,6 @@
 module trace_ppm_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   private
@@ -28,6 +29,7 @@ contains
          npassive, qpass_map
     use ppm_module, only : ppm
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer ilo1,ilo2,ihi1,ihi2
@@ -37,66 +39,66 @@ contains
     integer src_l1,src_l2,src_h1,src_h2
     integer gc_l1,gc_l2,gc_h1,gc_h2
 
-    double precision     q(qd_l1:qd_h1,qd_l2:qd_h2,QVAR)
-    double precision     c(qd_l1:qd_h1,qd_l2:qd_h2)
-    double precision flatn(qd_l1:qd_h1,qd_l2:qd_h2)
-    double precision dloga(dloga_l1:dloga_h1,dloga_l2:dloga_h2)
+    real(rt)             q(qd_l1:qd_h1,qd_l2:qd_h2,QVAR)
+    real(rt)             c(qd_l1:qd_h1,qd_l2:qd_h2)
+    real(rt)         flatn(qd_l1:qd_h1,qd_l2:qd_h2)
+    real(rt)         dloga(dloga_l1:dloga_h1,dloga_l2:dloga_h2)
 
-    double precision qxm(qpd_l1:qpd_h1,qpd_l2:qpd_h2,QVAR)
-    double precision qxp(qpd_l1:qpd_h1,qpd_l2:qpd_h2,QVAR)
-    double precision qym(qpd_l1:qpd_h1,qpd_l2:qpd_h2,QVAR)
-    double precision qyp(qpd_l1:qpd_h1,qpd_l2:qpd_h2,QVAR)
+    real(rt)         qxm(qpd_l1:qpd_h1,qpd_l2:qpd_h2,QVAR)
+    real(rt)         qxp(qpd_l1:qpd_h1,qpd_l2:qpd_h2,QVAR)
+    real(rt)         qym(qpd_l1:qpd_h1,qpd_l2:qpd_h2,QVAR)
+    real(rt)         qyp(qpd_l1:qpd_h1,qpd_l2:qpd_h2,QVAR)
 
-    double precision srcQ(src_l1:src_h1,src_l2:src_h2,QVAR)
-    double precision gamc(gc_l1:gc_h1,gc_l2:gc_h2)
+    real(rt)         srcQ(src_l1:src_h1,src_l2:src_h2,QVAR)
+    real(rt)         gamc(gc_l1:gc_h1,gc_l2:gc_h2)
 
-    double precision dx, dy, dt
+    real(rt)         dx, dy, dt
 
     ! Local variables
     integer          :: i, j, iwave, idim
     integer          :: n, ipassive
 
-    double precision :: dtdx, dtdy
-    double precision :: cc, csq, Clag, rho, u, v, p, rhoe_g, enth, temp
-    double precision :: drho, dptot, drhoe_g, dT0, dtau
-    double precision :: dup, dvp, du, dptotp, dTp, dtaup
-    double precision :: dum, dvm, dv, dptotm, dTm, dtaum
+    real(rt)         :: dtdx, dtdy
+    real(rt)         :: cc, csq, Clag, rho, u, v, p, rhoe_g, enth, temp
+    real(rt)         :: drho, dptot, drhoe_g, dT0, dtau
+    real(rt)         :: dup, dvp, du, dptotp, dTp, dtaup
+    real(rt)         :: dum, dvm, dv, dptotm, dTm, dtaum
 
-    double precision :: rho_ref, u_ref, v_ref, p_ref, rhoe_g_ref, temp_ref, tau_ref
-    double precision :: tau_s, e_s, de, dge
+    real(rt)         :: rho_ref, u_ref, v_ref, p_ref, rhoe_g_ref, temp_ref, tau_ref
+    real(rt)         :: tau_s, e_s, de, dge
 
-    double precision :: cc_ref, csq_ref, Clag_ref, enth_ref, gam_ref, game_ref, gfactor
-    double precision :: cc_ev, csq_ev, Clag_ev, rho_ev, p_ev, enth_ev, temp_ev, tau_ev
-    double precision :: gam, game
-    double precision :: p_r, p_T
+    real(rt)         :: cc_ref, csq_ref, Clag_ref, enth_ref, gam_ref, game_ref, gfactor
+    real(rt)         :: cc_ev, csq_ev, Clag_ev, rho_ev, p_ev, enth_ev, temp_ev, tau_ev
+    real(rt)         :: gam, game
+    real(rt)         :: p_r, p_T
 
-    double precision :: alpham, alphap, alpha0r, alpha0e
-    double precision :: apright, amright, azrright, azeright
-    double precision :: azu1rght, azv1rght
-    double precision :: apleft, amleft, azrleft, azeleft
-    double precision :: azu1left, azv1left
-    double precision :: sourcr,sourcp,source,courn,eta,dlogatmp
+    real(rt)         :: alpham, alphap, alpha0r, alpha0e
+    real(rt)         :: apright, amright, azrright, azeright
+    real(rt)         :: azu1rght, azv1rght
+    real(rt)         :: apleft, amleft, azrleft, azeleft
+    real(rt)         :: azu1left, azv1left
+    real(rt)         :: sourcr,sourcp,source,courn,eta,dlogatmp
 
-    double precision :: halfdt
+    real(rt)         :: halfdt
 
     integer, parameter :: isx = 1
     integer, parameter :: isy = 2
 
-    double precision, allocatable :: Ip(:,:,:,:,:)
-    double precision, allocatable :: Im(:,:,:,:,:)
+    real(rt)        , allocatable :: Ip(:,:,:,:,:)
+    real(rt)        , allocatable :: Im(:,:,:,:,:)
 
-    double precision, allocatable :: Ip_src(:,:,:,:,:)
-    double precision, allocatable :: Im_src(:,:,:,:,:)
+    real(rt)        , allocatable :: Ip_src(:,:,:,:,:)
+    real(rt)        , allocatable :: Im_src(:,:,:,:,:)
 
     ! gamma_c/1 on the interfaces
-    double precision, allocatable :: Ip_gc(:,:,:,:,:)
-    double precision, allocatable :: Im_gc(:,:,:,:,:)
+    real(rt)        , allocatable :: Ip_gc(:,:,:,:,:)
+    real(rt)        , allocatable :: Im_gc(:,:,:,:,:)
 
-    double precision, allocatable :: tau(:,:)
-    double precision, allocatable :: Ip_tau(:,:,:,:,:)
-    double precision, allocatable :: Im_tau(:,:,:,:,:)
+    real(rt)        , allocatable :: tau(:,:)
+    real(rt)        , allocatable :: Ip_tau(:,:,:,:,:)
+    real(rt)        , allocatable :: Im_tau(:,:,:,:,:)
 
-    double precision :: eval(3), beta(3), rvec(3,3), lvec(3,3), dq(3)
+    real(rt)         :: eval(3), beta(3), rvec(3,3), lvec(3,3), dq(3)
 
     type (eos_t) :: eos_state
 

--- a/Exec/hydro_tests/Vortices_LWAcoustics/Prob_2d.f90
+++ b/Exec/hydro_tests/Vortices_LWAcoustics/Prob_2d.f90
@@ -5,11 +5,12 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
   use probdata_module
   use eos_module, only : gamma_const
 
+  use bl_fort_module, only : rt => c_real
   implicit none
   
   integer init, namlen
   integer name(namlen)
-  double precision problo(2), probhi(2)
+  real(rt)         problo(2), probhi(2)
   
   integer untin,i
 
@@ -30,19 +31,19 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
   ! These values are based on Lee & Koo, 1995 AIAA Journal, Figure 6
 
   ! Define reference pressure
-  p_ref = 1.0d0
+  p_ref = 1.0e0_rt
 
   ! Define r_0
-  r_0   = 0.25d0
+  r_0   = 0.25e0_rt
 
   ! Define rotating mach
-  mach  = 0.0796d0
+  mach  = 0.0796e0_rt
 
   ! Define ratio_c = r_c/r_0
-  ratio_c = 0.15d0
+  ratio_c = 0.15e0_rt
 
   ! Define r_circ = circ/r_0*c_0
-  r_circ  = 1.0d0
+  r_circ  = 1.0e0_rt
 
   ! Read namelists
   untin = 9
@@ -51,7 +52,7 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
   close(unit=untin)
 
   ! Define rho_0
-  rho_0 = p_ref**(1d0/gamma_const)
+  rho_0 = p_ref**(1e0_rt/gamma_const)
 
   ! Define c_0
   c_0   = sqrt(gamma_const*p_ref/rho_0)
@@ -60,7 +61,7 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
   r_c   = ratio_c*r_0
 
   ! Define circ
-  circ  = r_circ*r_0*c_0 !4d0*M_PI*r_0*c_0*mach
+  circ  = r_circ*r_0*c_0 !4e0_rt*M_PI*r_0*c_0*mach
  
   ! Center of first vortex
   x_c1  = HALF*probhi(1)
@@ -102,17 +103,18 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
   use eos_module, only : gamma_const
   use meth_params_module, only : NVAR, URHO, UMX, UMY, UEDEN, UEINT, UFS
   
+  use bl_fort_module, only : rt => c_real
   implicit none
   
   integer level, nscal
   integer lo(2), hi(2)
   integer state_l1,state_l2,state_h1,state_h2
-  double precision xlo(2), xhi(2), time, delta(2)
-  double precision state(state_l1:state_h1,state_l2:state_h2,NVAR)
+  real(rt)         xlo(2), xhi(2), time, delta(2)
+  real(rt)         state(state_l1:state_h1,state_l2:state_h2,NVAR)
   
-  double precision rho, u,v
-  double precision x, y, r_1, r_2, vel_theta_1, vel_theta_2
-  double precision cos_theta_1, sin_theta_1, cos_theta_2, sin_theta_2
+  real(rt)         rho, u,v
+  real(rt)         x, y, r_1, r_2, vel_theta_1, vel_theta_2
+  real(rt)         cos_theta_1, sin_theta_1, cos_theta_2, sin_theta_2
   integer i,j
   
   
@@ -128,8 +130,8 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
         r_1 = sqrt( (x-x_c1)**2 + (y-y_c1)**2 )
         r_2 = sqrt( (x-x_c2)**2 + (y-y_c2)**2 )
 
-        vel_theta_1 = circ * r_1 / ( 2d0 * M_PI * (r_c**2 + r_1**2) )
-        vel_theta_2 = circ * r_2 / ( 2d0 * M_PI * (r_c**2 + r_2**2) )
+        vel_theta_1 = circ * r_1 / ( 2e0_rt * M_PI * (r_c**2 + r_1**2) )
+        vel_theta_2 = circ * r_2 / ( 2e0_rt * M_PI * (r_c**2 + r_2**2) )
 
         sin_theta_1 = (y-y_c1) / r_1
         cos_theta_1 = (x-x_c1) / r_1
@@ -141,7 +143,7 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
         v = - vel_theta_1 * cos_theta_1 - vel_theta_2 * cos_theta_2
 
         ! single species for all zones
-        state(i,j,UFS) = 1.0d0
+        state(i,j,UFS) = 1.0e0_rt
            
         ! momentum field
         state(i,j,UMX) = rho * u
@@ -151,7 +153,7 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
         state(i,j,URHO) = rho
        
         ! internal energy
-        state(i,j,UEINT) = p_ref / (gamma_const - 1.d0)
+        state(i,j,UEINT) = p_ref / (gamma_const - 1.e0_rt)
         
         ! Total energy
         state(i,j,UEDEN) = state(i,j,UEINT) + HALF * &

--- a/Exec/hydro_tests/Vortices_LWAcoustics/probdata.f90
+++ b/Exec/hydro_tests/Vortices_LWAcoustics/probdata.f90
@@ -1,8 +1,9 @@
 module probdata_module
 
 !     variables for initialization; see Lee & Koo AIAA Journal 1995
-      double precision, save :: p_ref, r_0, mach, ratio_c, r_circ 
-      double precision, save :: rho_0, c_0, r_c, circ
-      double precision, save :: x_c1, y_c1, x_c2, y_c2 
+      use bl_fort_module, only : rt => c_real
+      real(rt)        , save :: p_ref, r_0, mach, ratio_c, r_circ 
+      real(rt)        , save :: rho_0, c_0, r_c, circ
+      real(rt)        , save :: x_c1, y_c1, x_c2, y_c2 
  
 end module probdata_module

--- a/Exec/hydro_tests/double_bubble/Prob_2d.f90
+++ b/Exec/hydro_tests/double_bubble/Prob_2d.f90
@@ -4,11 +4,12 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
   use probdata_module
   use bl_error_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer init, namlen
   integer name(namlen)
-  double precision problo(2), probhi(2)
+  real(rt)         problo(2), probhi(2)
 
   integer untin,i
 
@@ -35,8 +36,8 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
 
 
   ! model composition
-  xn_model(:) = 0.0d0
-  xn_model(1) = 1.0d0
+  xn_model(:) = 0.0e0_rt
+  xn_model(1) = 1.0e0_rt
 
   ! Read namelists
   untin = 9
@@ -45,17 +46,17 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
   close(unit=untin)
 
   ! set local variable defaults
-  center(1) = 0.5d0*(problo(1)+probhi(1))
-  center(2) = 0.5d0*(problo(2)+probhi(2))
+  center(1) = 0.5e0_rt*(problo(1)+probhi(1))
+  center(2) = 0.5e0_rt*(problo(2)+probhi(2))
 
   ymin = problo(2)
   ymax = probhi(2)
 
   if (single) then
-     left_bubble_x_center = problo(1) + 0.5d0*(probhi(1)-problo(1))
+     left_bubble_x_center = problo(1) + 0.5e0_rt*(probhi(1)-problo(1))
   else
-     left_bubble_x_center = problo(1) + (probhi(1)-problo(1))/3.d0
-     right_bubble_x_center = problo(1) + 2.d0*(probhi(1)-problo(1))/3.d0
+     left_bubble_x_center = problo(1) + (probhi(1)-problo(1))/3.e0_rt
+     right_bubble_x_center = problo(1) + 2.e0_rt*(probhi(1)-problo(1))/3.e0_rt
   endif
 
 end subroutine PROBINIT
@@ -95,18 +96,19 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
 
   use model_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer level, nscal
   integer lo(2), hi(2)
   integer state_l1,state_l2,state_h1,state_h2
-  double precision xlo(2), xhi(2), time, delta(2)
-  double precision state(state_l1:state_h1,state_l2:state_h2,NVAR)
+  real(rt)         xlo(2), xhi(2), time, delta(2)
+  real(rt)         state(state_l1:state_h1,state_l2:state_h2,NVAR)
 
   integer i,j,npts_1d
-  double precision z,xn(nspec),x,y,x1,y1,x2,y2,r1,r2,const
+  real(rt)         z,xn(nspec),x,y,x1,y1,x2,y2,r1,r2,const
 
-  double precision, allocatable :: r_model(:), rho_model(:), T_model(:), &
+  real(rt)        , allocatable :: r_model(:), rho_model(:), T_model(:), &
                                    e_model(:), p_model(:)
 
   integer :: lo_model, hi_model
@@ -137,10 +139,10 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
      y2 = y_pert_center
 
      do j=lo(2),hi(2)
-        y = (dble(j)+0.5d0)*delta(2) + ymin
+        y = (dble(j)+0.5e0_rt)*delta(2) + ymin
 
         do i=lo(1),hi(1)
-           x = (dble(i)+0.5d0)*delta(1)
+           x = (dble(i)+0.5e0_rt)*delta(1)
 
            r1 = sqrt( (x-x1)**2 +(y-y1)**2 ) / pert_width
            r2 = sqrt( (x-x2)**2 +(y-y2)**2 ) / pert_width
@@ -151,16 +153,16 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
 
            ! which bubble are we in? -- we want their rho perturbations to be the
            ! same so they have the same buoyancy
-           if (r1 < 2.0d0) then
-              state(i,j,URHO) = rho_model(j) * (1.d0 - (pert_factor * (1.d0 + tanh(2.d0-r1))))
-              eos_state % xn(:) = 0.0d0
-              eos_state % xn(2) = 1.0d0
+           if (r1 < 2.0e0_rt) then
+              state(i,j,URHO) = rho_model(j) * (1.e0_rt - (pert_factor * (1.e0_rt + tanh(2.e0_rt-r1))))
+              eos_state % xn(:) = 0.0e0_rt
+              eos_state % xn(2) = 1.0e0_rt
            endif
 
-           if (r2 < 2.0d0) then
-              state(i,j,URHO) = rho_model(j) * (1.d0 - (pert_factor * (1.d0 + tanh(2.d0-r2))))
-              eos_state % xn(:) = 0.0d0
-              eos_state % xn(3) = 1.0d0
+           if (r2 < 2.0e0_rt) then
+              state(i,j,URHO) = rho_model(j) * (1.e0_rt - (pert_factor * (1.e0_rt + tanh(2.e0_rt-r2))))
+              eos_state % xn(:) = 0.0e0_rt
+              eos_state % xn(3) = 1.0e0_rt
            endif
 
            eos_state % p = p_model(j)
@@ -179,7 +181,7 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
            ! assumes ke=0
            state(i,j,UEDEN) = state(i,j,UEINT)
 
-           state(i,j,UMX:UMY) = 0.d0
+           state(i,j,UMX:UMY) = 0.e0_rt
 
         end do
      end do
@@ -190,10 +192,10 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
      y1 = y_pert_center
 
      do j=lo(2),hi(2)
-        y = (dble(j)+0.5d0)*delta(2) + ymin
+        y = (dble(j)+0.5e0_rt)*delta(2) + ymin
 
         do i=lo(1),hi(1)
-           x = (dble(i)+0.5d0)*delta(1)
+           x = (dble(i)+0.5e0_rt)*delta(1)
 
            r1 = sqrt( (x-x1)**2 +(y-y1)**2 ) / pert_width
 
@@ -203,10 +205,10 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
 
            ! which bubble are we in? -- we want their rho perturbations to be the
            ! same so they have the same buoyancy
-           if (r1 < 2.0d0) then
-              state(i,j,URHO) = rho_model(j) * (1.d0 - (pert_factor * (1.d0 + tanh(2.d0-r1))))
-              eos_state % xn(:) = 0.0d0
-              eos_state % xn(2) = 1.0d0
+           if (r1 < 2.0e0_rt) then
+              state(i,j,URHO) = rho_model(j) * (1.e0_rt - (pert_factor * (1.e0_rt + tanh(2.e0_rt-r1))))
+              eos_state % xn(:) = 0.0e0_rt
+              eos_state % xn(2) = 1.0e0_rt
            endif
 
            eos_state % p = p_model(j)
@@ -225,7 +227,7 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
            ! assumes ke=0
            state(i,j,UEDEN) = state(i,j,UEINT)
 
-           state(i,j,UMX:UMY) = 0.d0
+           state(i,j,UMX:UMY) = 0.e0_rt
 
         end do
      end do

--- a/Exec/hydro_tests/double_bubble/bc_fill_2d.F90
+++ b/Exec/hydro_tests/double_bubble/bc_fill_2d.F90
@@ -1,5 +1,6 @@
 module bc_fill_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   public
@@ -17,6 +18,7 @@ contains
 
     use model_module
 
+    use bl_fort_module, only : rt => c_real
     implicit none
     
     include 'bc_types.fi'
@@ -24,12 +26,12 @@ contains
     integer adv_l1,adv_l2,adv_h1,adv_h2
     integer bc(2,2,*)
     integer domlo(2), domhi(2)
-    double precision delta(2), xlo(2), time
-    double precision adv(adv_l1:adv_h1,adv_l2:adv_h2,NVAR)
+    real(rt)         delta(2), xlo(2), time
+    real(rt)         adv(adv_l1:adv_h1,adv_l2:adv_h2,NVAR)
 
     integer i,j,n
 
-    double precision, allocatable :: r_model(:), rho_model(:), T_model(:), &
+    real(rt)        , allocatable :: r_model(:), rho_model(:), T_model(:), &
          e_model(:), p_model(:)
 
     integer :: lo_model, hi_model
@@ -62,7 +64,7 @@ contains
           do i=domlo(1)-1,adv_l1,-1
 
              ! zero transverse momentum
-             adv(i,j,UMY) = 0.d0
+             adv(i,j,UMY) = 0.e0_rt
 
              if (boundary_type .eq. 1) then
                 ! extrapolate normal momentum
@@ -71,14 +73,14 @@ contains
              else
                 ! zero normal momentum
                 ! permits pi to pass through boundary
-                adv(i,j,UMX) = 0.d0
+                adv(i,j,UMX) = 0.e0_rt
              end if
 
              adv(i,j,URHO) = rho_model(j)
              adv(i,j,UFS:UFS-1+nspec) = adv(i,j,URHO)*xn_model(:)
              adv(i,j,UEINT) = e_model(j)*adv(i,j,URHO)
              adv(i,j,UEDEN) = adv(i,j,UEINT) &
-                  + 0.5d0*(adv(i,j,UMX)**2+adv(i,j,UMY)**2)/adv(i,j,URHO)
+                  + 0.5e0_rt*(adv(i,j,UMX)**2+adv(i,j,UMY)**2)/adv(i,j,URHO)
              adv(i,j,UTEMP) = T_model(j)
 
           end do
@@ -93,7 +95,7 @@ contains
           do i=domhi(1)+1,adv_h1
 
              ! zero transverse momentum
-             adv(i,j,UMY) = 0.d0
+             adv(i,j,UMY) = 0.e0_rt
 
              if (boundary_type .eq. 1) then
                 ! extrapolate normal momentum
@@ -102,14 +104,14 @@ contains
              else
                 ! zero normal momentum
                 ! permits pi to pass through boundary
-                adv(i,j,UMX) = 0.d0
+                adv(i,j,UMX) = 0.e0_rt
              end if
 
              adv(i,j,URHO) = rho_model(j)
              adv(i,j,UFS:UFS-1+nspec) = adv(i,j,URHO)*xn_model(:)
              adv(i,j,UEINT) = e_model(j)*adv(i,j,URHO)
              adv(i,j,UEDEN) = adv(i,j,UEINT) &
-                  + 0.5d0*(adv(i,j,UMX)**2+adv(i,j,UMY)**2)/adv(i,j,URHO)
+                  + 0.5e0_rt*(adv(i,j,UMX)**2+adv(i,j,UMY)**2)/adv(i,j,URHO)
              adv(i,j,UTEMP) = T_model(j)
 
           end do
@@ -125,7 +127,7 @@ contains
           do i=adv_l1,adv_h1
 
              ! zero transverse momentum
-             adv(i,j,UMX) = 0.d0
+             adv(i,j,UMX) = 0.e0_rt
 
              if (boundary_type .eq. 1) then
                 ! extrapolate normal momentum
@@ -134,14 +136,14 @@ contains
              else
                 ! zero normal momentum
                 ! permits pi to pass through boundary
-                adv(i,j,UMY) = 0.d0
+                adv(i,j,UMY) = 0.e0_rt
              end if
 
              adv(i,j,URHO) = rho_model(j)
              adv(i,j,UFS:UFS-1+nspec) = adv(i,j,URHO)*xn_model(:)
              adv(i,j,UEINT) = e_model(j)*adv(i,j,URHO)
              adv(i,j,UEDEN) = adv(i,j,UEINT) &
-                  + 0.5d0*(adv(i,j,UMX)**2+adv(i,j,UMY)**2)/adv(i,j,URHO)
+                  + 0.5e0_rt*(adv(i,j,UMX)**2+adv(i,j,UMY)**2)/adv(i,j,URHO)
              adv(i,j,UTEMP) = T_model(j)
 
           end do
@@ -154,7 +156,7 @@ contains
           do i=adv_l1,adv_h1
 
              ! zero transverse momentum
-             adv(i,j,UMX) = 0.d0
+             adv(i,j,UMX) = 0.e0_rt
 
              if (boundary_type .eq. 1) then
                 ! extrapolate normal momentum
@@ -163,14 +165,14 @@ contains
              else
                 ! zero normal momentum
                 ! permits pi to pass through boundary
-                adv(i,j,UMY) = 0.d0
+                adv(i,j,UMY) = 0.e0_rt
              end if
 
              adv(i,j,URHO) = rho_model(j)
              adv(i,j,UFS:UFS-1+nspec) = adv(i,j,URHO)*xn_model(:)
              adv(i,j,UEINT) = e_model(j)*adv(i,j,URHO)
              adv(i,j,UEDEN) = adv(i,j,UEINT) &
-                  + 0.5d0*(adv(i,j,UMX)**2+adv(i,j,UMY)**2)/adv(i,j,URHO)
+                  + 0.5e0_rt*(adv(i,j,UMX)**2+adv(i,j,UMY)**2)/adv(i,j,URHO)
              adv(i,j,UTEMP) = T_model(j)
 
           end do
@@ -190,6 +192,7 @@ contains
 
     use model_module
 
+    use bl_fort_module, only : rt => c_real
     implicit none
     
     include 'bc_types.fi'
@@ -197,12 +200,12 @@ contains
     integer adv_l1,adv_l2,adv_h1,adv_h2
     integer bc(2,2,*)
     integer domlo(2), domhi(2)
-    double precision delta(2), xlo(2), time
-    double precision adv(adv_l1:adv_h1,adv_l2:adv_h2)
+    real(rt)         delta(2), xlo(2), time
+    real(rt)         adv(adv_l1:adv_h1,adv_l2:adv_h2)
 
     integer i,j
 
-    double precision, allocatable :: r_model(:), rho_model(:), T_model(:), &
+    real(rt)        , allocatable :: r_model(:), rho_model(:), T_model(:), &
          e_model(:), p_model(:)
 
     integer :: lo_model, hi_model
@@ -286,14 +289,15 @@ contains
                           domlo,domhi,delta,xlo,time,bc) bind(C, name="ca_gravxfill")
 
     use probdata_module
+    use bl_fort_module, only : rt => c_real
     implicit none
     include 'bc_types.fi'
 
     integer :: grav_l1,grav_l2,grav_h1,grav_h2
     integer :: bc(2,2,*)
     integer :: domlo(2), domhi(2)
-    double precision delta(2), xlo(2), time
-    double precision grav(grav_l1:grav_h1,grav_l2:grav_h2)
+    real(rt)         delta(2), xlo(2), time
+    real(rt)         grav(grav_l1:grav_h1,grav_l2:grav_h2)
 
     call filcc(grav,grav_l1,grav_l2,grav_h1,grav_h2,domlo,domhi,delta,xlo,bc)
 
@@ -306,6 +310,7 @@ contains
 
     use probdata_module
     
+    use bl_fort_module, only : rt => c_real
     implicit none
     
     include 'bc_types.fi'
@@ -313,8 +318,8 @@ contains
     integer :: grav_l1,grav_l2,grav_h1,grav_h2
     integer :: bc(2,2,*)
     integer :: domlo(2), domhi(2)
-    double precision delta(2), xlo(2), time
-    double precision grav(grav_l1:grav_h1,grav_l2:grav_h2)
+    real(rt)         delta(2), xlo(2), time
+    real(rt)         grav(grav_l1:grav_h1,grav_l2:grav_h2)
 
     call filcc(grav,grav_l1,grav_l2,grav_h1,grav_h2,domlo,domhi,delta,xlo,bc)
 
@@ -327,6 +332,7 @@ contains
 
     use probdata_module
     
+    use bl_fort_module, only : rt => c_real
     implicit none
     
     include 'bc_types.fi'
@@ -334,8 +340,8 @@ contains
     integer :: grav_l1,grav_l2,grav_h1,grav_h2
     integer :: bc(2,2,*)
     integer :: domlo(2), domhi(2)
-    double precision delta(2), xlo(2), time
-    double precision grav(grav_l1:grav_h1,grav_l2:grav_h2)
+    real(rt)         delta(2), xlo(2), time
+    real(rt)         grav(grav_l1:grav_h1,grav_l2:grav_h2)
 
     call filcc(grav,grav_l1,grav_l2,grav_h1,grav_h2,domlo,domhi,delta,xlo,bc)
 
@@ -347,6 +353,7 @@ contains
                             phi_h1,phi_h2,domlo,domhi,delta,xlo,time,bc) &
                             bind(C, name="ca_phigravfill")
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     include 'bc_types.fi'
@@ -354,8 +361,8 @@ contains
     integer          :: phi_l1,phi_l2,phi_h1,phi_h2
     integer          :: bc(2,2,*)
     integer          :: domlo(2), domhi(2)
-    double precision :: delta(2), xlo(2), time
-    double precision :: phi(phi_l1:phi_h1,phi_l2:phi_h2)
+    real(rt)         :: delta(2), xlo(2), time
+    real(rt)         :: phi(phi_l1:phi_h1,phi_l2:phi_h2)
 
     call filcc(phi,phi_l1,phi_l2,phi_h1,phi_h2, &
          domlo,domhi,delta,xlo,bc)

--- a/Exec/hydro_tests/double_bubble/model_stuff.f90
+++ b/Exec/hydro_tests/double_bubble/model_stuff.f90
@@ -1,12 +1,14 @@
 module model_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
 contains
 
   subroutine get_model_size(ymin, ymax, dy, lo, hi)
     
-    double precision, intent(in) :: ymin, ymax, dy
+    use bl_fort_module, only : rt => c_real
+    real(rt)        , intent(in) :: ymin, ymax, dy
     integer, intent(out) :: lo, hi
     
     integer :: npts
@@ -31,19 +33,20 @@ contains
     use eos_type_module
     use meth_params_module, only: const_grav
 
+    use bl_fort_module, only : rt => c_real
     integer, intent(in) :: lo, hi
-    double precision, intent(in) :: ymin, ymax, dy
-    double precision, intent(in) :: pres_base, dens_base
+    real(rt)        , intent(in) :: ymin, ymax, dy
+    real(rt)        , intent(in) :: pres_base, dens_base
     logical,          intent(in) :: do_isentropic
-    double precision, intent(in) :: xn_model(nspec)
+    real(rt)        , intent(in) :: xn_model(nspec)
 
-    double precision, intent(out) ::   r_model(lo:hi)
-    double precision, intent(out) :: rho_model(lo:hi)
-    double precision, intent(out) ::   T_model(lo:hi)
-    double precision, intent(out) ::   e_model(lo:hi)
-    double precision, intent(out) ::   p_model(lo:hi)
+    real(rt)        , intent(out) ::   r_model(lo:hi)
+    real(rt)        , intent(out) :: rho_model(lo:hi)
+    real(rt)        , intent(out) ::   T_model(lo:hi)
+    real(rt)        , intent(out) ::   e_model(lo:hi)
+    real(rt)        , intent(out) ::   p_model(lo:hi)
 
-    double precision :: H, gamma_const
+    real(rt)         :: H, gamma_const
     
     integer :: j
 
@@ -59,51 +62,51 @@ contains
     eos_state % xn(:) = xn_model(:)
 
     ! initial guess
-    eos_state % T = 1000.0d0
+    eos_state % T = 1000.0e0_rt
 
     call eos(eos_input_rp, eos_state)
 
-    gamma_const = pres_base/(dens_base * eos_state % e) + 1.0d0
+    gamma_const = pres_base/(dens_base * eos_state % e) + 1.0e0_rt
 
 
     rho_model(0) = dens_base
     p_model(0) = pres_base
 
-    r_model(0) = ymin + 0.5d0*dy
+    r_model(0) = ymin + 0.5e0_rt*dy
 
     ! integrate up from the base
     do j = 1, hi
 
-       r_model(j) = ymin + (dble(j)+0.5d0)*dy
+       r_model(j) = ymin + (dble(j)+0.5e0_rt)*dy
 
        if (do_isentropic) then
           rho_model(j) = dens_base*(const_grav*dens_base*(gamma_const - 1.0)* &
                (r_model(j)-r_model(0))/ &
-               (gamma_const*pres_base) + 1.d0)**(1.d0/(gamma_const - 1.d0))
+               (gamma_const*pres_base) + 1.e0_rt)**(1.e0_rt/(gamma_const - 1.e0_rt))
        else
           rho_model(j) = dens_base * exp(-(r_model(j)-r_model(0))/H)
        endif
 
        p_model(j) = p_model(j-1) - &
-             dy * 0.5d0 * (rho_model(j)+rho_model(j-1)) * abs(const_grav)
+             dy * 0.5e0_rt * (rho_model(j)+rho_model(j-1)) * abs(const_grav)
        
     enddo
 
     ! integrate down from the base
     do j = -1, lo, -1
        
-       r_model(j) = ymin + (dble(j)+0.5d0)*dy
+       r_model(j) = ymin + (dble(j)+0.5e0_rt)*dy
 
        if (do_isentropic) then
           rho_model(j) = dens_base*(const_grav*dens_base*(gamma_const - 1.0)* &
                (r_model(j)-r_model(0))/ &
-             (gamma_const*pres_base) + 1.d0)**(1.d0/(gamma_const - 1.d0))
+             (gamma_const*pres_base) + 1.e0_rt)**(1.e0_rt/(gamma_const - 1.e0_rt))
        else
           rho_model(j) = dens_base * exp(-(r_model(j)-r_model(0))/H)
        endif
 
        p_model(j) = p_model(j+1) + &
-             dy * 0.5d0 * (rho_model(j)+rho_model(j+1)) * abs(const_grav)
+             dy * 0.5e0_rt * (rho_model(j)+rho_model(j+1)) * abs(const_grav)
        
     enddo
      
@@ -114,7 +117,7 @@ contains
        eos_state % xn(:) = xn_model(:)
 
        ! initial guess
-       eos_state % T = 1000.0d0
+       eos_state % T = 1000.0e0_rt
 
        call eos(eos_input_rp, eos_state)
 

--- a/Exec/hydro_tests/double_bubble/probdata.f90
+++ b/Exec/hydro_tests/double_bubble/probdata.f90
@@ -2,18 +2,19 @@ module probdata_module
 
   use network
 
-  double precision, save :: dens_base, pres_base
-  double precision, save :: pert_factor, y_pert_center, pert_width
+  use bl_fort_module, only : rt => c_real
+  real(rt)        , save :: dens_base, pres_base
+  real(rt)        , save :: pert_factor, y_pert_center, pert_width
 
   logical,          save :: do_isentropic
 
   integer,          save :: boundary_type
 
-  double precision, save :: xn_model(nspec)
+  real(rt)        , save :: xn_model(nspec)
 
-  double precision, save :: ymin, ymax
+  real(rt)        , save :: ymin, ymax
 
-  double precision, save :: left_bubble_x_center, right_bubble_x_center
+  real(rt)        , save :: left_bubble_x_center, right_bubble_x_center
 
   logical         , save :: single
 

--- a/Exec/hydro_tests/gamma_law_bubble/Prob_2d.f90
+++ b/Exec/hydro_tests/gamma_law_bubble/Prob_2d.f90
@@ -4,11 +4,12 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
   use probdata_module
   use prob_params_module, only: center
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer init, namlen
   integer name(namlen)
-  double precision problo(2), probhi(2)
+  real(rt)         problo(2), probhi(2)
 
   integer untin,i
 
@@ -76,22 +77,23 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
   use eos_module
   use eos_type_module
   
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer level, nscal
   integer lo(2), hi(2)
   integer state_l1,state_l2,state_h1,state_h2
-  double precision xlo(2), xhi(2), time, delta(2)
-  double precision state(state_l1:state_h1,state_l2:state_h2,NVAR)
+  real(rt)         xlo(2), xhi(2), time, delta(2)
+  real(rt)         state(state_l1:state_h1,state_l2:state_h2,NVAR)
 
   integer i,j,npts_1d
-  double precision H,z,xn(1),x,y,x1,y1,r1,const
-  double precision, allocatable :: pressure(:), density(:), temp(:), eint(:)
+  real(rt)         H,z,xn(1),x,y,x1,y1,r1,const
+  real(rt)        , allocatable :: pressure(:), density(:), temp(:), eint(:)
 
   type (eos_t) :: eos_state
   
   ! first make a 1D initial model for the entire domain
-  npts_1d = (2.d0*center(2)+1.d-8) / delta(2)
+  npts_1d = (2.e0_rt*center(2)+1.e-8_rt) / delta(2)
 
   allocate(pressure(0:npts_1d-1))
   allocate(density (0:npts_1d-1))
@@ -104,7 +106,7 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
   density(0)  = dens_base
 
   ! only initialize the first species
-  xn(1) = 1.d0
+  xn(1) = 1.e0_rt
 
   ! compute the pressure scale height (for an isothermal, ideal-gas
   ! atmosphere)
@@ -113,20 +115,20 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
   do j=0,npts_1d-1
 
      ! initial guess
-     temp(j) = 1000.d0
+     temp(j) = 1000.e0_rt
 
      if (do_isentropic) then
         z = dble(j) * delta(2)
         density(j) = dens_base*(const_grav*dens_base*(gamma_const - 1.0)*z/ &
-             (gamma_const*pres_base) + 1.d0)**(1.d0/(gamma_const - 1.d0))
+             (gamma_const*pres_base) + 1.e0_rt)**(1.e0_rt/(gamma_const - 1.e0_rt))
      else
-        z = (dble(j)+0.5d0) * delta(2)
+        z = (dble(j)+0.5e0_rt) * delta(2)
         density(j) = dens_base * exp(-z/H)
      end if
 
      if (j .gt. 0) then
         pressure(j) = pressure(j-1) - &
-             delta(2) * 0.5d0 * (density(j)+density(j-1)) * abs(const_grav)
+             delta(2) * 0.5e0_rt * (density(j)+density(j-1)) * abs(const_grav)
      end if
 
      eos_state%p = pressure(j)
@@ -147,14 +149,14 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
   y1 = y_pert_center
 
   do j=lo(2),hi(2)
-     y = (dble(j)+0.5d0)*delta(2)
+     y = (dble(j)+0.5e0_rt)*delta(2)
      do i=lo(1),hi(1)
-        x = (dble(i)+0.5d0)*delta(1)
+        x = (dble(i)+0.5e0_rt)*delta(1)
 
         r1 = sqrt( (x-x1)**2 +(y-y1)**2 ) / pert_width
 
-        state(i,j,UTEMP) = temp(j) * (1.d0 + (pert_factor * (1.d0 + tanh(2.d0-r1))))
-        state(i,j,UFS) = 1.d0
+        state(i,j,UTEMP) = temp(j) * (1.e0_rt + (pert_factor * (1.e0_rt + tanh(2.e0_rt-r1))))
+        state(i,j,UFS) = 1.e0_rt
 
         eos_state%T = state(i,j,UTEMP)
         eos_state%rho = state(i,j,URHO)
@@ -173,7 +175,7 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
         ! assumes ke=0
         state(i,j,UEDEN) = state(i,j,UEINT)
 
-        state(i,j,UMX:UMY) = 0.d0
+        state(i,j,UMX:UMY) = 0.e0_rt
 
      end do
   end do

--- a/Exec/hydro_tests/gamma_law_bubble/bc_fill_2d.F90
+++ b/Exec/hydro_tests/gamma_law_bubble/bc_fill_2d.F90
@@ -1,5 +1,6 @@
 module bc_fill_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   public
@@ -16,6 +17,7 @@ contains
     use eos_type_module
     use network, only: nspec
 
+    use bl_fort_module, only : rt => c_real
     implicit none
     
     include 'bc_types.fi'
@@ -23,17 +25,17 @@ contains
     integer adv_l1,adv_l2,adv_h1,adv_h2
     integer bc(2,2,*)
     integer domlo(2), domhi(2)
-    double precision delta(2), xlo(2), time
-    double precision adv(adv_l1:adv_h1,adv_l2:adv_h2,NVAR)
+    real(rt)         delta(2), xlo(2), time
+    real(rt)         adv(adv_l1:adv_h1,adv_l2:adv_h2,NVAR)
 
     integer i,j,n
-    double precision y
-    double precision X_in(nspec)
-    double precision H
+    real(rt)         y
+    real(rt)         X_in(nspec)
+    real(rt)         H
 
     integer npts_1d
-    double precision, allocatable :: pressure(:), density(:), temp(:), eint(:)
-    double precision const
+    real(rt)        , allocatable :: pressure(:), density(:), temp(:), eint(:)
+    real(rt)         const
 
     type (eos_t) :: eos_state
 
@@ -41,7 +43,7 @@ contains
     ! compute background state
 
     ! first make a 1D initial model for the entire domain
-    npts_1d = (2.d0*center(2)+1.d-8) / delta(2)
+    npts_1d = (2.e0_rt*center(2)+1.e-8_rt) / delta(2)
 
     allocate(pressure(-5:npts_1d+4))
     allocate(density (-5:npts_1d+4))
@@ -54,7 +56,7 @@ contains
     density(0)  = dens_base
 
     ! only initialize the first species
-    X_in(1) = 1.d0
+    X_in(1) = 1.e0_rt
 
     ! compute the pressure scale height (for an isothermal, ideal-gas
     ! atmosphere)
@@ -63,20 +65,20 @@ contains
     do j=0,npts_1d+4
 
        ! initial guess
-       temp(j) = 1000.d0
+       temp(j) = 1000.e0_rt
 
        if (do_isentropic) then
           y = dble(j) * delta(2)
           density(j) = dens_base*(const_grav*dens_base*(gamma_const - 1.0)*y/ &
-               (gamma_const*pres_base) + 1.d0)**(1.d0/(gamma_const - 1.d0))
+               (gamma_const*pres_base) + 1.e0_rt)**(1.e0_rt/(gamma_const - 1.e0_rt))
        else
-          y = (dble(j)+0.5d0) * delta(2)
+          y = (dble(j)+0.5e0_rt) * delta(2)
           density(j) = dens_base * exp(-y/H)
        end if
 
        if (j .gt. 0) then
           pressure(j) = pressure(j-1) - &
-               delta(2) * 0.5d0 * (density(j)+density(j-1)) * abs(const_grav)
+               delta(2) * 0.5e0_rt * (density(j)+density(j-1)) * abs(const_grav)
        end if
 
        eos_state%rho = density(j)
@@ -94,19 +96,19 @@ contains
     do j=-1,-5,-1
 
        ! initial guess
-       temp(j) = 1000.d0
+       temp(j) = 1000.e0_rt
 
        if (do_isentropic) then
           y = dble(j) * delta(2)
           density(j) = dens_base*(const_grav*dens_base*(gamma_const - 1.0)*y/ &
-               (gamma_const*pres_base) + 1.d0)**(1.d0/(gamma_const - 1.d0))
+               (gamma_const*pres_base) + 1.e0_rt)**(1.e0_rt/(gamma_const - 1.e0_rt))
        else
-          y = (dble(j)+0.5d0) * delta(2)
+          y = (dble(j)+0.5e0_rt) * delta(2)
           density(j) = dens_base * exp(-y/H)
        end if
 
        pressure(j) = pressure(j+1) + &
-            delta(2) * 0.5d0 * (density(j)+density(j+1)) * abs(const_grav)
+            delta(2) * 0.5e0_rt * (density(j)+density(j+1)) * abs(const_grav)
 
        eos_state%rho = density(j)
        eos_state%T = temp(j)
@@ -132,11 +134,11 @@ contains
     if ( bc(1,1,1).eq.EXT_DIR .and. adv_l1.lt.domlo(1)) then
 
        do j=adv_l2,adv_h2
-          y = xlo(2) + delta(2)*(float(j-adv_l2) + 0.5d0)
+          y = xlo(2) + delta(2)*(float(j-adv_l2) + 0.5e0_rt)
           do i=domlo(1)-1,adv_l1,-1
 
              ! zero transverse momentum
-             adv(i,j,UMY) = 0.d0
+             adv(i,j,UMY) = 0.e0_rt
 
              if (boundary_type .eq. 1) then
                 ! extrapolate normal momentum
@@ -145,14 +147,14 @@ contains
              else
                 ! zero normal momentum
                 ! permits pi to pass through boundary
-                adv(i,j,UMX) = 0.d0
+                adv(i,j,UMX) = 0.e0_rt
              end if
 
              adv(i,j,URHO) = density(j)
              adv(i,j,UFS) = adv(i,j,URHO)
              adv(i,j,UEINT) = eint(j)*adv(i,j,URHO)
              adv(i,j,UEDEN) = adv(i,j,UEINT) &
-                  + 0.5d0*(adv(i,j,UMX)**2+adv(i,j,UMY)**2)/adv(i,j,URHO)
+                  + 0.5e0_rt*(adv(i,j,UMX)**2+adv(i,j,UMY)**2)/adv(i,j,URHO)
              adv(i,j,UTEMP) = temp(j)
 
           end do
@@ -164,11 +166,11 @@ contains
     if ( bc(1,2,1).eq.EXT_DIR .and. adv_h1.gt.domhi(1)) then
 
        do j=adv_l2,adv_h2
-          y = xlo(2) + delta(2)*(float(j-adv_l2) + 0.5d0)
+          y = xlo(2) + delta(2)*(float(j-adv_l2) + 0.5e0_rt)
           do i=domhi(1)+1,adv_h1
 
              ! zero transverse momentum
-             adv(i,j,UMY) = 0.d0
+             adv(i,j,UMY) = 0.e0_rt
 
              if (boundary_type .eq. 1) then
                 ! extrapolate normal momentum
@@ -177,14 +179,14 @@ contains
              else
                 ! zero normal momentum
                 ! permits pi to pass through boundary
-                adv(i,j,UMX) = 0.d0
+                adv(i,j,UMX) = 0.e0_rt
              end if
 
              adv(i,j,URHO) = density(j)
              adv(i,j,UFS) = adv(i,j,URHO)
              adv(i,j,UEINT) = eint(j)*adv(i,j,URHO)
              adv(i,j,UEDEN) = adv(i,j,UEINT) &
-                  + 0.5d0*(adv(i,j,UMX)**2+adv(i,j,UMY)**2)/adv(i,j,URHO)
+                  + 0.5e0_rt*(adv(i,j,UMX)**2+adv(i,j,UMY)**2)/adv(i,j,URHO)
              adv(i,j,UTEMP) = temp(j)
 
           end do
@@ -197,11 +199,11 @@ contains
     if ( bc(2,1,1).eq.EXT_DIR .and. adv_l2.lt.domlo(2)) then
        ! this do loop counts backwards since we want to work downward
        do j=domlo(2)-1,adv_l2,-1
-          y = xlo(2) + delta(2)*(float(j-adv_l2) + 0.5d0)
+          y = xlo(2) + delta(2)*(float(j-adv_l2) + 0.5e0_rt)
           do i=adv_l1,adv_h1
 
              ! zero transverse momentum
-             adv(i,j,UMX) = 0.d0
+             adv(i,j,UMX) = 0.e0_rt
 
              if (boundary_type .eq. 1) then
                 ! extrapolate normal momentum
@@ -210,14 +212,14 @@ contains
              else
                 ! zero normal momentum
                 ! permits pi to pass through boundary
-                adv(i,j,UMY) = 0.d0
+                adv(i,j,UMY) = 0.e0_rt
              end if
 
              adv(i,j,URHO) = density(j)
              adv(i,j,UFS) = adv(i,j,URHO)
              adv(i,j,UEINT) = eint(j)*adv(i,j,URHO)
              adv(i,j,UEDEN) = adv(i,j,UEINT) &
-                  + 0.5d0*(adv(i,j,UMX)**2+adv(i,j,UMY)**2)/adv(i,j,URHO)
+                  + 0.5e0_rt*(adv(i,j,UMX)**2+adv(i,j,UMY)**2)/adv(i,j,URHO)
              adv(i,j,UTEMP) = temp(j)
 
           end do
@@ -227,11 +229,11 @@ contains
     !        YHI
     if ( bc(2,2,1).eq.EXT_DIR .and. adv_h2.gt.domhi(2)) then
        do j=domhi(2)+1,adv_h2
-          y = xlo(2) + delta(2)*(float(j-adv_l2) + 0.5d0)
+          y = xlo(2) + delta(2)*(float(j-adv_l2) + 0.5e0_rt)
           do i=adv_l1,adv_h1
 
              ! zero transverse momentum
-             adv(i,j,UMX) = 0.d0
+             adv(i,j,UMX) = 0.e0_rt
 
              if (boundary_type .eq. 1) then
                 ! extrapolate normal momentum
@@ -240,14 +242,14 @@ contains
              else
                 ! zero normal momentum
                 ! permits pi to pass through boundary
-                adv(i,j,UMY) = 0.d0
+                adv(i,j,UMY) = 0.e0_rt
              end if
 
              adv(i,j,URHO) = density(j)
              adv(i,j,UFS) = adv(i,j,URHO)
              adv(i,j,UEINT) = eint(j)*adv(i,j,URHO)
              adv(i,j,UEDEN) = adv(i,j,UEINT) &
-                  + 0.5d0*(adv(i,j,UMX)**2+adv(i,j,UMY)**2)/adv(i,j,URHO)
+                  + 0.5e0_rt*(adv(i,j,UMX)**2+adv(i,j,UMY)**2)/adv(i,j,URHO)
              adv(i,j,UTEMP) = temp(j)
 
           end do
@@ -268,6 +270,7 @@ contains
     use eos_module, only: gamma_const
     use meth_params_module, only : const_grav
 
+    use bl_fort_module, only : rt => c_real
     implicit none
     
     include 'bc_types.fi'
@@ -275,11 +278,11 @@ contains
     integer adv_l1,adv_l2,adv_h1,adv_h2
     integer bc(2,2,*)
     integer domlo(2), domhi(2)
-    double precision delta(2), xlo(2), time
-    double precision adv(adv_l1:adv_h1,adv_l2:adv_h2)
+    real(rt)         delta(2), xlo(2), time
+    real(rt)         adv(adv_l1:adv_h1,adv_l2:adv_h2)
 
     integer i,j
-    double precision y,H
+    real(rt)         y,H
 
     ! compute the pressure scale height (for an isothermal, ideal-gas
     ! atmosphere)
@@ -300,9 +303,9 @@ contains
              if (do_isentropic) then
                 y = xlo(2) + delta(2)*float(j-adv_l2)
                 adv(i,j) = dens_base*(const_grav*dens_base*(gamma_const - 1.0)*y/ &
-                     (gamma_const*pres_base) + 1.d0)**(1.d0/(gamma_const - 1.d0))
+                     (gamma_const*pres_base) + 1.e0_rt)**(1.e0_rt/(gamma_const - 1.e0_rt))
              else
-                y = xlo(2) + delta(2)*(float(j-adv_l2) + 0.5d0)
+                y = xlo(2) + delta(2)*(float(j-adv_l2) + 0.5e0_rt)
                 adv(i,j) = dens_base * exp(-y/H)
              end if
 
@@ -318,9 +321,9 @@ contains
              if (do_isentropic) then
                 y = xlo(2) + delta(2)*float(j-adv_l2)
                 adv(i,j) = dens_base*(const_grav*dens_base*(gamma_const - 1.0)*y/ &
-                     (gamma_const*pres_base) + 1.d0)**(1.d0/(gamma_const - 1.d0))
+                     (gamma_const*pres_base) + 1.e0_rt)**(1.e0_rt/(gamma_const - 1.e0_rt))
              else
-                y = xlo(2) + delta(2)*(float(j-adv_l2) + 0.5d0)
+                y = xlo(2) + delta(2)*(float(j-adv_l2) + 0.5e0_rt)
                 adv(i,j) = dens_base * exp(-y/H)
              end if
 
@@ -336,9 +339,9 @@ contains
              if (do_isentropic) then
                 y = xlo(2) + delta(2)*float(j-adv_l2)
                 adv(i,j) = dens_base*(const_grav*dens_base*(gamma_const - 1.0)*y/ &
-                     (gamma_const*pres_base) + 1.d0)**(1.d0/(gamma_const - 1.d0))
+                     (gamma_const*pres_base) + 1.e0_rt)**(1.e0_rt/(gamma_const - 1.e0_rt))
              else
-                y = xlo(2) + delta(2)*(float(j-adv_l2) + 0.5d0)
+                y = xlo(2) + delta(2)*(float(j-adv_l2) + 0.5e0_rt)
                 adv(i,j) = dens_base * exp(-y/H)
              end if
 
@@ -354,9 +357,9 @@ contains
              if (do_isentropic) then
                 y = xlo(2) + delta(2)*float(j-adv_l2)
                 adv(i,j) = dens_base*(const_grav*dens_base*(gamma_const - 1.0)*y/ &
-                     (gamma_const*pres_base) + 1.d0)**(1.d0/(gamma_const - 1.d0))
+                     (gamma_const*pres_base) + 1.e0_rt)**(1.e0_rt/(gamma_const - 1.e0_rt))
              else
-                y = xlo(2) + delta(2)*(float(j-adv_l2) + 0.5d0)
+                y = xlo(2) + delta(2)*(float(j-adv_l2) + 0.5e0_rt)
                 adv(i,j) = dens_base * exp(-y/H)
              end if
 
@@ -374,6 +377,7 @@ contains
 
     use probdata_module
     
+    use bl_fort_module, only : rt => c_real
     implicit none
     
     include 'bc_types.fi'
@@ -381,8 +385,8 @@ contains
     integer :: grav_l1,grav_l2,grav_h1,grav_h2
     integer :: bc(2,2,*)
     integer :: domlo(2), domhi(2)
-    double precision delta(2), xlo(2), time
-    double precision grav(grav_l1:grav_h1,grav_l2:grav_h2)
+    real(rt)         delta(2), xlo(2), time
+    real(rt)         grav(grav_l1:grav_h1,grav_l2:grav_h2)
 
     call filcc(grav,grav_l1,grav_l2,grav_h1,grav_h2,domlo,domhi,delta,xlo,bc)
 
@@ -395,6 +399,7 @@ contains
 
     use probdata_module
     
+    use bl_fort_module, only : rt => c_real
     implicit none
     
     include 'bc_types.fi'
@@ -402,8 +407,8 @@ contains
     integer :: grav_l1,grav_l2,grav_h1,grav_h2
     integer :: bc(2,2,*)
     integer :: domlo(2), domhi(2)
-    double precision delta(2), xlo(2), time
-    double precision grav(grav_l1:grav_h1,grav_l2:grav_h2)
+    real(rt)         delta(2), xlo(2), time
+    real(rt)         grav(grav_l1:grav_h1,grav_l2:grav_h2)
 
     call filcc(grav,grav_l1,grav_l2,grav_h1,grav_h2,domlo,domhi,delta,xlo,bc)
 
@@ -416,6 +421,7 @@ contains
 
     use probdata_module
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     include 'bc_types.fi'
@@ -423,8 +429,8 @@ contains
     integer :: grav_l1,grav_l2,grav_h1,grav_h2
     integer :: bc(2,2,*)
     integer :: domlo(2), domhi(2)
-    double precision delta(2), xlo(2), time
-    double precision grav(grav_l1:grav_h1,grav_l2:grav_h2)
+    real(rt)         delta(2), xlo(2), time
+    real(rt)         grav(grav_l1:grav_h1,grav_l2:grav_h2)
 
     call filcc(grav,grav_l1,grav_l2,grav_h1,grav_h2,domlo,domhi,delta,xlo,bc)
 
@@ -435,6 +441,7 @@ contains
   subroutine ca_phigravfill(phi,phi_l1,phi_l2, &
                             phi_h1,phi_h2,domlo,domhi,delta,xlo,time,bc) bind(C)
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     include 'bc_types.fi'
@@ -442,8 +449,8 @@ contains
     integer          :: phi_l1,phi_l2,phi_h1,phi_h2
     integer          :: bc(2,2,*)
     integer          :: domlo(2), domhi(2)
-    double precision :: delta(2), xlo(2), time
-    double precision :: phi(phi_l1:phi_h1,phi_l2:phi_h2)
+    real(rt)         :: delta(2), xlo(2), time
+    real(rt)         :: phi(phi_l1:phi_h1,phi_l2:phi_h2)
 
     call filcc(phi,phi_l1,phi_l2,phi_h1,phi_h2, &
                domlo,domhi,delta,xlo,bc)

--- a/Exec/hydro_tests/gamma_law_bubble/extra_derives_2d.f90
+++ b/Exec/hydro_tests/gamma_law_bubble/extra_derives_2d.f90
@@ -11,26 +11,27 @@ subroutine ca_derpi(p,p_l1,p_l2,p_h1,p_h2,ncomp_p, &
        allow_negative_energy, const_grav
   use probdata_module, only: pres_base, dens_base, do_isentropic
   use prob_params_module, only: center
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer          :: p_l1,p_l2,p_h1,p_h2,ncomp_p
   integer          :: u_l1,u_l2,u_h1,u_h2,ncomp_u
   integer          :: lo(2), hi(2), domlo(2), domhi(2)
-  double precision :: p(p_l1:p_h1,p_l2:p_h2,ncomp_p)
-  double precision :: u(u_l1:u_h1,u_l2:u_h2,ncomp_u)
-  double precision :: dx(2), xlo(2), time, dt
+  real(rt)         :: p(p_l1:p_h1,p_l2:p_h2,ncomp_p)
+  real(rt)         :: u(u_l1:u_h1,u_l2:u_h2,ncomp_u)
+  real(rt)         :: dx(2), xlo(2), time, dt
   integer          :: bc(2,2,ncomp_u), level, grid_no
 
-  double precision :: e, T
-  double precision :: rhoInv
+  real(rt)         :: e, T
+  real(rt)         :: rhoInv
   integer          :: i,j,npts_1d
-  double precision H,z,xn(1), const
-  double precision, allocatable :: pressure(:), density(:), temp(:), eint(:)
+  real(rt)         H,z,xn(1), const
+  real(rt)        , allocatable :: pressure(:), density(:), temp(:), eint(:)
 
   type (eos_t) :: eos_state      
 
   ! first make a 1D initial model for the entire domain
-  npts_1d = (2.d0*center(2)+1.d-8) / dx(2)
+  npts_1d = (2.e0_rt*center(2)+1.e-8_rt) / dx(2)
 
   allocate(pressure(0:npts_1d-1))
   allocate(density (0:npts_1d-1))
@@ -43,7 +44,7 @@ subroutine ca_derpi(p,p_l1,p_l2,p_h1,p_h2,ncomp_p, &
   density(0)  = dens_base
 
   ! only initialize the first species
-  xn(1) = 1.d0
+  xn(1) = 1.e0_rt
 
   ! compute the pressure scale height (for an isothermal, ideal-gas
   ! atmosphere)
@@ -52,20 +53,20 @@ subroutine ca_derpi(p,p_l1,p_l2,p_h1,p_h2,ncomp_p, &
   do j=0,npts_1d-1
 
      ! initial guess
-     temp(j) = 1000.d0
+     temp(j) = 1000.e0_rt
 
      if (do_isentropic) then
         z = dble(j) * dx(2)
         density(j) = dens_base*(const_grav*dens_base*(gamma_const - 1.0)*z/ &
-             (gamma_const*pres_base) + 1.d0)**(1.d0/(gamma_const - 1.d0))
+             (gamma_const*pres_base) + 1.e0_rt)**(1.e0_rt/(gamma_const - 1.e0_rt))
      else
-        z = (dble(j)+0.5d0) * dx(2)
+        z = (dble(j)+0.5e0_rt) * dx(2)
         density(j) = dens_base * exp(-z/H)
      end if
 
      if (j .gt. 0) then
         pressure(j) = pressure(j-1) - &
-             dx(2) * 0.5d0 * (density(j)+density(j-1)) * abs(const_grav)
+             dx(2) * 0.5e0_rt * (density(j)+density(j-1)) * abs(const_grav)
      end if
 
      eos_state%rho = density(j)
@@ -82,7 +83,7 @@ subroutine ca_derpi(p,p_l1,p_l2,p_h1,p_h2,ncomp_p, &
   ! Compute pressure from the EOS
   do j = lo(2),hi(2)
      do i = lo(1),hi(1)
-        rhoInv = 1.d0/u(i,j,URHO)
+        rhoInv = 1.e0_rt/u(i,j,URHO)
         T = u(i,j,UTEMP)
 
         eos_state%rho = u(i,j,URHO)
@@ -92,7 +93,7 @@ subroutine ca_derpi(p,p_l1,p_l2,p_h1,p_h2,ncomp_p, &
         eos_state%aux(:) = u(i,j,UFX:UFX-1+naux)/u(i,j,URHO)            
 
         ! Protect against negative internal energy
-        if (allow_negative_energy .eq. 0 .and. e .le. 0.d0) then
+        if (allow_negative_energy .eq. 0 .and. e .le. 0.e0_rt) then
            call eos(eos_input_rt, eos_state)
            p(i,j,1) = eos_state%p
 
@@ -123,26 +124,27 @@ subroutine ca_derpioverp0(p,p_l1,p_l2,p_h1,p_h2,ncomp_p, &
   use probdata_module, only: pres_base, dens_base, do_isentropic
   use prob_params_module, only: center
   
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer          :: p_l1,p_l2,p_h1,p_h2,ncomp_p
   integer          :: u_l1,u_l2,u_h1,u_h2,ncomp_u
   integer          :: lo(2), hi(2), domlo(2), domhi(2)
-  double precision :: p(p_l1:p_h1,p_l2:p_h2,ncomp_p)
-  double precision :: u(u_l1:u_h1,u_l2:u_h2,ncomp_u)
-  double precision :: dx(2), xlo(2), time, dt
+  real(rt)         :: p(p_l1:p_h1,p_l2:p_h2,ncomp_p)
+  real(rt)         :: u(u_l1:u_h1,u_l2:u_h2,ncomp_u)
+  real(rt)         :: dx(2), xlo(2), time, dt
   integer          :: bc(2,2,ncomp_u), level, grid_no
 
-  double precision :: e, T
-  double precision :: rhoInv
+  real(rt)         :: e, T
+  real(rt)         :: rhoInv
   integer          :: i,j,npts_1d
-  double precision H,z,xn(1), const
-  double precision, allocatable :: pressure(:), density(:), temp(:), eint(:)
+  real(rt)         H,z,xn(1), const
+  real(rt)        , allocatable :: pressure(:), density(:), temp(:), eint(:)
 
   type (eos_t) :: eos_state      
 
   ! first make a 1D initial model for the entire domain
-  npts_1d = (2.d0*center(2)+1.d-8) / dx(2)
+  npts_1d = (2.e0_rt*center(2)+1.e-8_rt) / dx(2)
 
   allocate(pressure(0:npts_1d-1))
   allocate(density (0:npts_1d-1))
@@ -155,7 +157,7 @@ subroutine ca_derpioverp0(p,p_l1,p_l2,p_h1,p_h2,ncomp_p, &
   density(0)  = dens_base
 
   ! only initialize the first species
-  xn(1) = 1.d0
+  xn(1) = 1.e0_rt
 
   ! compute the pressure scale height (for an isothermal, ideal-gas
   ! atmosphere)
@@ -164,20 +166,20 @@ subroutine ca_derpioverp0(p,p_l1,p_l2,p_h1,p_h2,ncomp_p, &
   do j=0,npts_1d-1
 
      ! initial guess
-     temp(j) = 1000.d0
+     temp(j) = 1000.e0_rt
 
      if (do_isentropic) then
         z = dble(j) * dx(2)
         density(j) = dens_base*(const_grav*dens_base*(gamma_const - 1.0)*z/ &
-             (gamma_const*pres_base) + 1.d0)**(1.d0/(gamma_const - 1.d0))
+             (gamma_const*pres_base) + 1.e0_rt)**(1.e0_rt/(gamma_const - 1.e0_rt))
      else
-        z = (dble(j)+0.5d0) * dx(2)
+        z = (dble(j)+0.5e0_rt) * dx(2)
         density(j) = dens_base * exp(-z/H)
      end if
 
      if (j .gt. 0) then
         pressure(j) = pressure(j-1) - &
-             dx(2) * 0.5d0 * (density(j)+density(j-1)) * abs(const_grav)
+             dx(2) * 0.5e0_rt * (density(j)+density(j-1)) * abs(const_grav)
      end if
 
      eos_state%rho = density(j)
@@ -194,7 +196,7 @@ subroutine ca_derpioverp0(p,p_l1,p_l2,p_h1,p_h2,ncomp_p, &
   ! Compute pressure from the EOS
   do j = lo(2),hi(2)
      do i = lo(1),hi(1)
-        rhoInv = 1.d0/u(i,j,URHO)
+        rhoInv = 1.e0_rt/u(i,j,URHO)
         e = u(i,j,UEINT)*rhoInv
         T = u(i,j,UTEMP)
 
@@ -205,7 +207,7 @@ subroutine ca_derpioverp0(p,p_l1,p_l2,p_h1,p_h2,ncomp_p, &
         eos_state%e = e
 
         ! Protect against negative internal energy
-        if (allow_negative_energy .eq. 0 .and. e .le. 0.d0) then
+        if (allow_negative_energy .eq. 0 .and. e .le. 0.e0_rt) then
            call eos(eos_input_rt, eos_state)
            p(i,j,1) = eos_state%p
 
@@ -234,29 +236,30 @@ subroutine ca_derrhopert(p,p_l1,p_l2,p_h1,p_h2,ncomp_p, &
   use probdata_module
   use interpolate_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer          :: p_l1,p_l2,p_h1,p_h2,ncomp_p
   integer          :: u_l1,u_l2,u_h1,u_h2,ncomp_u
   integer          :: lo(2), hi(2), domlo(2), domhi(2)
-  double precision :: p(p_l1:p_h1,p_l2:p_h2,ncomp_p)
-  double precision :: u(u_l1:u_h1,u_l2:u_h2,ncomp_u)
-  double precision :: dx(2), xlo(2), time, dt
+  real(rt)         :: p(p_l1:p_h1,p_l2:p_h2,ncomp_p)
+  real(rt)         :: u(u_l1:u_h1,u_l2:u_h2,ncomp_u)
+  real(rt)         :: dx(2), xlo(2), time, dt
   integer          :: bc(2,2,ncomp_u), level, grid_no
 
   ! local
   integer :: i,j
 
-  double precision :: y,dens,H
+  real(rt)         :: y,dens,H
 
   do j=lo(2),hi(2)
 
      if (do_isentropic) then
         y = xlo(2) + dx(2)*float(j-lo(2))
         dens = dens_base*(const_grav*dens_base*(gamma_const - 1.0)*y/ &
-             (gamma_const*pres_base) + 1.d0)**(1.d0/(gamma_const - 1.d0))
+             (gamma_const*pres_base) + 1.e0_rt)**(1.e0_rt/(gamma_const - 1.e0_rt))
      else
-        y = xlo(2) + dx(2)*(float(j-lo(2)) + 0.5d0)
+        y = xlo(2) + dx(2)*(float(j-lo(2)) + 0.5e0_rt)
         dens = dens_base * exp(-y/H)
      end if
 
@@ -281,24 +284,25 @@ subroutine ca_dertpert(p,p_l1,p_l2,p_h1,p_h2,ncomp_p, &
   use probdata_module, only: pres_base, dens_base, do_isentropic
   use prob_params_module, only: center
   
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer          :: p_l1,p_l2,p_h1,p_h2,ncomp_p
   integer          :: u_l1,u_l2,u_h1,u_h2,ncomp_u
   integer          :: lo(2), hi(2), domlo(2), domhi(2)
-  double precision :: p(p_l1:p_h1,p_l2:p_h2,ncomp_p)
-  double precision :: u(u_l1:u_h1,u_l2:u_h2,ncomp_u)
-  double precision :: dx(2), xlo(2), time, dt
+  real(rt)         :: p(p_l1:p_h1,p_l2:p_h2,ncomp_p)
+  real(rt)         :: u(u_l1:u_h1,u_l2:u_h2,ncomp_u)
+  real(rt)         :: dx(2), xlo(2), time, dt
   integer          :: bc(2,2,ncomp_u), level, grid_no
 
   integer          :: i,j,npts_1d
-  double precision H,z,xn(1), const
-  double precision, allocatable :: pressure(:), density(:), temp(:), eint(:)
+  real(rt)         H,z,xn(1), const
+  real(rt)        , allocatable :: pressure(:), density(:), temp(:), eint(:)
 
   type (eos_t) :: eos_state      
 
   ! first make a 1D initial model for the entire domain
-  npts_1d = (2.d0*center(2)+1.d-8) / dx(2)
+  npts_1d = (2.e0_rt*center(2)+1.e-8_rt) / dx(2)
 
   allocate(pressure(0:npts_1d-1))
   allocate(density (0:npts_1d-1))
@@ -311,7 +315,7 @@ subroutine ca_dertpert(p,p_l1,p_l2,p_h1,p_h2,ncomp_p, &
   density(0)  = dens_base
 
   ! only initialize the first species
-  xn(1) = 1.d0
+  xn(1) = 1.e0_rt
 
   ! compute the pressure scale height (for an isothermal, ideal-gas
   ! atmosphere)
@@ -320,20 +324,20 @@ subroutine ca_dertpert(p,p_l1,p_l2,p_h1,p_h2,ncomp_p, &
   do j=0,npts_1d-1
 
      ! initial guess
-     temp(j) = 1000.d0
+     temp(j) = 1000.e0_rt
 
      if (do_isentropic) then
         z = dble(j) * dx(2)
         density(j) = dens_base*(const_grav*dens_base*(gamma_const - 1.0)*z/ &
-             (gamma_const*pres_base) + 1.d0)**(1.d0/(gamma_const - 1.d0))
+             (gamma_const*pres_base) + 1.e0_rt)**(1.e0_rt/(gamma_const - 1.e0_rt))
      else
-        z = (dble(j)+0.5d0) * dx(2)
+        z = (dble(j)+0.5e0_rt) * dx(2)
         density(j) = dens_base * exp(-z/H)
      end if
 
      if (j .gt. 0) then
         pressure(j) = pressure(j-1) - &
-             dx(2) * 0.5d0 * (density(j)+density(j-1)) * abs(const_grav)
+             dx(2) * 0.5e0_rt * (density(j)+density(j-1)) * abs(const_grav)
      end if
 
      eos_state%rho = density(j)

--- a/Exec/hydro_tests/gamma_law_bubble/probdata.f90
+++ b/Exec/hydro_tests/gamma_law_bubble/probdata.f90
@@ -1,12 +1,13 @@
 module probdata_module
 
-  double precision, save :: pert_factor, dens_base, pres_base, y_pert_center
-  double precision, save :: pert_width
+  use bl_fort_module, only : rt => c_real
+  real(rt)        , save :: pert_factor, dens_base, pres_base, y_pert_center
+  real(rt)        , save :: pert_width
   
   logical,          save :: do_isentropic
 
   integer,          save :: boundary_type
 
-  double precision, save :: frac
+  real(rt)        , save :: frac
 
 end module probdata_module

--- a/Exec/hydro_tests/gresho_vortex/Prob_2d.f90
+++ b/Exec/hydro_tests/gresho_vortex/Prob_2d.f90
@@ -11,11 +11,12 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
   use bl_constants_module
   use bl_error_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer :: init, namlen
   integer :: name(namlen)
-  double precision :: problo(2), probhi(2)
+  real(rt)         :: problo(2), probhi(2)
 
   integer :: untin,i
 
@@ -46,12 +47,12 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
   close(unit=untin)
 
   ! problem center
-  center(1) = (problo(1)+probhi(1))/2.d0
-  center(2) = (problo(2)+probhi(2))/2.d0
+  center(1) = (problo(1)+probhi(1))/2.e0_rt
+  center(2) = (problo(2)+probhi(2))/2.e0_rt
 
   ! characteristic scales
   x_r = probhi(1) - problo(1)
-  q_r = 0.4_dp_t*M_pi*x_r/t_r
+  q_r = 0.4_rt*M_pi*x_r/t_r
 
 end subroutine PROBINIT
 
@@ -88,17 +89,18 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
   use prob_params_module, only : center, problo
   use network, only: nspec
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer :: level, nscal
   integer :: lo(2), hi(2)
   integer :: state_l1,state_l2,state_h1,state_h2
-  double precision :: xlo(2), xhi(2), time, delta(2)
-  double precision :: state(state_l1:state_h1,state_l2:state_h2,NVAR)
+  real(rt)         :: xlo(2), xhi(2), time, delta(2)
+  real(rt)         :: state(state_l1:state_h1,state_l2:state_h2,NVAR)
 
-  double precision :: x, y, xl, yl, xx, yy, xc, yc
-  double precision :: r
-  double precision :: reint, p, u_phi, u_tot
+  real(rt)         :: x, y, xl, yl, xx, yy, xc, yc
+  real(rt)         :: r
+  real(rt)         :: reint, p, u_phi, u_tot
 
   integer :: i,j,ii,jj
 
@@ -121,13 +123,13 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
 
               r = sqrt((xx - center(1))**2 + (yy - center(2))**2)
 
-              if (r < 0.2_dp_t) then
+              if (r < 0.2_rt) then
                  u_phi = FIVE*r
-                 p = p0 + 12.5_dp_t*r**2
+                 p = p0 + 12.5_rt*r**2
 
-              else if (r < 0.4_dp_t) then
+              else if (r < 0.4_rt) then
                  u_phi = TWO - FIVE*r
-                 p = p0 + 12.5_dp_t*r**2 + FOUR*(ONE - FIVE*r - log(0.2_dp_t) + log(r))
+                 p = p0 + 12.5_rt*r**2 + FOUR*(ONE - FIVE*r - log(0.2_dp_t) + log(r))
 
               else
                  u_phi = ZERO
@@ -156,7 +158,7 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
         state(i,j,UMY) = rho0*q_r*u_phi*((xc-center(1))/r)   ! cos(phi) = x/r
 
         state(i,j,UEDEN) = reint +  &
-             0.5d0*(state(i,j,UMX)**2/state(i,j,URHO) + &
+             0.5e0_rt*(state(i,j,UMX)**2/state(i,j,URHO) + &
                     state(i,j,UMY)**2/state(i,j,URHO))
 
         state(i,j,UEINT) = reint

--- a/Exec/hydro_tests/gresho_vortex/probdata.f90
+++ b/Exec/hydro_tests/gresho_vortex/probdata.f90
@@ -1,7 +1,8 @@
 module probdata_module
 
-      double precision, save ::  p0, rho0, t_r
-      double precision, save :: x_r, q_r
+      use bl_fort_module, only : rt => c_real
+      real(rt)        , save ::  p0, rho0, t_r
+      real(rt)        , save :: x_r, q_r
       integer, save :: nsub
 
 end module probdata_module

--- a/Exec/hydro_tests/oddeven/Prob_2d.f90
+++ b/Exec/hydro_tests/oddeven/Prob_2d.f90
@@ -5,11 +5,12 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
   use bl_constants_module
   use bl_error_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer init, namlen
   integer name(namlen)
-  double precision problo(2), probhi(2)
+  real(rt)         problo(2), probhi(2)
 
   integer untin,i
 
@@ -29,8 +30,8 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
   ! set namelist defaults
 
   ! set center, domain extrema
-  center(1) = (problo(1)+probhi(1))/2.d0
-  center(2) = (problo(2)+probhi(2))/2.d0
+  center(1) = (problo(1)+probhi(1))/2.e0_rt
+  center(2) = (problo(2)+probhi(2))/2.e0_rt
   
   ! Read namelists
   open(newunit=untin, file=probin(1:namlen), form='formatted', status='old')
@@ -72,16 +73,17 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
   use meth_params_module, only : NVAR, URHO, UMX, UMY, UMZ, UEDEN, UEINT, UFS, UTEMP
   use prob_params_module, only: center
   
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer level, nscal
   integer lo(2), hi(2)
   integer state_l1,state_l2,state_h1,state_h2
-  double precision xlo(2), xhi(2), time, delta(2)
-  double precision state(state_l1:state_h1,state_l2:state_h2,NVAR)
+  real(rt)         xlo(2), xhi(2), time, delta(2)
+  real(rt)         state(state_l1:state_h1,state_l2:state_h2,NVAR)
 
-  double precision xcen, ycen
-  double precision dens, eint, xvel, X(nspec), temp
+  real(rt)         xcen, ycen
+  real(rt)         dens, eint, xvel, X(nspec), temp
   
   integer i,j, icen, jcen
 

--- a/Exec/hydro_tests/oddeven/Prob_3d.f90
+++ b/Exec/hydro_tests/oddeven/Prob_3d.f90
@@ -5,11 +5,12 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
   use bl_constants_module
   use bl_error_module
   
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer init, namlen
   integer name(namlen)
-  double precision problo(3), probhi(3)
+  real(rt)         problo(3), probhi(3)
 
   integer untin,i
 
@@ -29,9 +30,9 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
   ! set namelist defaults
 
   ! set center, domain extrema
-  center(1) = (problo(1)+probhi(1))/2.d0
-  center(2) = (problo(2)+probhi(2))/2.d0
-  center(3) = (problo(3)+probhi(3))/2.d0
+  center(1) = (problo(1)+probhi(1))/2.e0_rt
+  center(2) = (problo(2)+probhi(2))/2.e0_rt
+  center(3) = (problo(3)+probhi(3))/2.e0_rt
 
   ! Read namelists
   open(newunit=untin, file=probin(1:namlen), form='formatted', status='old')
@@ -74,17 +75,18 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
   use meth_params_module, only : NVAR, URHO, UMX, UMY, UMZ, UEDEN, UEINT, UFS, UTEMP
   use prob_params_module, only : center
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer level, nscal
   integer lo(3), hi(3)
   integer state_l1,state_l2,state_l3,state_h1,state_h2,state_h3
-  double precision xlo(3), xhi(3), time, delta(3)
-  double precision state(state_l1:state_h1,state_l2:state_h2, &
+  real(rt)         xlo(3), xhi(3), time, delta(3)
+  real(rt)         state(state_l1:state_h1,state_l2:state_h2, &
                          state_l3:state_h3,NVAR)
 
-  double precision xcen, ycen, zcen
-  double precision dens, eint, xvel, X(nspec), temp
+  real(rt)         xcen, ycen, zcen
+  real(rt)         dens, eint, xvel, X(nspec), temp
   integer i,j,k, icen, jcen, kcen
 
   type (eos_t) :: eos_state

--- a/Exec/hydro_tests/oddeven/probdata.f90
+++ b/Exec/hydro_tests/oddeven/probdata.f90
@@ -1,7 +1,8 @@
 module probdata_module
 
   ! odd even variables
-  double precision, save ::  p_ambient, dens_ambient, &
+  use bl_fort_module, only : rt => c_real
+  real(rt)        , save ::  p_ambient, dens_ambient, &
                              dens_pert_factor, vel_pert
       
 end module probdata_module

--- a/Exec/hydro_tests/reacting_bubble/Prob_2d.f90
+++ b/Exec/hydro_tests/reacting_bubble/Prob_2d.f90
@@ -4,11 +4,12 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
   use model_parser_module
   use bl_error_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer init, namlen
   integer name(namlen)
-  double precision problo(2), probhi(2)
+  real(rt)         problo(2), probhi(2)
 
   integer untin,i
 
@@ -74,25 +75,26 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
   use network, only: nspec
   use model_parser_module
   
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer level, nscal
   integer lo(2), hi(2)
   integer state_l1,state_l2,state_h1,state_h2
-  double precision xlo(2), xhi(2), time, delta(2)
-  double precision state(state_l1:state_h1,state_l2:state_h2,NVAR)
+  real(rt)         xlo(2), xhi(2), time, delta(2)
+  real(rt)         state(state_l1:state_h1,state_l2:state_h2,NVAR)
 
-  double precision dist,x,y
+  real(rt)         dist,x,y
   integer i,j,n
 
-  double precision t0,x1,y1,r1,x2,y2,r2,x3,y3,r3,x4,y4,r4,temp
+  real(rt)         t0,x1,y1,r1,x2,y2,r2,x3,y3,r3,x4,y4,r4,temp
 
-  double precision temppres(state_l1:state_h1,state_l2:state_h2)
+  real(rt)         temppres(state_l1:state_h1,state_l2:state_h2)
 
   type (eos_t) :: eos_state
 
   do j = lo(2), hi(2)
-     y = xlo(2) + delta(2)*(float(j-lo(2)) + 0.5d0)
+     y = xlo(2) + delta(2)*(float(j-lo(2)) + 0.5e0_rt)
      do i = lo(1), hi(1)
 
         state(i,j,URHO)  = interpolate(y,npts_model,model_r, &
@@ -134,32 +136,32 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
   enddo
 
   ! Initial velocities = 0
-  state(:,:,UMX:UMZ) = 0.d0
+  state(:,:,UMX:UMZ) = 0.e0_rt
 
   ! Now add the perturbation
   do j = lo(2), hi(2)
-     y = xlo(2) + delta(2)*(float(j-lo(2)) + 0.5d0)
+     y = xlo(2) + delta(2)*(float(j-lo(2)) + 0.5e0_rt)
      do i = lo(1), hi(1)
-        x = xlo(1) + delta(1)*(float(i-lo(1)) + 0.5d0)
+        x = xlo(1) + delta(1)*(float(i-lo(1)) + 0.5e0_rt)
 
         t0 = state(i,j,UTEMP)
 
-        x1 = 5.0d7
-        y1 = 6.5d7
-        r1 = sqrt( (x-x1)**2 +(y-y1)**2 ) / (2.5d6*pert_rad_factor)
+        x1 = 5.0e7_rt
+        y1 = 6.5e7_rt
+        r1 = sqrt( (x-x1)**2 +(y-y1)**2 ) / (2.5e6_rt*pert_rad_factor)
 
-        x2 = 1.2d8
-        y2 = 8.5d7
-        r2 = sqrt( (x-x2)**2 +(y-y2)**2 ) / (2.5d6*pert_rad_factor)
+        x2 = 1.2e8_rt
+        y2 = 8.5e7_rt
+        r2 = sqrt( (x-x2)**2 +(y-y2)**2 ) / (2.5e6_rt*pert_rad_factor)
 
-        x3 = 2.0d8
-        y3 = 7.5d7
-        r3 = sqrt( (x-x3)**2 +(y-y3)**2 ) / (2.5d6*pert_rad_factor)
+        x3 = 2.0e8_rt
+        y3 = 7.5e7_rt
+        r3 = sqrt( (x-x3)**2 +(y-y3)**2 ) / (2.5e6_rt*pert_rad_factor)
 
-        state(i,j,UTEMP) = t0 * (1.d0 + pert_temp_factor* &
-             (0.150d0 * (1.d0 + tanh(2.d0-r1)) + &
-              0.300d0 * (1.d0 + tanh(2.d0-r2)) + &
-              0.225d0 * (1.d0 + tanh(2.d0-r3))))
+        state(i,j,UTEMP) = t0 * (1.e0_rt + pert_temp_factor* &
+             (0.150e0_rt * (1.e0_rt + tanh(2.e0_rt-r1)) + &
+              0.300e0_rt * (1.e0_rt + tanh(2.e0_rt-r2)) + &
+              0.225e0_rt * (1.e0_rt + tanh(2.e0_rt-r3))))
 
         state(i,j,UEINT) = state(i,j,UEINT) / state(i,j,URHO)
 

--- a/Exec/hydro_tests/reacting_bubble/bc_fill_2d.F90
+++ b/Exec/hydro_tests/reacting_bubble/bc_fill_2d.F90
@@ -1,5 +1,6 @@
 module bc_fill_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   public
@@ -16,6 +17,7 @@ contains
     use network, only: nspec
     use model_parser_module
 
+    use bl_fort_module, only : rt => c_real
     implicit none
     
     include 'bc_types.fi'
@@ -23,20 +25,20 @@ contains
     integer adv_l1,adv_l2,adv_h1,adv_h2
     integer bc(2,2,*)
     integer domlo(2), domhi(2)
-    double precision delta(2), xlo(2), time
-    double precision adv(adv_l1:adv_h1,adv_l2:adv_h2,NVAR)
+    real(rt)         delta(2), xlo(2), time
+    real(rt)         adv(adv_l1:adv_h1,adv_l2:adv_h2,NVAR)
 
     integer i,j,n,iter,MAX_ITER,l
-    double precision y
-    double precision pres_above,pres_below,pres_want,pres_zone
-    double precision drho,dpdr,temperature,eint,pressure,species(3),density
-    double precision TOL
+    real(rt)         y
+    real(rt)         pres_above,pres_below,pres_want,pres_zone
+    real(rt)         drho,dpdr,temperature,eint,pressure,species(3),density
+    real(rt)         TOL
     logical converged_hse
 
     type (eos_t) :: eos_state
 
     MAX_ITER = 100
-    TOL = 1.d-8
+    TOL = 1.e-8_rt
 
     do n = 1,NVAR
        call filcc(adv(adv_l1,adv_l2,n),adv_l1,adv_l2,adv_h1,adv_h2, &
@@ -49,7 +51,7 @@ contains
        if ( bc(1,1,n).eq.EXT_DIR .and. adv_l1.lt.domlo(1)) then
 
           do j=adv_l2,adv_h2
-             y = xlo(2) + delta(2)*(float(j-adv_l2) + 0.5d0)
+             y = xlo(2) + delta(2)*(float(j-adv_l2) + 0.5e0_rt)
              do i=domlo(1)-1,adv_l1,-1
 
                 ! set all the variables even though we're testing on URHO
@@ -95,7 +97,7 @@ contains
        if ( bc(1,2,n).eq.EXT_DIR .and. adv_h1.gt.domhi(1)) then
 
           do j=adv_l2,adv_h2
-             y = xlo(2) + delta(2)*(float(j-adv_l2) + 0.5d0)
+             y = xlo(2) + delta(2)*(float(j-adv_l2) + 0.5e0_rt)
              do i=domhi(1)+1,adv_h1
 
                 ! set all the variables even though we're testing on URHO
@@ -141,7 +143,7 @@ contains
        if ( bc(2,1,n).eq.EXT_DIR .and. adv_l2.lt.domlo(2)) then
           ! this do loop counts backwards since we want to work downward
           do j=domlo(2)-1,adv_l2,-1
-             y = xlo(2) + delta(2)*(float(j-adv_l2) + 0.5d0)
+             y = xlo(2) + delta(2)*(float(j-adv_l2) + 0.5e0_rt)
              do i=adv_l1,adv_h1
 
                 ! set all the variables even though we're testing on URHO
@@ -188,7 +190,7 @@ contains
        !        YHI
        if ( bc(2,2,n).eq.EXT_DIR .and. adv_h2.gt.domhi(2)) then
           do j=domhi(2)+1,adv_h2
-             y = xlo(2) + delta(2)*(float(j-adv_l2) + 0.5d0)
+             y = xlo(2) + delta(2)*(float(j-adv_l2) + 0.5e0_rt)
              do i=adv_l1,adv_h1
 
                 ! set all the variables even though we're testing on URHO
@@ -241,6 +243,7 @@ contains
     use interpolate_module
     use model_parser_module
 
+    use bl_fort_module, only : rt => c_real
     implicit none
     
     include 'bc_types.fi'
@@ -248,11 +251,11 @@ contains
     integer adv_l1,adv_l2,adv_h1,adv_h2
     integer bc(2,2,*)
     integer domlo(2), domhi(2)
-    double precision delta(2), xlo(2), time
-    double precision adv(adv_l1:adv_h1,adv_l2:adv_h2)
+    real(rt)         delta(2), xlo(2), time
+    real(rt)         adv(adv_l1:adv_h1,adv_l2:adv_h2)
 
     integer i,j
-    double precision y
+    real(rt)         y
 
     ! Note: this function should not be needed, technically, but is
     ! provided to filpatch because there are many times in the algorithm
@@ -265,7 +268,7 @@ contains
     !     XLO
     if ( bc(1,1,1).eq.EXT_DIR .and. adv_l1.lt.domlo(1)) then
        do j=adv_l2,adv_h2
-          y = xlo(2) + delta(2)*(float(j-adv_l2) + 0.5d0)
+          y = xlo(2) + delta(2)*(float(j-adv_l2) + 0.5e0_rt)
           do i=adv_l1,domlo(1)-1
              adv(i,j) = interpolate(y,npts_model,model_r, &
                   model_state(:,idens_model))
@@ -276,7 +279,7 @@ contains
     !     XHI
     if ( bc(1,2,1).eq.EXT_DIR .and. adv_h1.gt.domhi(1)) then
        do j=adv_l2,adv_h2
-          y = xlo(2) + delta(2)*(float(j-adv_l2) + 0.5d0)
+          y = xlo(2) + delta(2)*(float(j-adv_l2) + 0.5e0_rt)
           do i=domhi(1)+1,adv_h1
              adv(i,j) = interpolate(y,npts_model,model_r, &
                   model_state(:,idens_model))
@@ -287,7 +290,7 @@ contains
     !     YLO
     if ( bc(2,1,1).eq.EXT_DIR .and. adv_l2.lt.domlo(2)) then
        do j=adv_l2,domlo(2)-1
-          y = xlo(2) + delta(2)*(float(j-adv_l2)+ 0.5d0)
+          y = xlo(2) + delta(2)*(float(j-adv_l2)+ 0.5e0_rt)
           do i=adv_l1,adv_h1
              adv(i,j) = interpolate(y,npts_model,model_r, &
                   model_state(:,idens_model))
@@ -298,7 +301,7 @@ contains
     !     YHI
     if ( bc(2,2,1).eq.EXT_DIR .and. adv_h2.gt.domhi(2)) then
        do j=domhi(2)+1,adv_h2
-          y = xlo(2) + delta(2)*(float(j-adv_l2)+ 0.5d0)
+          y = xlo(2) + delta(2)*(float(j-adv_l2)+ 0.5e0_rt)
           do i=adv_l1,adv_h1
              adv(i,j) = interpolate(y,npts_model,model_r, &
                   model_state(:,idens_model))
@@ -315,6 +318,7 @@ contains
 
     use probdata_module
     
+    use bl_fort_module, only : rt => c_real
     implicit none
     
     include 'bc_types.fi'
@@ -322,8 +326,8 @@ contains
     integer :: grav_l1,grav_l2,grav_h1,grav_h2
     integer :: bc(2,2,*)
     integer :: domlo(2), domhi(2)
-    double precision delta(2), xlo(2), time
-    double precision grav(grav_l1:grav_h1,grav_l2:grav_h2)
+    real(rt)         delta(2), xlo(2), time
+    real(rt)         grav(grav_l1:grav_h1,grav_l2:grav_h2)
 
     call filcc(grav,grav_l1,grav_l2,grav_h1,grav_h2,domlo,domhi,delta,xlo,bc)
 
@@ -336,6 +340,7 @@ contains
 
     use probdata_module
     
+    use bl_fort_module, only : rt => c_real
     implicit none
     
     include 'bc_types.fi'
@@ -343,8 +348,8 @@ contains
     integer :: grav_l1,grav_l2,grav_h1,grav_h2
     integer :: bc(2,2,*)
     integer :: domlo(2), domhi(2)
-    double precision delta(2), xlo(2), time
-    double precision grav(grav_l1:grav_h1,grav_l2:grav_h2)
+    real(rt)         delta(2), xlo(2), time
+    real(rt)         grav(grav_l1:grav_h1,grav_l2:grav_h2)
 
     call filcc(grav,grav_l1,grav_l2,grav_h1,grav_h2,domlo,domhi,delta,xlo,bc)
 
@@ -357,6 +362,7 @@ contains
 
     use probdata_module
     
+    use bl_fort_module, only : rt => c_real
     implicit none
     
     include 'bc_types.fi'
@@ -364,8 +370,8 @@ contains
     integer :: grav_l1,grav_l2,grav_h1,grav_h2
     integer :: bc(2,2,*)
     integer :: domlo(2), domhi(2)
-    double precision delta(2), xlo(2), time
-    double precision grav(grav_l1:grav_h1,grav_l2:grav_h2)
+    real(rt)         delta(2), xlo(2), time
+    real(rt)         grav(grav_l1:grav_h1,grav_l2:grav_h2)
 
     call filcc(grav,grav_l1,grav_l2,grav_h1,grav_h2,domlo,domhi,delta,xlo,bc)
 
@@ -379,6 +385,7 @@ contains
 
     use probdata_module
     
+    use bl_fort_module, only : rt => c_real
     implicit none
     
     include 'bc_types.fi'
@@ -386,8 +393,8 @@ contains
     integer :: react_l1,react_l2,react_h1,react_h2
     integer :: bc(2,2,*)
     integer :: domlo(2), domhi(2)
-    double precision delta(2), xlo(2), time
-    double precision react(react_l1:react_h1,react_l2:react_h2)
+    real(rt)         delta(2), xlo(2), time
+    real(rt)         react(react_l1:react_h1,react_l2:react_h2)
 
     call filcc(react,react_l1,react_l2,react_h1,react_h2,domlo,domhi,delta,xlo,bc)
 
@@ -399,6 +406,7 @@ contains
                             phi_h1,phi_h2,domlo,domhi,delta,xlo,time,bc) &
                             bind(C, name="ca_phigravfill")
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     include 'bc_types.fi'
@@ -406,8 +414,8 @@ contains
     integer          :: phi_l1,phi_l2,phi_h1,phi_h2
     integer          :: bc(2,2,*)
     integer          :: domlo(2), domhi(2)
-    double precision :: delta(2), xlo(2), time
-    double precision :: phi(phi_l1:phi_h1,phi_l2:phi_h2)
+    real(rt)         :: delta(2), xlo(2), time
+    real(rt)         :: phi(phi_l1:phi_h1,phi_l2:phi_h2)
 
     call filcc(phi,phi_l1,phi_l2,phi_h1,phi_h2, &
                domlo,domhi,delta,xlo,bc)

--- a/Exec/hydro_tests/reacting_bubble/initdata_others.f90
+++ b/Exec/hydro_tests/reacting_bubble/initdata_others.f90
@@ -8,18 +8,19 @@ subroutine ca_initdata_maestro(lo,hi,MAESTRO_init_type, &
   use meth_params_module, only : NVAR, URHO, UMX, UMY, UEDEN, UEINT, UFS, UTEMP
   use network, only: nspec
         
+  use bl_fort_module, only : rt => c_real
   implicit none
         
   integer lo(2), hi(2), MAESTRO_init_type, level
   integer MAESTRO_npts_model
   integer state_l1,state_l2,state_h1,state_h2
-  double precision xlo(2), xhi(2), dx(2), dr
-  double precision p0(0:MAESTRO_npts_model-1)
-  double precision state(state_l1:state_h1,state_l2:state_h2,NVAR)
+  real(rt)         xlo(2), xhi(2), dx(2), dr
+  real(rt)         p0(0:MAESTRO_npts_model-1)
+  real(rt)         state(state_l1:state_h1,state_l2:state_h2,NVAR)
   
   ! local variables
-  double precision ekin
-  double precision pressure,entropy,minpres
+  real(rt)         ekin
+  real(rt)         pressure,entropy,minpres
   
   integer i,j,n
 
@@ -170,39 +171,40 @@ subroutine ca_initdata_makemodel(model,model_size,MAESTRO_npts_model, &
   use network, only: nspec
   use eos_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer model_size,MAESTRO_npts_model
-  double precision model(model_size,0:MAESTRO_npts_model-1)
-  double precision rho0   (0:MAESTRO_npts_model-1)
-  double precision tempbar(0:MAESTRO_npts_model-1)
-  double precision dx(2), dr
+  real(rt)         model(model_size,0:MAESTRO_npts_model-1)
+  real(rt)         rho0   (0:MAESTRO_npts_model-1)
+  real(rt)         tempbar(0:MAESTRO_npts_model-1)
+  real(rt)         dx(2), dr
   integer r_model_start
         
   ! local
   integer i,n,iter,comp
   integer MAX_ITER
   
-  double precision TOL
+  real(rt)         TOL
 
-  double precision pres(0:MAESTRO_npts_model-1)
-  double precision entropy_want,entropy
-  double precision dens_zone,temp_zone,xn(nspec)
+  real(rt)         pres(0:MAESTRO_npts_model-1)
+  real(rt)         entropy_want,entropy
+  real(rt)         dens_zone,temp_zone,xn(nspec)
   
   logical converged_hse,isentropic,fluff
-  double precision g_zone,low_density_cutoff,temp_fluff
+  real(rt)         g_zone,low_density_cutoff,temp_fluff
   
-  double precision p_want,pres_zone,dpt,dpd,dst,dsd,A,B,drho,dtemp
+  real(rt)         p_want,pres_zone,dpt,dpd,dst,dsd,A,B,drho,dtemp
 
   type (eos_t) eos_state
 
   MAX_ITER = 250
   TOL = 1.e-10
 
-  g_zone = -1.5d10
+  g_zone = -1.5e10_rt
 
-  low_density_cutoff = 1.d-4
-  temp_fluff = 1.d7
+  low_density_cutoff = 1.e-4_rt
+  temp_fluff = 1.e7_rt
 
   !-----------------------------------------------------------------------------
   ! put the model onto our new uniform grid
@@ -211,9 +213,9 @@ subroutine ca_initdata_makemodel(model,model_size,MAESTRO_npts_model, &
   fluff = .false.
 
   ! hard code species
-  xn(1) = 0.3d0
-  xn(2) = 0.7d0
-  xn(3) = 0.d0
+  xn(1) = 0.3e0_rt
+  xn(2) = 0.7e0_rt
+  xn(3) = 0.e0_rt
   
   eos_state % rho  = rho0(r_model_start)
   eos_state % T    = tempbar(r_model_start)
@@ -308,11 +310,11 @@ subroutine ca_initdata_makemodel(model,model_size,MAESTRO_npts_model, &
 
               drho = (A - dpt*dtemp)/(dpd - 0.5*dr*g_zone)
 
-              dens_zone = max(0.9d0*dens_zone, &
-                   min(dens_zone + drho, 1.1d0*dens_zone))
+              dens_zone = max(0.9e0_rt*dens_zone, &
+                   min(dens_zone + drho, 1.1e0_rt*dens_zone))
 
-              temp_zone = max(0.9d0*temp_zone, &
-                   min(temp_zone + dtemp, 1.1d0*temp_zone))
+              temp_zone = max(0.9e0_rt*temp_zone, &
+                   min(temp_zone + dtemp, 1.1e0_rt*temp_zone))
 
 
               ! check if the density falls below our minimum cut-off -- 
@@ -431,18 +433,19 @@ subroutine ca_initdata_overwrite(lo,hi, &
   use network, only: nspec
   use eos_module
   
+  use bl_fort_module, only : rt => c_real
   implicit none
   
   integer lo(2), hi(2), r_model_start
   integer model_size,MAESTRO_npts_model
   integer state_l1,state_l2,state_h1,state_h2
-  double precision state(state_l1:state_h1,state_l2:state_h2,NVAR)
-  double precision model(model_size,0:MAESTRO_npts_model-1)
-  double precision dx(2), xlo(2), xhi(2), dr
+  real(rt)         state(state_l1:state_h1,state_l2:state_h2,NVAR)
+  real(rt)         model(model_size,0:MAESTRO_npts_model-1)
+  real(rt)         dx(2), xlo(2), xhi(2), dr
   
   ! local
   integer i,j,n
-  double precision ekin,radius,temppres
+  real(rt)         ekin,radius,temppres
 
   type (eos_t) eos_state
   
@@ -453,14 +456,14 @@ subroutine ca_initdata_overwrite(lo,hi, &
         do i=lo(1),hi(1)
            ! need to zero momentum since we're going to be
            ! lowering the density by many orders of magnitude
-           state(i,j,UMX:UMY) = 0.d0
+           state(i,j,UMX:UMY) = 0.e0_rt
            
            state(i,j,URHO) = model(1,j)
            state(i,j,UTEMP) = model(2,j)
            
-           state(i,j,UFS  ) = 0.3d0
-           state(i,j,UFS+1) = 0.7d0
-           state(i,j,UFS+2) = 0.0d0
+           state(i,j,UFS  ) = 0.3e0_rt
+           state(i,j,UFS+1) = 0.7e0_rt
+           state(i,j,UFS+2) = 0.0e0_rt
            
            ! compute e
            eos_state % rho = state(i,j,URHO)

--- a/Exec/hydro_tests/reacting_bubble/probdata.f90
+++ b/Exec/hydro_tests/reacting_bubble/probdata.f90
@@ -1,7 +1,8 @@
 module probdata_module
 
+  use bl_fort_module, only : rt => c_real
   character(len=80), save :: model_name
 
-  double precision, save :: pert_temp_factor, pert_rad_factor
+  real(rt)        , save :: pert_temp_factor, pert_rad_factor
 
 end module probdata_module

--- a/Exec/hydro_tests/reacting_bubble/problem_derive_nd.f90
+++ b/Exec/hydro_tests/reacting_bubble/problem_derive_nd.f90
@@ -11,26 +11,27 @@ subroutine ca_derpi(p,p_lo,p_hi,ncomp_p, &
   use interpolate_module
   use model_parser_module
   
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer          :: p_lo(3),p_hi(3),ncomp_p
   integer          :: u_lo(3),u_hi(3),ncomp_u
   integer          :: lo(3), hi(3), domlo(3), domhi(3)
-  double precision :: p(p_lo(1):p_hi(1),p_lo(2):p_hi(2),p_lo(3):p_hi(3),ncomp_p)
-  double precision :: u(u_lo(1):u_hi(1),u_lo(2):u_hi(2),u_lo(3):u_hi(3),ncomp_u)
-  double precision :: dx(3), xlo(3), time, dt
+  real(rt)         :: p(p_lo(1):p_hi(1),p_lo(2):p_hi(2),p_lo(3):p_hi(3),ncomp_p)
+  real(rt)         :: u(u_lo(1):u_hi(1),u_lo(2):u_hi(2),u_lo(3):u_hi(3),ncomp_u)
+  real(rt)         :: dx(3), xlo(3), time, dt
   integer          :: bc(3,2,ncomp_u), level, grid_no
 
   ! local
   integer :: i,j,k
 
-  double precision :: y,pres,pres_local
+  real(rt)         :: y,pres,pres_local
 
   type (eos_t) :: eos_state
 
   do k=lo(3),hi(3)  
      do j=lo(2),hi(2)
-        y = xlo(2) + dx(2)*(float(j-lo(2)) + 0.5d0)
+        y = xlo(2) + dx(2)*(float(j-lo(2)) + 0.5e0_rt)
         pres = interpolate(y,npts_model,model_r, &
                            model_state(:,ipres_model))
 
@@ -68,26 +69,27 @@ subroutine ca_derpioverp0(p,p_lo,p_hi,ncomp_p, &
   use interpolate_module
   use model_parser_module
   
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer          :: p_lo(3),p_hi(3),ncomp_p
   integer          :: u_lo(3),u_hi(3),ncomp_u
   integer          :: lo(3), hi(3), domlo(3), domhi(3)
-  double precision :: p(p_lo(1):p_hi(1),p_lo(2):p_hi(2),p_lo(3):p_hi(3),ncomp_p)
-  double precision :: u(u_lo(1):u_hi(1),u_lo(2):u_hi(2),u_lo(3):u_hi(3),ncomp_u)
-  double precision :: dx(3), xlo(3), time, dt
+  real(rt)         :: p(p_lo(1):p_hi(1),p_lo(2):p_hi(2),p_lo(3):p_hi(3),ncomp_p)
+  real(rt)         :: u(u_lo(1):u_hi(1),u_lo(2):u_hi(2),u_lo(3):u_hi(3),ncomp_u)
+  real(rt)         :: dx(3), xlo(3), time, dt
   integer          :: bc(3,2,ncomp_u), level, grid_no
 
   ! local
   integer :: i,j,k
 
-  double precision :: y,pres,pres_local
+  real(rt)         :: y,pres,pres_local
 
   type (eos_t) :: eos_state
 
   do k=lo(3),hi(3)
      do j=lo(2),hi(2)
-        y = xlo(2) + dx(2)*(float(j-lo(2)) + 0.5d0)
+        y = xlo(2) + dx(2)*(float(j-lo(2)) + 0.5e0_rt)
         pres = interpolate(y,npts_model,model_r, &
                            model_state(:,ipres_model))
 
@@ -125,24 +127,25 @@ subroutine ca_derrhopert(p,p_lo,p_hi,ncomp_p, &
   use interpolate_module
   use model_parser_module
   
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer          :: p_lo(3),p_hi(3),ncomp_p
   integer          :: u_lo(3),u_hi(3),ncomp_u
   integer          :: lo(3), hi(3), domlo(3), domhi(3)
-  double precision :: p(p_lo(1):p_hi(1),p_lo(2):p_hi(2),p_lo(3):p_hi(3),ncomp_p)
-  double precision :: u(u_lo(1):u_hi(1),u_lo(2):u_hi(2),u_lo(3):u_hi(3),ncomp_u)
-  double precision :: dx(3), xlo(3), time, dt
+  real(rt)         :: p(p_lo(1):p_hi(1),p_lo(2):p_hi(2),p_lo(3):p_hi(3),ncomp_p)
+  real(rt)         :: u(u_lo(1):u_hi(1),u_lo(2):u_hi(2),u_lo(3):u_hi(3),ncomp_u)
+  real(rt)         :: dx(3), xlo(3), time, dt
   integer          :: bc(3,2,ncomp_u), level, grid_no
 
   ! local
   integer :: i,j,k
 
-  double precision :: y,dens
+  real(rt)         :: y,dens
 
   do k=lo(3),hi(3)
      do j=lo(2),hi(2)
-        y = xlo(2) + dx(2)*(float(j-lo(2)) + 0.5d0)
+        y = xlo(2) + dx(2)*(float(j-lo(2)) + 0.5e0_rt)
 
         dens = interpolate(y,npts_model,model_r, &
                            model_state(:,idens_model))
@@ -171,24 +174,25 @@ subroutine ca_dertpert(p,p_lo,p_hi,ncomp_p, &
   use interpolate_module
   use model_parser_module
   
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer          :: p_lo(3),p_hi(3),ncomp_p
   integer          :: u_lo(3),u_hi(3),ncomp_u
   integer          :: lo(3), hi(3), domlo(3), domhi(3)
-  double precision :: p(p_lo(1):p_hi(1),p_lo(2):p_hi(2),p_lo(3):p_hi(3),ncomp_p)
-  double precision :: u(u_lo(1):u_hi(1),u_lo(2):u_hi(2),u_lo(3):u_hi(3),ncomp_u)
-  double precision :: dx(3), xlo(3), time, dt
+  real(rt)         :: p(p_lo(1):p_hi(1),p_lo(2):p_hi(2),p_lo(3):p_hi(3),ncomp_p)
+  real(rt)         :: u(u_lo(1):u_hi(1),u_lo(2):u_hi(2),u_lo(3):u_hi(3),ncomp_u)
+  real(rt)         :: dx(3), xlo(3), time, dt
   integer          :: bc(3,2,ncomp_u), level, grid_no
 
   ! local
   integer :: i,j,k
 
-  double precision :: y,temp
+  real(rt)         :: y,temp
 
   do k=lo(3),hi(3)
      do j=lo(2),hi(2)
-        y = xlo(2) + dx(2)*(float(j-lo(2)) + 0.5d0)
+        y = xlo(2) + dx(2)*(float(j-lo(2)) + 0.5e0_rt)
 
         temp = interpolate(y,npts_model,model_r, &
                            model_state(:,itemp_model))

--- a/Exec/hydro_tests/riemann_test_zone/Prob_2d.f90
+++ b/Exec/hydro_tests/riemann_test_zone/Prob_2d.f90
@@ -6,16 +6,17 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
   use riemann_module
   use meth_params_module
   
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer :: init, namlen
   integer :: name(namlen)
-  double precision :: problo(2), probhi(2)
+  real(rt)         :: problo(2), probhi(2)
 
-  double precision, allocatable :: ql(:,:,:), qr(:,:,:)
-  double precision, allocatable :: gamcl(:,:), gamcr(:,:)
-  double precision, allocatable :: cav(:,:), smallc(:,:)
-  double precision, allocatable :: uflx(:,:,:), qint(:,:,:)
+  real(rt)        , allocatable :: ql(:,:,:), qr(:,:,:)
+  real(rt)        , allocatable :: gamcl(:,:), gamcr(:,:)
+  real(rt)        , allocatable :: cav(:,:), smallc(:,:)
+  real(rt)        , allocatable :: uflx(:,:,:), qint(:,:,:)
 
   integer :: ilo, ihi, jlo, jhi
   integer :: idir
@@ -51,10 +52,10 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
   u_r = 1.0
   p_r = 1.0
   re_r = 1.0
-  gc_r = 4.0d0/3.0d0
+  gc_r = 4.0e0_rt/3.0e0_rt
   
   cav_s = 1.0
-  smallc_s = 1.d-10
+  smallc_s = 1.e-10_rt
   
   open(newunit=untin, file=probin(1:namlen), form='formatted', status='old')
   read(untin, fortin)
@@ -158,13 +159,14 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
   use bl_constants_module, only: M_PI, FOUR3RD
   use meth_params_module , only: NVAR, URHO, UMX, UMY, UEDEN, UEINT, UFS
   use prob_params_module, only : center
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer :: level, nscal
   integer :: lo(2), hi(2)
   integer :: state_l1,state_l2,state_h1,state_h2
-  double precision :: xlo(2), xhi(2), time, delta(2)
-  double precision :: state(state_l1:state_h1,state_l2:state_h2,NVAR)
+  real(rt)         :: xlo(2), xhi(2), time, delta(2)
+  real(rt)         :: state(state_l1:state_h1,state_l2:state_h2,NVAR)
   
 
 end subroutine ca_initdata

--- a/Exec/hydro_tests/riemann_test_zone/probdata.f90
+++ b/Exec/hydro_tests/riemann_test_zone/probdata.f90
@@ -1,7 +1,8 @@
 module probdata_module
 
-  double precision, save ::  rho_l, u_l, p_l, re_l, gc_l
-  double precision, save ::  rho_r, u_r, p_r, re_r, gc_r
-  double precision, save ::  cav_s, smallc_s
+  use bl_fort_module, only : rt => c_real
+  real(rt)        , save ::  rho_l, u_l, p_l, re_l, gc_l
+  real(rt)        , save ::  rho_r, u_r, p_r, re_r, gc_r
+  real(rt)        , save ::  cav_s, smallc_s
 
 end module probdata_module

--- a/Exec/hydro_tests/rotating_torus/Prob_nd.F90
+++ b/Exec/hydro_tests/rotating_torus/Prob_nd.F90
@@ -8,11 +8,12 @@ subroutine probinit(init,name,namlen,problo,probhi)
   use meth_params_module, only: point_mass
   use rotation_frequency_module, only: get_omega
   
+  use bl_fort_module, only : rt => c_real
   implicit none 
 
   integer :: init,namlen,untin,i
   integer :: name(namlen)
-  double precision :: problo(3), probhi(3)
+  real(rt)         :: problo(3), probhi(3)
   
   namelist /fortin/ inner_radius, outer_radius, density_maximum_radius, ambient_density
 
@@ -20,7 +21,7 @@ subroutine probinit(init,name,namlen,problo,probhi)
   integer, parameter :: maxlen = 127
   character :: probin*(maxlen)
 
-  double precision :: omega(3)
+  real(rt)         :: omega(3)
   
   do i = 1, namlen
      probin(i:i) = char(name(i))
@@ -67,22 +68,23 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
   use prob_params_module, only: center
   use castro_util_module, only: position
   
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer          :: level, nscal
   integer          :: lo(3), hi(3)
   integer          :: state_lo(3), state_hi(3)
-  double precision :: state(state_lo(1):state_hi(1),state_lo(2):state_hi(2),state_lo(3):state_hi(3),NVAR)
-  double precision :: time, dx(3)
-  double precision :: xlo(3), xhi(3)
+  real(rt)         :: state(state_lo(1):state_hi(1),state_lo(2):state_hi(2),state_lo(3):state_hi(3),NVAR)
+  real(rt)         :: time, dx(3)
+  real(rt)         :: xlo(3), xhi(3)
   
-  double precision :: loc(3), vel(3), R, Z, dist
-  double precision :: rho, rho_s, fac
+  real(rt)         :: loc(3), vel(3), R, Z, dist
+  real(rt)         :: rho, rho_s, fac
   integer          :: i, j, k
 
   type (eos_t)     :: eos_state
 
-  double precision :: omega(3)
+  real(rt)         :: omega(3)
 
   omega = get_omega(time)
 

--- a/Exec/hydro_tests/rotating_torus/probdata.f90
+++ b/Exec/hydro_tests/rotating_torus/probdata.f90
@@ -1,13 +1,14 @@
 module probdata_module
 
-  double precision, save :: inner_radius = 0.75d0
-  double precision, save :: outer_radius = 1.50d0
+  use bl_fort_module, only : rt => c_real
+  real(rt)        , save :: inner_radius = 0.75e0_rt
+  real(rt)        , save :: outer_radius = 1.50e0_rt
 
-  double precision, save :: density_maximum_radius
+  real(rt)        , save :: density_maximum_radius
 
-  double precision, save :: torus_width
-  double precision, save :: torus_center
+  real(rt)        , save :: torus_width
+  real(rt)        , save :: torus_center
 
-  double precision, save :: ambient_density = 1.0d-8
+  real(rt)        , save :: ambient_density = 1.0e-8_rt
   
 end module probdata_module

--- a/Exec/hydro_tests/rotating_torus/problem_tagging_nd.F90
+++ b/Exec/hydro_tests/rotating_torus/problem_tagging_nd.F90
@@ -12,20 +12,21 @@ subroutine set_problem_tags(tag,tag_lo,tag_hi, &
   use castro_util_module, only: position
   use probdata_module, only: torus_center, torus_width
   
+  use bl_fort_module, only : rt => c_real
   implicit none
   
   integer          :: lo(3),hi(3)
   integer          :: state_lo(3),state_hi(3)
   integer          :: tag_lo(3),tag_hi(3)
-  double precision :: state(state_lo(1):state_hi(1), &
+  real(rt)         :: state(state_lo(1):state_hi(1), &
                             state_lo(2):state_hi(2), &
                             state_lo(3):state_hi(3),NVAR)
   integer          :: tag(tag_lo(1):tag_hi(1),tag_lo(2):tag_hi(2),tag_lo(3):tag_hi(3))
-  double precision :: problo(3),dx(3),time
+  real(rt)         :: problo(3),dx(3),time
   integer          :: level,set,clear
 
   integer :: i, j, k
-  double precision :: loc(3), R, Z
+  real(rt)         :: loc(3), R, Z
   
   do k = lo(3), hi(3)
      do j = lo(2), hi(2)

--- a/Exec/hydro_tests/symmetry/Prob_1d.f90
+++ b/Exec/hydro_tests/symmetry/Prob_1d.f90
@@ -5,11 +5,12 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
   use prob_params_module, only : center
   use bl_error_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer :: init, namlen
   integer :: name(namlen)
-  double precision :: problo(1), probhi(1)
+  real(rt)         :: problo(1), probhi(1)
 
   integer :: untin,i
 
@@ -29,10 +30,10 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
 
   ! set namelist defaults
 
-  rho_ambient = 1.d0
-  rho_peak = 2.d0
-  t_ambient = 1.d0
-  sigma = 0.1d0
+  rho_ambient = 1.e0_rt
+  rho_peak = 2.e0_rt
+  t_ambient = 1.e0_rt
+  sigma = 0.1e0_rt
 
   ! Read namelists
   open(newunit=untin, file=probin(1:namlen), &
@@ -77,15 +78,16 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
   use meth_params_module , only: NVAR, URHO, UMX, UMZ, UEDEN, UEINT, UFS, UTEMP
   use prob_params_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer :: level, nscal
   integer :: lo(1), hi(1)
   integer :: state_l1,state_h1
-  double precision :: xlo(1), xhi(1), time, delta(1)
-  double precision :: state(state_l1:state_h1,NVAR)
+  real(rt)         :: xlo(1), xhi(1), time, delta(1)
+  real(rt)         :: state(state_l1:state_h1,NVAR)
 
-  double precision :: xx
+  real(rt)         :: xx
 
   integer :: i
   type(eos_t) :: eos_state

--- a/Exec/hydro_tests/symmetry/Prob_2d.f90
+++ b/Exec/hydro_tests/symmetry/Prob_2d.f90
@@ -5,11 +5,12 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
   use prob_params_module, only: center
   use bl_error_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer :: init, namlen
   integer :: name(namlen)
-  double precision :: problo(2), probhi(2)
+  real(rt)         :: problo(2), probhi(2)
 
   integer :: untin,i
 
@@ -29,10 +30,10 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
 
   ! Set namelist defaults
 
-  rho_ambient = 1.d0
-  rho_peak = 2.d0
-  t_ambient = 1.d0
-  sigma = 0.1d0
+  rho_ambient = 1.e0_rt
+  rho_peak = 2.e0_rt
+  t_ambient = 1.e0_rt
+  sigma = 0.1e0_rt
 
   !     Read namelists
   open(newunit=untin, file=probin(1:namlen), &
@@ -79,15 +80,16 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
   use meth_params_module , only: NVAR, URHO, UMX, UMZ, UEDEN, UEINT, UFS, UTEMP
   use prob_params_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer :: level, nscal
   integer :: lo(2), hi(2)
   integer :: state_l1,state_l2,state_h1,state_h2
-  double precision :: xlo(2), xhi(2), time, delta(2)
-  double precision :: state(state_l1:state_h1,state_l2:state_h2,NVAR)
+  real(rt)         :: xlo(2), xhi(2), time, delta(2)
+  real(rt)         :: state(state_l1:state_h1,state_l2:state_h2,NVAR)
 
-  double precision :: xx, yy
+  real(rt)         :: xx, yy
 
   integer :: i, j
   type(eos_t) :: eos_state

--- a/Exec/hydro_tests/symmetry/Prob_3d.f90
+++ b/Exec/hydro_tests/symmetry/Prob_3d.f90
@@ -5,11 +5,12 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
   use prob_params_module, only : center
   use bl_error_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer :: init, namlen
   integer :: name(namlen)
-  double precision :: problo(3), probhi(3)
+  real(rt)         :: problo(3), probhi(3)
 
   integer :: untin,i
 
@@ -29,10 +30,10 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
 
   ! set namelist defaults
 
-  rho_ambient = 1.d0
-  rho_peak = 2.d0
-  t_ambient = 1.d0
-  sigma = 0.1d0
+  rho_ambient = 1.e0_rt
+  rho_peak = 2.e0_rt
+  t_ambient = 1.e0_rt
+  sigma = 0.1e0_rt
 
   ! Read namelists
   open(newunit=untin, file=probin(1:namlen), &
@@ -79,17 +80,18 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
   use meth_params_module , only: NVAR, URHO, UMX, UMZ, UEDEN, UEINT, UFS, UTEMP
   use prob_params_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer :: level, nscal
   integer :: lo(3), hi(3)
   integer :: state_l1,state_l2,state_l3,state_h1,state_h2,state_h3
-  double precision :: xlo(3), xhi(3), time, delta(3)
-  double precision :: state(state_l1:state_h1, &
+  real(rt)         :: xlo(3), xhi(3), time, delta(3)
+  real(rt)         :: state(state_l1:state_h1, &
                             state_l2:state_h2, &
                             state_l3:state_h3,NVAR)
 
-  double precision :: xx, yy, zz
+  real(rt)         :: xx, yy, zz
 
   integer :: i, j, k
 

--- a/Exec/hydro_tests/symmetry/probdata.f90
+++ b/Exec/hydro_tests/symmetry/probdata.f90
@@ -1,5 +1,6 @@
 module probdata_module
 
-  double precision, save ::  rho_ambient, rho_peak, t_ambient, sigma
+  use bl_fort_module, only : rt => c_real
+  real(rt)        , save ::  rho_ambient, rho_peak, t_ambient, sigma
 
 end module probdata_module

--- a/Exec/hydro_tests/test_convect/Prob_2d.f90
+++ b/Exec/hydro_tests/test_convect/Prob_2d.f90
@@ -5,13 +5,14 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
   use model_parser_module
   use bl_error_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer init, namlen
   integer name(namlen)
-  double precision problo(2), probhi(2)
+  real(rt)         problo(2), probhi(2)
 
-  double precision offset
+  real(rt)         offset
   integer untin,i
 
   namelist /fortin/ model_name, apply_vel_field, &
@@ -34,9 +35,9 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
 
   ! Namelist defaults
   apply_vel_field = .false.
-  velpert_scale = 1.0d2
-  velpert_amplitude = 1.0d2
-  velpert_height_loc = 6.5d3
+  velpert_scale = 1.0e2_rt
+  velpert_amplitude = 1.0e2_rt
+  velpert_height_loc = 6.5e3_rt
   num_vortices = 1
   interp_BC = .false.
   zero_vels = .false.
@@ -64,7 +65,7 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
   allocate(xloc_vortices(num_vortices))
 
   do i = 1, num_vortices
-     xloc_vortices(i) = (dble(i-1) + 0.5d0) * offset + problo(1)
+     xloc_vortices(i) = (dble(i-1) + 0.5e0_rt) * offset + problo(1)
   enddo
 
 end subroutine PROBINIT
@@ -102,23 +103,24 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
   use network, only: nspec
   use model_parser_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
         
   integer level, nscal
   integer lo(2), hi(2)
   integer state_l1,state_l2,state_h1,state_h2
-  double precision xlo(2), xhi(2), time, delta(2)
-  double precision state(state_l1:state_h1,state_l2:state_h2,NVAR)
+  real(rt)         xlo(2), xhi(2), time, delta(2)
+  real(rt)         state(state_l1:state_h1,state_l2:state_h2,NVAR)
   
-  double precision xdist,ydist,x,y,r,upert(2)
+  real(rt)         xdist,ydist,x,y,r,upert(2)
   integer i,j,n,vortex
 
-  double precision temppres(state_l1:state_h1,state_l2:state_h2)
+  real(rt)         temppres(state_l1:state_h1,state_l2:state_h2)
 
   type (eos_t) :: eos_state
         
   do j = lo(2), hi(2)
-     y = xlo(2) + delta(2)*(dble(j-lo(2)) + 0.5d0)
+     y = xlo(2) + delta(2)*(dble(j-lo(2)) + 0.5e0_rt)
 
      do i = lo(1), hi(1)   
 
@@ -162,19 +164,19 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
   enddo
 
   ! Initial velocities = 0
-  state(:,:,UMX:UMY) = 0.d0
+  state(:,:,UMX:UMY) = 0.e0_rt
 
   ! Now add the velocity perturbation
   if (apply_vel_field) then
 
      do j = lo(2), hi(2)
-        y = xlo(2) + delta(2)*(dble(j-lo(2)) + 0.5d0)
+        y = xlo(2) + delta(2)*(dble(j-lo(2)) + 0.5e0_rt)
         ydist = y - velpert_height_loc
 
         do i = lo(1), hi(1)
-           x = xlo(1) + delta(1)*(dble(i-lo(1)) + 0.5d0)
+           x = xlo(1) + delta(1)*(dble(i-lo(1)) + 0.5e0_rt)
 
-           upert = 0.d0
+           upert = 0.e0_rt
 
            ! loop over each vortex
            do vortex = 1, num_vortices
@@ -184,12 +186,12 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
               r = sqrt(xdist**2 + ydist**2)
 
               upert(1) = upert(1) - (ydist/velpert_scale) * &
-                   velpert_amplitude * exp( -r**2/(2.d0*velpert_scale**2)) &
-                   * (-1.d0)**vortex
+                   velpert_amplitude * exp( -r**2/(2.e0_rt*velpert_scale**2)) &
+                   * (-1.e0_rt)**vortex
 
               upert(2) = upert(2) + (xdist/velpert_scale) * &
-                   velpert_amplitude * exp(-r**2/(2.d0*velpert_scale**2)) &
-                   * (-1.d0)**vortex
+                   velpert_amplitude * exp(-r**2/(2.e0_rt*velpert_scale**2)) &
+                   * (-1.e0_rt)**vortex
            enddo
 
            state(i,j,UMX) = state(i,j,URHO) * upert(1)

--- a/Exec/hydro_tests/test_convect/bc_fill_2d.F90
+++ b/Exec/hydro_tests/test_convect/bc_fill_2d.F90
@@ -1,5 +1,6 @@
 module bc_fill_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   public
@@ -17,6 +18,7 @@ contains
     use network, only: nspec
     use model_parser_module
 
+    use bl_fort_module, only : rt => c_real
     implicit none
     
     include 'bc_types.fi'
@@ -24,20 +26,20 @@ contains
     integer adv_l1,adv_l2,adv_h1,adv_h2
     integer bc(2,2,*)
     integer domlo(2), domhi(2)
-    double precision delta(2), xlo(2), time
-    double precision adv(adv_l1:adv_h1,adv_l2:adv_h2,NVAR)
+    real(rt)         delta(2), xlo(2), time
+    real(rt)         adv(adv_l1:adv_h1,adv_l2:adv_h2,NVAR)
 
     integer i,j,q,n,iter,MAX_ITER
-    double precision y
-    double precision pres_above,p_want,pres_zone, A
-    double precision drho,dpdr,temp_zone,eint,X_zone(nspec),dens_zone
-    double precision TOL
+    real(rt)         y
+    real(rt)         pres_above,p_want,pres_zone, A
+    real(rt)         drho,dpdr,temp_zone,eint,X_zone(nspec),dens_zone
+    real(rt)         TOL
     logical converged_hse
 
     type (eos_t) :: eos_state
 
     MAX_ITER = 100
-    TOL = 1.d-8
+    TOL = 1.e-8_rt
 
     do n = 1,NVAR
        call filcc(adv(adv_l1,adv_l2,n),adv_l1,adv_l2,adv_h1,adv_h2, &
@@ -67,7 +69,7 @@ contains
 
           ! this do loop counts backwards since we want to work downward
           do j=domlo(2)-1,adv_l2,-1
-             y = xlo(2) + delta(2)*(dble(j-adv_l2) + 0.5d0)
+             y = xlo(2) + delta(2)*(dble(j-adv_l2) + 0.5e0_rt)
 
              do i=adv_l1,adv_h1
 
@@ -115,7 +117,7 @@ contains
 
                          ! pressure needed from HSE
                          p_want = pres_above - &
-                              delta(2)*0.5d0*(dens_zone + adv(i,j+1,URHO))*const_grav
+                              delta(2)*0.5e0_rt*(dens_zone + adv(i,j+1,URHO))*const_grav
 
                          ! pressure from EOS
                          eos_state%rho = dens_zone
@@ -132,8 +134,8 @@ contains
                          A = p_want - pres_zone
                          drho = A/(dpdr + 0.5*delta(2)*const_grav)
 
-                         dens_zone = max(0.9_dp_t*dens_zone, &
-                              min(dens_zone + drho, 1.1_dp_t*dens_zone))
+                         dens_zone = max(0.9_rt*dens_zone, &
+                              min(dens_zone + drho, 1.1_rt*dens_zone))
 
 
                          ! convergence?
@@ -153,11 +155,11 @@ contains
                    if (zero_vels) then
 
                       ! zero normal momentum causes pi waves to pass through
-                      adv(i,j,UMY) = 0.d0
+                      adv(i,j,UMY) = 0.e0_rt
 
                       ! zero transverse momentum
-                      adv(i,j,UMX) = 0.d0
-                      adv(i,j,UMZ) = 0.d0
+                      adv(i,j,UMX) = 0.e0_rt
+                      adv(i,j,UMZ) = 0.e0_rt
                    else
 
                       ! zero gradient velocity
@@ -178,7 +180,7 @@ contains
                    adv(i,j,URHO) = dens_zone
                    adv(i,j,UEINT) = dens_zone*eint
                    adv(i,j,UEDEN) = dens_zone*eint + & 
-                        0.5d0*(adv(i,j,UMX)**2+adv(i,j,UMY)**2+adv(i,j,UMZ)**2)/dens_zone
+                        0.5e0_rt*(adv(i,j,UMX)**2+adv(i,j,UMY)**2+adv(i,j,UMZ)**2)/dens_zone
                    adv(i,j,UTEMP) = temp_zone
                    adv(i,j,UFS:UFS-1+nspec) = dens_zone*X_zone(:)
 
@@ -192,7 +194,7 @@ contains
        if ( bc(2,2,n).eq.EXT_DIR .and. adv_h2.gt.domhi(2)) then
 
           do j=domhi(2)+1,adv_h2
-             y = xlo(2) + delta(2)*(dble(j-adv_l2) + 0.5d0)
+             y = xlo(2) + delta(2)*(dble(j-adv_l2) + 0.5e0_rt)
 
              do i=adv_l1,adv_h1
 
@@ -212,11 +214,11 @@ contains
 
 
                    ! extrap normal momentum
-                   adv(i,j,UMY) = max(0.d0,adv(i,domhi(2),UMY))
+                   adv(i,j,UMY) = max(0.e0_rt,adv(i,domhi(2),UMY))
 
                    ! zero transverse momentum
-                   adv(i,j,UMX) = 0.d0
-                   adv(i,j,UMZ) = 0.d0
+                   adv(i,j,UMX) = 0.e0_rt
+                   adv(i,j,UMZ) = 0.e0_rt
 
                    eos_state%rho = dens_zone
                    eos_state%T = temp_zone
@@ -230,7 +232,7 @@ contains
                    adv(i,j,URHO) = dens_zone
                    adv(i,j,UEINT) = dens_zone*eint
                    adv(i,j,UEDEN) = dens_zone*eint + &
-                        0.5d0*(adv(i,j,UMX)**2+adv(i,j,UMY)**2+adv(i,j,UMZ)**2)/dens_zone
+                        0.5e0_rt*(adv(i,j,UMX)**2+adv(i,j,UMY)**2+adv(i,j,UMZ)**2)/dens_zone
                    adv(i,j,UTEMP) = temp_zone
                    adv(i,j,UFS:UFS-1+nspec) = dens_zone*X_zone(:)
 
@@ -255,6 +257,7 @@ contains
     use model_parser_module
     use bl_error_module
 
+    use bl_fort_module, only : rt => c_real
     implicit none
     
     include 'bc_types.fi'
@@ -262,11 +265,11 @@ contains
     integer adv_l1,adv_l2,adv_h1,adv_h2
     integer bc(2,2,*)
     integer domlo(2), domhi(2)
-    double precision delta(2), xlo(2), time
-    double precision adv(adv_l1:adv_h1,adv_l2:adv_h2)
+    real(rt)         delta(2), xlo(2), time
+    real(rt)         adv(adv_l1:adv_h1,adv_l2:adv_h2)
 
     integer i,j
-    double precision y
+    real(rt)         y
 
     ! Note: this function should not be needed, technically, but is
     ! provided to filpatch because there are many times in the algorithm
@@ -290,7 +293,7 @@ contains
     !     YLO
     if ( bc(2,1,1).eq.EXT_DIR .and. adv_l2.lt.domlo(2)) then
        do j=adv_l2,domlo(2)-1
-          y = xlo(2) + delta(2)*(dble(j-adv_l2) + 0.5d0)
+          y = xlo(2) + delta(2)*(dble(j-adv_l2) + 0.5e0_rt)
           do i=adv_l1,adv_h1
              adv(i,j) = interpolate(y,npts_model,model_r,model_state(:,idens_model))
           end do
@@ -300,7 +303,7 @@ contains
     !     YHI
     if ( bc(2,2,1).eq.EXT_DIR .and. adv_h2.gt.domhi(2)) then
        do j=domhi(2)+1,adv_h2
-          y = xlo(2) + delta(2)*(dble(j-adv_l2)+ 0.5d0)
+          y = xlo(2) + delta(2)*(dble(j-adv_l2)+ 0.5e0_rt)
           do i=adv_l1,adv_h1
              adv(i,j) = interpolate(y,npts_model,model_r,model_state(:,idens_model))
           end do
@@ -317,6 +320,7 @@ contains
 
     use probdata_module
     
+    use bl_fort_module, only : rt => c_real
     implicit none
     
     include 'bc_types.fi'
@@ -324,8 +328,8 @@ contains
     integer :: grav_l1,grav_l2,grav_h1,grav_h2
     integer :: bc(2,2,*)
     integer :: domlo(2), domhi(2)
-    double precision delta(2), xlo(2), time
-    double precision grav(grav_l1:grav_h1,grav_l2:grav_h2)
+    real(rt)         delta(2), xlo(2), time
+    real(rt)         grav(grav_l1:grav_h1,grav_l2:grav_h2)
 
     call filcc(grav,grav_l1,grav_l2,grav_h1,grav_h2,domlo,domhi,delta,xlo,bc)
 
@@ -339,6 +343,7 @@ contains
 
     use probdata_module
     
+    use bl_fort_module, only : rt => c_real
     implicit none
     
     include 'bc_types.fi'
@@ -346,8 +351,8 @@ contains
     integer :: grav_l1,grav_l2,grav_h1,grav_h2
     integer :: bc(2,2,*)
     integer :: domlo(2), domhi(2)
-    double precision delta(2), xlo(2), time
-    double precision grav(grav_l1:grav_h1,grav_l2:grav_h2)
+    real(rt)         delta(2), xlo(2), time
+    real(rt)         grav(grav_l1:grav_h1,grav_l2:grav_h2)
 
     call filcc(grav,grav_l1,grav_l2,grav_h1,grav_h2,domlo,domhi,delta,xlo,bc)
 
@@ -361,6 +366,7 @@ contains
 
     use probdata_module
     
+    use bl_fort_module, only : rt => c_real
     implicit none
     
     include 'bc_types.fi'
@@ -368,8 +374,8 @@ contains
     integer :: grav_l1,grav_l2,grav_h1,grav_h2
     integer :: bc(2,2,*)
     integer :: domlo(2), domhi(2)
-    double precision delta(2), xlo(2), time
-    double precision grav(grav_l1:grav_h1,grav_l2:grav_h2)
+    real(rt)         delta(2), xlo(2), time
+    real(rt)         grav(grav_l1:grav_h1,grav_l2:grav_h2)
 
     call filcc(grav,grav_l1,grav_l2,grav_h1,grav_h2,domlo,domhi,delta,xlo,bc)
 
@@ -383,6 +389,7 @@ contains
 
     use probdata_module
     
+    use bl_fort_module, only : rt => c_real
     implicit none
     
     include 'bc_types.fi'
@@ -390,8 +397,8 @@ contains
     integer :: react_l1,react_l2,react_h1,react_h2
     integer :: bc(2,2,*)
     integer :: domlo(2), domhi(2)
-    double precision delta(2), xlo(2), time
-    double precision react(react_l1:react_h1,react_l2:react_h2)
+    real(rt)         delta(2), xlo(2), time
+    real(rt)         react(react_l1:react_h1,react_l2:react_h2)
 
     call filcc(react,react_l1,react_l2,react_h1,react_h2,domlo,domhi,delta,xlo,bc)
 
@@ -403,6 +410,7 @@ contains
                             phi_h1,phi_h2,domlo,domhi,delta,xlo,time,bc) &
                             bind(C, name="ca_phigravfill")
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     include 'bc_types.fi'
@@ -410,8 +418,8 @@ contains
     integer          :: phi_l1,phi_l2,phi_h1,phi_h2
     integer          :: bc(2,2,*)
     integer          :: domlo(2), domhi(2)
-    double precision :: delta(2), xlo(2), time
-    double precision :: phi(phi_l1:phi_h1,phi_l2:phi_h2)
+    real(rt)         :: delta(2), xlo(2), time
+    real(rt)         :: phi(phi_l1:phi_h1,phi_l2:phi_h2)
 
     call filcc(phi,phi_l1,phi_l2,phi_h1,phi_h2, &
                domlo,domhi,delta,xlo,bc)

--- a/Exec/hydro_tests/test_convect/ext_src_2d.f90
+++ b/Exec/hydro_tests/test_convect/ext_src_2d.f90
@@ -8,21 +8,22 @@ subroutine ca_ext_src(lo,hi, &
   use meth_params_module, only : NVAR, UEDEN, UEINT, URHO, UTEMP, UFS
   use network, only: network_species_index
 
+  use bl_fort_module, only : rt => c_real
   implicit none
   integer         , intent(in   ) :: lo(2),hi(2)
   integer         , intent(in   ) :: old_state_l1,old_state_l2,old_state_h1,old_state_h2
   integer         , intent(in   ) :: new_state_l1,new_state_l2,new_state_h1,new_state_h2
   integer         , intent(in   ) :: src_l1,src_l2,src_h1,src_h2
-  real(kind=dp_t) , intent(in   ) :: old_state(old_state_l1:old_state_h1,old_state_l2:old_state_h2,NVAR)
-  real(kind=dp_t) , intent(in   ) :: new_state(new_state_l1:new_state_h1,new_state_l2:new_state_h2,NVAR)
-  real(kind=dp_t) , intent(  out) :: src(    src_l1:  src_h1,  src_l2:src_h2  ,NVAR)
-  real(kind=dp_t) , intent(in   ) :: problo(2),dx(2),time,dt
+  real(rt)        , intent(in   ) :: old_state(old_state_l1:old_state_h1,old_state_l2:old_state_h2,NVAR)
+  real(rt)        , intent(in   ) :: new_state(new_state_l1:new_state_h1,new_state_l2:new_state_h2,NVAR)
+  real(rt)        , intent(  out) :: src(    src_l1:  src_h1,  src_l2:src_h2  ,NVAR)
+  real(rt)        , intent(in   ) :: problo(2),dx(2),time,dt
 
   integer          :: i,j
-  double precision :: x,y
+  real(rt)         :: x,y
 
-  real(kind=dp_t) :: H, ey, y_layer, H_0, L_x, pi
-  real(kind=dp_t) :: H_max
+  real(rt)        :: H, ey, y_layer, H_0, L_x, pi
+  real(rt)        :: H_max
 
   integer, save :: ic12, im24, io16
 
@@ -35,27 +36,27 @@ subroutine ca_ext_src(lo,hi, &
      firstCall = .false.
   endif
 
-  src(lo(1):hi(1),lo(2):hi(2),:) = 0.d0
-  H_max = 0.d0
+  src(lo(1):hi(1),lo(2):hi(2),:) = 0.e0_rt
+  H_max = 0.e0_rt
 
-  y_layer = 1.25d8
-  L_x = 2.5d8
-  pi = 3.1415926535897932384626433d0
-  H_0 = 2.5d16
+  y_layer = 1.25e8_rt
+  L_x = 2.5e8_rt
+  pi = 3.1415926535897932384626433e0_rt
+  H_0 = 2.5e16_rt
 
   do j = lo(2),hi(2)
-      y = (dble(j)+0.5d0)*dx(2)
-      ey = exp(-(y-y_layer)*(y-y_layer)/1.d14)
+      y = (dble(j)+0.5e0_rt)*dx(2)
+      ey = exp(-(y-y_layer)*(y-y_layer)/1.e14_rt)
       do i = lo(1),hi(1)
-         x =  (dble(i)+0.5d0)*dx(1) 
+         x =  (dble(i)+0.5e0_rt)*dx(1) 
 
-         H = ey*(1.d0 + &
-                .00625_dp_t * sin( 2*pi*x/L_x) &
-              + .01875_dp_t * sin((6*pi*x/L_x) + pi/3.d0) &
-              + .01250_dp_t * sin((8*pi*x/L_x) + pi/5.d0))
+         H = ey*(1.e0_rt + &
+                .00625_rt * sin( 2*pi*x/L_x) &
+              + .01875_rt * sin((6*pi*x/L_x) + pi/3.e0_rt) &
+              + .01250_rt * sin((8*pi*x/L_x) + pi/5.e0_rt))
 
         ! Source terms
-        src(i,j,UEDEN) = new_state(i,j,URHO) * H * 2.5d16
+        src(i,j,UEDEN) = new_state(i,j,URHO) * H * 2.5e16_rt
         src(i,j,UEINT) = src(i,j,UEDEN)
 
         ! H_max = max(H_max, src(i,j,UEDEN))

--- a/Exec/hydro_tests/test_convect/probdata.f90
+++ b/Exec/hydro_tests/test_convect/probdata.f90
@@ -1,17 +1,18 @@
 module probdata_module
 
+  use bl_fort_module, only : rt => c_real
   character(len=80), save :: model_name
 
   ! Velocity perturbation
   logical         , save :: apply_vel_field
 
-  double precision, save :: velpert_scale, velpert_amplitude, velpert_height_loc
+  real(rt)        , save :: velpert_scale, velpert_amplitude, velpert_height_loc
   integer         , save :: num_vortices
 
-  double precision, allocatable, save :: xloc_vortices(:)
+  real(rt)        , allocatable, save :: xloc_vortices(:)
 
   ! Domain stuff
-  double precision, save :: center(3)
+  real(rt)        , save :: center(3)
 
   ! lower boundary
   logical         , save :: interp_BC, zero_vels

--- a/Exec/hydro_tests/toy_convect/Prob_2d.f90
+++ b/Exec/hydro_tests/toy_convect/Prob_2d.f90
@@ -5,13 +5,14 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
   use model_parser_module
   use bl_error_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer init, namlen
   integer name(namlen)
-  double precision problo(2), probhi(2)
+  real(rt)         problo(2), probhi(2)
 
-  double precision offset
+  real(rt)         offset
   integer untin,i
 
   namelist /fortin/ model_name, apply_vel_field, &
@@ -33,14 +34,14 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
 
   ! Namelist defaults
   apply_vel_field = .false.
-  velpert_scale = 1.0d2
-  velpert_amplitude = 1.0d2
-  velpert_height_loc = 6.5d3
+  velpert_scale = 1.0e2_rt
+  velpert_amplitude = 1.0e2_rt
+  velpert_height_loc = 6.5e3_rt
   num_vortices = 1
 
   ! these are used in tagging
-  H_min = 1.d-4
-  cutoff_density = 50.d0
+  H_min = 1.e-4_rt
+  cutoff_density = 50.e0_rt
 
   interp_BC = .false.
   zero_vels = .false.
@@ -68,7 +69,7 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
   allocate(xloc_vortices(num_vortices))
 
   do i = 1, num_vortices
-     xloc_vortices(i) = (dble(i-1) + 0.5d0) * offset + problo(1)
+     xloc_vortices(i) = (dble(i-1) + 0.5e0_rt) * offset + problo(1)
   enddo
 
 end subroutine PROBINIT
@@ -106,23 +107,24 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
   use network, only: nspec
   use model_parser_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer level, nscal
   integer lo(2), hi(2)
   integer state_l1,state_l2,state_h1,state_h2
-  double precision xlo(2), xhi(2), time, delta(2)
-  double precision state(state_l1:state_h1,state_l2:state_h2,NVAR)
+  real(rt)         xlo(2), xhi(2), time, delta(2)
+  real(rt)         state(state_l1:state_h1,state_l2:state_h2,NVAR)
 
-  double precision xdist,ydist,x,y,r,upert(2)
+  real(rt)         xdist,ydist,x,y,r,upert(2)
   integer i,j,n,vortex
 
-  double precision temppres(state_l1:state_h1,state_l2:state_h2)
+  real(rt)         temppres(state_l1:state_h1,state_l2:state_h2)
 
   type (eos_t) :: eos_state
 
   do j = lo(2), hi(2)
-     y = xlo(2) + delta(2)*(dble(j-lo(2)) + 0.5d0)
+     y = xlo(2) + delta(2)*(dble(j-lo(2)) + 0.5e0_rt)
 
      do i = lo(1), hi(1)
 
@@ -166,19 +168,19 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
   enddo
 
   ! Initial velocities = 0
-  state(:,:,UMX:UMZ) = 0.d0
+  state(:,:,UMX:UMZ) = 0.e0_rt
 
   ! Now add the velocity perturbation
   if (apply_vel_field) then
 
      do j = lo(2), hi(2)
-        y = xlo(2) + delta(2)*(dble(j-lo(2)) + 0.5d0)
+        y = xlo(2) + delta(2)*(dble(j-lo(2)) + 0.5e0_rt)
         ydist = y - velpert_height_loc
 
         do i = lo(1), hi(1)
-           x = xlo(1) + delta(1)*(dble(i-lo(1)) + 0.5d0)
+           x = xlo(1) + delta(1)*(dble(i-lo(1)) + 0.5e0_rt)
 
-           upert = 0.d0
+           upert = 0.e0_rt
 
            ! loop over each vortex
            do vortex = 1, num_vortices
@@ -188,12 +190,12 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
               r = sqrt(xdist**2 + ydist**2)
 
               upert(1) = upert(1) - (ydist/velpert_scale) * &
-                   velpert_amplitude * exp( -r**2/(2.d0*velpert_scale**2)) &
-                   * (-1.d0)**vortex
+                   velpert_amplitude * exp( -r**2/(2.e0_rt*velpert_scale**2)) &
+                   * (-1.e0_rt)**vortex
 
               upert(2) = upert(2) + (xdist/velpert_scale) * &
-                   velpert_amplitude * exp(-r**2/(2.d0*velpert_scale**2)) &
-                   * (-1.d0)**vortex
+                   velpert_amplitude * exp(-r**2/(2.e0_rt*velpert_scale**2)) &
+                   * (-1.e0_rt)**vortex
            enddo
 
            state(i,j,UMX) = state(i,j,URHO) * upert(1)

--- a/Exec/hydro_tests/toy_convect/bc_fill_2d.F90
+++ b/Exec/hydro_tests/toy_convect/bc_fill_2d.F90
@@ -1,5 +1,6 @@
 module bc_fill_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   public
@@ -17,6 +18,7 @@ contains
     use network, only: nspec
     use model_parser_module
 
+    use bl_fort_module, only : rt => c_real
     implicit none
     
     include 'bc_types.fi'
@@ -24,16 +26,16 @@ contains
     integer adv_l1,adv_l2,adv_h1,adv_h2
     integer bc(2,2,*)
     integer domlo(2), domhi(2)
-    double precision delta(2), xlo(2), time
-    double precision adv(adv_l1:adv_h1,adv_l2:adv_h2,NVAR)
+    real(rt)         delta(2), xlo(2), time
+    real(rt)         adv(adv_l1:adv_h1,adv_l2:adv_h2,NVAR)
 
     integer i,j,q,n,iter
-    double precision y
-    double precision pres_above,p_want,pres_zone, A
-    double precision drho,dpdr,temp_zone,eint,X_zone(nspec),dens_zone
+    real(rt)         y
+    real(rt)         pres_above,p_want,pres_zone, A
+    real(rt)         drho,dpdr,temp_zone,eint,X_zone(nspec),dens_zone
 
     integer, parameter :: MAX_ITER = 100 
-    double precision, parameter :: TOL = 1.d-8
+    real(rt)        , parameter :: TOL = 1.e-8_rt
     logical converged_hse
 
     type (eos_t) :: eos_state
@@ -66,7 +68,7 @@ contains
 
           ! this do loop counts backwards since we want to work downward
           do j=domlo(2)-1,adv_l2,-1
-             y = xlo(2) + delta(2)*(dble(j-adv_l2) + 0.5d0)
+             y = xlo(2) + delta(2)*(dble(j-adv_l2) + 0.5e0_rt)
 
              do i=adv_l1,adv_h1
 
@@ -114,7 +116,7 @@ contains
 
                          ! pressure needed from HSE
                          p_want = pres_above - &
-                              delta(2)*0.5d0*(dens_zone + adv(i,j+1,URHO))*const_grav
+                              delta(2)*0.5e0_rt*(dens_zone + adv(i,j+1,URHO))*const_grav
 
                          ! pressure from EOS
                          eos_state%rho = dens_zone
@@ -131,8 +133,8 @@ contains
                          A = p_want - pres_zone
                          drho = A/(dpdr + 0.5*delta(2)*const_grav)
 
-                         dens_zone = max(0.9_dp_t*dens_zone, &
-                              min(dens_zone + drho, 1.1_dp_t*dens_zone))
+                         dens_zone = max(0.9_rt*dens_zone, &
+                              min(dens_zone + drho, 1.1_rt*dens_zone))
 
 
                          ! convergence?
@@ -152,11 +154,11 @@ contains
                    if (zero_vels) then
 
                       ! zero normal momentum causes pi waves to pass through
-                      adv(i,j,UMY) = 0.d0
+                      adv(i,j,UMY) = 0.e0_rt
 
                       ! zero transverse momentum
-                      adv(i,j,UMX) = 0.d0
-                      adv(i,j,UMZ) = 0.d0
+                      adv(i,j,UMX) = 0.e0_rt
+                      adv(i,j,UMZ) = 0.e0_rt
                    else
 
                       ! zero gradient velocity
@@ -177,7 +179,7 @@ contains
                    adv(i,j,URHO) = dens_zone
                    adv(i,j,UEINT) = dens_zone*eint
                    adv(i,j,UEDEN) = dens_zone*eint + &
-                        0.5d0*(adv(i,j,UMX)**2+adv(i,j,UMY)**2+adv(i,j,UMZ)**2)/dens_zone
+                        0.5e0_rt*(adv(i,j,UMX)**2+adv(i,j,UMY)**2+adv(i,j,UMZ)**2)/dens_zone
                    adv(i,j,UTEMP) = temp_zone
                    adv(i,j,UFS:UFS-1+nspec) = dens_zone*X_zone(:)
 
@@ -191,7 +193,7 @@ contains
        if ( bc(2,2,n).eq.EXT_DIR .and. adv_h2.gt.domhi(2)) then
 
           do j=domhi(2)+1,adv_h2
-             y = xlo(2) + delta(2)*(dble(j-adv_l2) + 0.5d0)
+             y = xlo(2) + delta(2)*(dble(j-adv_l2) + 0.5e0_rt)
 
              do i=adv_l1,adv_h1
 
@@ -211,11 +213,11 @@ contains
 
 
                    ! extrap normal momentum
-                   adv(i,j,UMY) = max(0.d0,adv(i,domhi(2),UMY))
+                   adv(i,j,UMY) = max(0.e0_rt,adv(i,domhi(2),UMY))
 
                    ! zero transverse momentum
-                   adv(i,j,UMX) = 0.d0
-                   adv(i,j,UMZ) = 0.d0
+                   adv(i,j,UMX) = 0.e0_rt
+                   adv(i,j,UMZ) = 0.e0_rt
 
                    eos_state%rho = dens_zone
                    eos_state%T = temp_zone
@@ -229,7 +231,7 @@ contains
                    adv(i,j,URHO) = dens_zone
                    adv(i,j,UEINT) = dens_zone*eint
                    adv(i,j,UEDEN) = dens_zone*eint + &
-                        0.5d0*(adv(i,j,UMX)**2+adv(i,j,UMY)**2+adv(i,j,UMZ)**2)/dens_zone
+                        0.5e0_rt*(adv(i,j,UMX)**2+adv(i,j,UMY)**2+adv(i,j,UMZ)**2)/dens_zone
                    adv(i,j,UTEMP) = temp_zone
                    adv(i,j,UFS:UFS-1+nspec) = dens_zone*X_zone(:)
 
@@ -254,6 +256,7 @@ contains
     use model_parser_module
     use bl_error_module
 
+    use bl_fort_module, only : rt => c_real
     implicit none
     
     include 'bc_types.fi'
@@ -261,11 +264,11 @@ contains
     integer adv_l1,adv_l2,adv_h1,adv_h2
     integer bc(2,2,*)
     integer domlo(2), domhi(2)
-    double precision delta(2), xlo(2), time
-    double precision adv(adv_l1:adv_h1,adv_l2:adv_h2)
+    real(rt)         delta(2), xlo(2), time
+    real(rt)         adv(adv_l1:adv_h1,adv_l2:adv_h2)
 
     integer i,j
-    double precision y
+    real(rt)         y
 
     ! Note: this function should not be needed, technically, but is
     ! provided to filpatch because there are many times in the algorithm
@@ -289,7 +292,7 @@ contains
     !     YLO
     if ( bc(2,1,1).eq.EXT_DIR .and. adv_l2.lt.domlo(2)) then
        do j=adv_l2,domlo(2)-1
-          y = xlo(2) + delta(2)*(dble(j-adv_l2) + 0.5d0)
+          y = xlo(2) + delta(2)*(dble(j-adv_l2) + 0.5e0_rt)
           do i=adv_l1,adv_h1
              adv(i,j) = interpolate(y,npts_model,model_r,model_state(:,idens_model))
           end do
@@ -299,7 +302,7 @@ contains
     !     YHI
     if ( bc(2,2,1).eq.EXT_DIR .and. adv_h2.gt.domhi(2)) then
        do j=domhi(2)+1,adv_h2
-          y = xlo(2) + delta(2)*(dble(j-adv_l2)+ 0.5d0)
+          y = xlo(2) + delta(2)*(dble(j-adv_l2)+ 0.5e0_rt)
           do i=adv_l1,adv_h1
              adv(i,j) = interpolate(y,npts_model,model_r,model_state(:,idens_model))
           end do
@@ -316,6 +319,7 @@ contains
 
     use probdata_module
     
+    use bl_fort_module, only : rt => c_real
     implicit none
     
     include 'bc_types.fi'
@@ -323,8 +327,8 @@ contains
     integer :: grav_l1,grav_l2,grav_h1,grav_h2
     integer :: bc(2,2,*)
     integer :: domlo(2), domhi(2)
-    double precision delta(2), xlo(2), time
-    double precision grav(grav_l1:grav_h1,grav_l2:grav_h2)
+    real(rt)         delta(2), xlo(2), time
+    real(rt)         grav(grav_l1:grav_h1,grav_l2:grav_h2)
 
     call filcc(grav,grav_l1,grav_l2,grav_h1,grav_h2,domlo,domhi,delta,xlo,bc)
 
@@ -338,6 +342,7 @@ contains
 
     use probdata_module
     
+    use bl_fort_module, only : rt => c_real
     implicit none
     
     include 'bc_types.fi'
@@ -345,8 +350,8 @@ contains
     integer :: grav_l1,grav_l2,grav_h1,grav_h2
     integer :: bc(2,2,*)
     integer :: domlo(2), domhi(2)
-    double precision delta(2), xlo(2), time
-    double precision grav(grav_l1:grav_h1,grav_l2:grav_h2)
+    real(rt)         delta(2), xlo(2), time
+    real(rt)         grav(grav_l1:grav_h1,grav_l2:grav_h2)
 
     call filcc(grav,grav_l1,grav_l2,grav_h1,grav_h2,domlo,domhi,delta,xlo,bc)
 
@@ -360,6 +365,7 @@ contains
 
     use probdata_module
     
+    use bl_fort_module, only : rt => c_real
     implicit none
     
     include 'bc_types.fi'
@@ -367,8 +373,8 @@ contains
     integer :: grav_l1,grav_l2,grav_h1,grav_h2
     integer :: bc(2,2,*)
     integer :: domlo(2), domhi(2)
-    double precision delta(2), xlo(2), time
-    double precision grav(grav_l1:grav_h1,grav_l2:grav_h2)
+    real(rt)         delta(2), xlo(2), time
+    real(rt)         grav(grav_l1:grav_h1,grav_l2:grav_h2)
 
     call filcc(grav,grav_l1,grav_l2,grav_h1,grav_h2,domlo,domhi,delta,xlo,bc)
 
@@ -382,6 +388,7 @@ contains
 
     use probdata_module
     
+    use bl_fort_module, only : rt => c_real
     implicit none
     
     include 'bc_types.fi'
@@ -389,8 +396,8 @@ contains
     integer :: react_l1,react_l2,react_h1,react_h2
     integer :: bc(2,2,*)
     integer :: domlo(2), domhi(2)
-    double precision delta(2), xlo(2), time
-    double precision react(react_l1:react_h1,react_l2:react_h2)
+    real(rt)         delta(2), xlo(2), time
+    real(rt)         react(react_l1:react_h1,react_l2:react_h2)
 
     call filcc(react,react_l1,react_l2,react_h1,react_h2,domlo,domhi,delta,xlo,bc)
 
@@ -401,6 +408,7 @@ contains
                             phi_h1,phi_h2,domlo,domhi,delta,xlo,time,bc) &
                             bind(C, name="ca_phigravfill")
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     include 'bc_types.fi'
@@ -408,8 +416,8 @@ contains
     integer          :: phi_l1,phi_l2,phi_h1,phi_h2
     integer          :: bc(2,2,*)
     integer          :: domlo(2), domhi(2)
-    double precision :: delta(2), xlo(2), time
-    double precision :: phi(phi_l1:phi_h1,phi_l2:phi_h2)
+    real(rt)         :: delta(2), xlo(2), time
+    real(rt)         :: phi(phi_l1:phi_h1,phi_l2:phi_h2)
 
     call filcc(phi,phi_l1,phi_l2,phi_h1,phi_h2, &
          domlo,domhi,delta,xlo,bc)

--- a/Exec/hydro_tests/toy_convect/ext_src_2d.f90
+++ b/Exec/hydro_tests/toy_convect/ext_src_2d.f90
@@ -8,20 +8,21 @@ subroutine ca_ext_src(lo,hi, &
   use meth_params_module, only : NVAR, UEDEN, UEINT, URHO, UTEMP, UFS
   use network, only: network_species_index
 
+  use bl_fort_module, only : rt => c_real
   implicit none
   integer         , intent(in   ) :: lo(2),hi(2)
   integer         , intent(in   ) :: old_state_l1,old_state_l2,old_state_h1,old_state_h2
   integer         , intent(in   ) :: new_state_l1,new_state_l2,new_state_h1,new_state_h2
   integer         , intent(in   ) :: src_l1,src_l2,src_h1,src_h2
-  real(kind=dp_t) , intent(in   ) :: old_state(old_state_l1:old_state_h1,old_state_l2:old_state_h2,NVAR)
-  real(kind=dp_t) , intent(in   ) :: new_state(new_state_l1:new_state_h1,new_state_l2:new_state_h2,NVAR)
-  real(kind=dp_t) , intent(  out) :: src(    src_l1:  src_h1,  src_l2:src_h2  ,NVAR)
-  real(kind=dp_t) , intent(in   ) :: problo(2),dx(2),time,dt
+  real(rt)        , intent(in   ) :: old_state(old_state_l1:old_state_h1,old_state_l2:old_state_h2,NVAR)
+  real(rt)        , intent(in   ) :: new_state(new_state_l1:new_state_h1,new_state_l2:new_state_h2,NVAR)
+  real(rt)        , intent(  out) :: src(    src_l1:  src_h1,  src_l2:src_h2  ,NVAR)
+  real(rt)        , intent(in   ) :: problo(2),dx(2),time,dt
 
   integer          :: i,j
-  double precision :: x,y
+  real(rt)         :: x,y
 
-  real(kind=dp_t) :: rho, temp, T6, T613, X_CNO, X_1, g14, eps_CNO
+  real(rt)        :: rho, temp, T6, T613, X_CNO, X_1, g14, eps_CNO
 
   integer, save :: ih1, ic12, in14, io16
 
@@ -36,18 +37,18 @@ subroutine ca_ext_src(lo,hi, &
      firstCall = .false.
   endif
 
-  src(lo(1):hi(1),lo(2):hi(2),:) = 0.d0
+  src(lo(1):hi(1),lo(2):hi(2),:) = 0.e0_rt
 
 
   do j=lo(2),hi(2)
-     !y = problo(2) + dx(2)*(float(j) + 0.5d0)
+     !y = problo(2) + dx(2)*(float(j) + 0.5e0_rt)
 
      do i=lo(1),hi(1)
-        !x = problo(1) + dx(1)*(float(i) + 0.5d0)
+        !x = problo(1) + dx(1)*(float(i) + 0.5e0_rt)
 
         rho = new_state(i,j,URHO)
 
-        T6 = new_state(i,j,UTEMP)/1.0d6
+        T6 = new_state(i,j,UTEMP)/1.0e6_rt
         T613 = T6**THIRD
 
         ! CNO abundance
@@ -59,8 +60,8 @@ subroutine ca_ext_src(lo,hi, &
         X_1 = new_state(i,j,UFS-1+ih1)/rho
 
         ! CNO heating from Kippenhahn & Weigert, Eq. 18.65                                                                            
-        g14 = 1.0_dp_t + 2.7d-3*T613 - 7.78d-3*T613**2 - 1.49d-4*T6
-        eps_CNO = 8.67e27_dp_t * g14 * X_CNO * X_1 * rho * exp(-152.28_dp_t/T613) / T613**2
+        g14 = 1.0_rt + 2.7e-3_rt*T613 - 7.78e-3_rt*T613**2 - 1.49e-4_rt*T6
+        eps_CNO = 8.67e27_rt * g14 * X_CNO * X_1 * rho * exp(-152.28_dp_t/T613) / T613**2
 
         ! source terms
         src(i,j,UEDEN) = rho*eps_CNO

--- a/Exec/hydro_tests/toy_convect/probdata.f90
+++ b/Exec/hydro_tests/toy_convect/probdata.f90
@@ -1,16 +1,17 @@
 module probdata_module
 
-  double precision, save :: H_min, cutoff_density
+  use bl_fort_module, only : rt => c_real
+  real(rt)        , save :: H_min, cutoff_density
 
   character(len=80), save :: model_name
 
   ! Velocity perturbation
   logical         , save :: apply_vel_field
 
-  double precision, save :: velpert_scale, velpert_amplitude, velpert_height_loc
+  real(rt)        , save :: velpert_scale, velpert_amplitude, velpert_height_loc
   integer         , save :: num_vortices
 
-  double precision, allocatable, save :: xloc_vortices(:)
+  real(rt)        , allocatable, save :: xloc_vortices(:)
 
   ! lower boundary
   logical         , save :: interp_BC, zero_vels

--- a/Exec/hydro_tests/toy_convect/problem_tagging_2d.f90
+++ b/Exec/hydro_tests/toy_convect/problem_tagging_2d.f90
@@ -1,5 +1,6 @@
 module problem_tagging_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   public
@@ -15,14 +16,15 @@ contains
     use meth_params_module, only: URHO, NVAR, UFS
     use probdata_module, only: H_min, cutoff_density
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer         ,intent(in   ) :: lo(2),hi(2)
     integer         ,intent(in   ) :: state_l1,state_l2,state_h1,state_h2
     integer         ,intent(in   ) :: tagl1,tagl2,tagh1,tagh2
-    double precision,intent(in   ) :: state(state_l1:state_h1,state_l2:state_h2, NVAR)
+    real(rt)        ,intent(in   ) :: state(state_l1:state_h1,state_l2:state_h2, NVAR)
     integer         ,intent(inout) :: tag(tagl1:tagh1,tagl2:tagh2)
-    double precision,intent(in   ) :: problo(2),dx(2),time
+    real(rt)        ,intent(in   ) :: problo(2),dx(2),time
     integer         ,intent(in   ) :: level,set,clear
 
     integer :: i, j

--- a/Exec/hydro_tests/toy_flame/Prob_1d.f90
+++ b/Exec/hydro_tests/toy_flame/Prob_1d.f90
@@ -7,18 +7,19 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
   use probdata_module
   use extern_probin_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer init, namlen
   integer name(namlen)
-  double precision problo(1), probhi(1)
-  double precision xn(nspec)
+  real(rt)         problo(1), probhi(1)
+  real(rt)         xn(nspec)
 
   integer untin,i
 
   type (eos_t) :: eos_state
 
-  double precision :: lambda_f, v_f
+  real(rt)         :: lambda_f, v_f
 
   namelist /fortin/ pert_frac, pert_delta, rho_fuel, T_fuel
 
@@ -36,8 +37,8 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
   end do
 
   ! set namelist defaults
-  pert_frac = 0.2d0
-  pert_delta = 0.02d0
+  pert_frac = 0.2e0_rt
+  pert_delta = 0.02e0_rt
   rho_fuel = ONE
   T_fuel = ONE
 
@@ -98,21 +99,22 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
   use eos_type_module
   use eos_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer level, nscal
   integer lo(1), hi(1)
   integer state_l1,state_h1
-  double precision state(state_l1:state_h1,NVAR)
-  double precision time, delta(1)
-  double precision xlo(1), xhi(1)
+  real(rt)         state(state_l1:state_h1,NVAR)
+  real(rt)         time, delta(1)
+  real(rt)         xlo(1), xhi(1)
 
-  double precision xx, x_int, L, f, pert_width
+  real(rt)         xx, x_int, L, f, pert_width
   integer i
 
-  double precision :: e_fuel, p_fuel
-  double precision :: rho_ash, T_ash, e_ash
-  double precision :: xn_fuel(nspec), xn_ash(nspec)
+  real(rt)         :: e_fuel, p_fuel
+  real(rt)         :: rho_ash, T_ash, e_ash
+  real(rt)         :: xn_fuel(nspec), xn_ash(nspec)
 
   type (eos_t) :: eos_state
 
@@ -140,7 +142,7 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
   p_fuel = eos_state%p
 
   ! compute the ash state
-  rho_ash = rho_fuel / (ONE + 0.6_dp_t*specific_q_burn/e_fuel)
+  rho_ash = rho_fuel / (ONE + 0.6_rt*specific_q_burn/e_fuel)
   e_ash = e_fuel - p_fuel*(ONE/rho_ash - ONE/rho_fuel) + specific_q_burn
   xn_ash(:) = ZERO
   xn_ash(iash) = ONE
@@ -157,7 +159,7 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
   print *, 'ash: ', rho_ash, T_ash, xn_ash
 
   do i = lo(1), hi(1)
-     xx = problo(1) + delta(1)*(dble(i) + 0.5d0)
+     xx = problo(1) + delta(1)*(dble(i) + 0.5e0_rt)
 
      if (xx <= x_int) then
 

--- a/Exec/hydro_tests/toy_flame/Problem.f90
+++ b/Exec/hydro_tests/toy_flame/Problem.f90
@@ -4,6 +4,7 @@ subroutine problem_checkpoint(int_dir_name, len) bind(C, name="problem_checkpoin
 
   ! called by the IO processor during checkpoint
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer :: len
@@ -26,6 +27,7 @@ subroutine problem_restart(int_dir_name, len) bind(C, name="problem_restart")
 
   ! called by ALL processors during restart 
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer :: len
@@ -50,21 +52,22 @@ subroutine flame_width_temp(temp, t_lo, t_hi, &
 
   use bl_constants_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer         , intent(in   ) :: t_lo(3), t_hi(3)
 
-  double precision, intent(in   ) :: temp(t_lo(1):t_hi(1),t_lo(2):t_hi(2),t_lo(3):t_hi(3))
+  real(rt)        , intent(in   ) :: temp(t_lo(1):t_hi(1),t_lo(2):t_hi(2),t_lo(3):t_hi(3))
 
   integer         , intent(in   ) :: lo(3), hi(3)
-  double precision, intent(in   ) :: dx(3), time
+  real(rt)        , intent(in   ) :: dx(3), time
 
-  double precision, intent(inout) :: T_max, T_min, grad_T_max
+  real(rt)        , intent(inout) :: T_max, T_min, grad_T_max
 
   ! Local variables
   
   integer :: i, j, k
-  double precision :: T, grad_T
+  real(rt)         :: T, grad_T
   
   ! Assumes 1D simulation, right now. Also assumes that
   ! we have at least one ghost cell in the x dimension.
@@ -106,16 +109,17 @@ subroutine flame_speed_data(omegadot, od_lo, od_hi, &
 
   use bl_constants_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer         , intent(in   ) :: od_lo(3), od_hi(3)
 
-  double precision, intent(in   ) :: omegadot(od_lo(1):od_hi(1),od_lo(2):od_hi(2),od_lo(3):od_hi(3))
+  real(rt)        , intent(in   ) :: omegadot(od_lo(1):od_hi(1),od_lo(2):od_hi(2),od_lo(3):od_hi(3))
 
   integer         , intent(in   ) :: lo(3), hi(3)
-  double precision, intent(in   ) :: dx(3)
+  real(rt)        , intent(in   ) :: dx(3)
 
-  double precision, intent(inout) :: rho_X_dot
+  real(rt)        , intent(inout) :: rho_X_dot
 
   ! Local variables
   

--- a/Exec/hydro_tests/toy_flame/probdata.f90
+++ b/Exec/hydro_tests/toy_flame/probdata.f90
@@ -1,9 +1,10 @@
 module probdata_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
-  double precision, save :: pert_frac, pert_delta
+  real(rt)        , save :: pert_frac, pert_delta
 
-  double precision, save :: rho_fuel, T_fuel
+  real(rt)        , save :: rho_fuel, T_fuel
 
 end module probdata_module

--- a/Exec/radiation_tests/Rad2Tshock/Prob_1d.f90
+++ b/Exec/radiation_tests/Rad2Tshock/Prob_1d.f90
@@ -3,11 +3,12 @@ subroutine probinit(init, name, namlen, problo, probhi)
   use probdata_module
   use network, only : network_init
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer init, namlen
   integer name(namlen)
-  double precision problo(1), probhi(1)
+  real(rt)         problo(1), probhi(1)
   
   integer untin,i
   
@@ -62,28 +63,29 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
   use network, only : nspec, naux
   use eos_module
   
+  use bl_fort_module, only : rt => c_real
   implicit none
   
   integer :: level, nscal
   integer :: lo(1), hi(1)
   integer :: state_l1,state_h1
-  double precision :: state(state_l1:state_h1,NVAR)
-  double precision :: time, delta(1)
-  double precision :: xlo(1), xhi(1)
+  real(rt)         :: state(state_l1:state_h1,NVAR)
+  real(rt)         :: time, delta(1)
+  real(rt)         :: xlo(1), xhi(1)
   
   integer :: i
-  double precision :: xcell, rhoInv
+  real(rt)         :: xcell, rhoInv
   type(eos_t) :: eos_state
 
   do i = lo(1), hi(1)
   
-     xcell = xmin + delta(1) * (dble(i) + 0.5d0)
+     xcell = xmin + delta(1) * (dble(i) + 0.5e0_rt)
 
-     if (xcell < 0.d0) then
+     if (xcell < 0.e0_rt) then
         state(i,URHO) = rho0
         
         ! set the composition to be all in the first species
-        state(i,UFS:UFS-1+nspec) = 0.d0
+        state(i,UFS:UFS-1+nspec) = 0.e0_rt
         state(i,UFS  ) = state(i,URHO)
 
         state(i,UTEMP) = T0
@@ -92,7 +94,7 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
         state(i,URHO) = rho1
         
         ! set the composition to be all in the first species
-        state(i,UFS:UFS-1+nspec) = 0.d0
+        state(i,UFS:UFS-1+nspec) = 0.e0_rt
         state(i,UFS  ) = state(i,URHO)
 
         state(i,UTEMP) = T1
@@ -106,7 +108,7 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
      eos_state % rho = state(i,URHO)
      eos_state % T   = state(i,UTEMP)
 
-     rhoInv = 1.d0 / state(i,URHO)
+     rhoInv = 1.e0_rt / state(i,URHO)
      eos_state % xn  = state(i,UFS:UFS+nspec-1) * rhoInv
      eos_state % aux = state(i,UFX:UFX+naux-1) * rhoInv
 
@@ -133,22 +135,23 @@ subroutine ca_initrad(level,time,lo,hi,nrad, &
   use rad_params_module, only : xnu
   use blackbody_module, only : BGroup
   
+  use bl_fort_module, only : rt => c_real
   implicit none
   integer :: level, nrad
   integer :: lo(1), hi(1)
   integer :: rad_state_l1,rad_state_h1
-  double precision :: xlo(1), xhi(1), time, delta(1)
-  double precision ::  rad_state(rad_state_l1:rad_state_h1, 0:nrad-1)
+  real(rt)         :: xlo(1), xhi(1), time, delta(1)
+  real(rt)         ::  rad_state(rad_state_l1:rad_state_h1, 0:nrad-1)
 
   ! local variables
   integer :: i, igroup
-  double precision xcell, t
+  real(rt)         xcell, t
 
   do i = lo(1), hi(1)
 
-     xcell = xmin + delta(1) * (dble(i) + 0.5d0)
+     xcell = xmin + delta(1) * (dble(i) + 0.5e0_rt)
    
-     if (xcell < 0.d0) then
+     if (xcell < 0.e0_rt) then
         T = T0
      else
         T = T1

--- a/Exec/radiation_tests/Rad2Tshock/Prob_2d.f90
+++ b/Exec/radiation_tests/Rad2Tshock/Prob_2d.f90
@@ -3,11 +3,12 @@ subroutine probinit(init, name, namlen, problo, probhi)
   use probdata_module
   use network, only : network_init
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer init, namlen
   integer name(namlen)
-  double precision problo(2), probhi(2)
+  real(rt)         problo(2), probhi(2)
   
   integer untin,i
   
@@ -65,44 +66,45 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
   use network, only : nspec, naux
   use eos_module
   
+  use bl_fort_module, only : rt => c_real
   implicit none
   
   integer :: level, nscal
   integer :: lo(2), hi(2)
   integer :: state_l1,state_l2,state_h1,state_h2
-  double precision :: state(state_l1:state_h1,state_l2:state_h2, NVAR)
-  double precision :: time, delta(2)
-  double precision :: xlo(2), xhi(2)
+  real(rt)         :: state(state_l1:state_h1,state_l2:state_h2, NVAR)
+  real(rt)         :: time, delta(2)
+  real(rt)         :: xlo(2), xhi(2)
   
   integer :: i,j
-  double precision :: xcell, rhoInv
+  real(rt)         :: xcell, rhoInv
   type(eos_t) :: eos_state
 
   do j = lo(2), hi(2)
      do i = lo(1), hi(1)
   
-        xcell = xmin  + delta(1) * (dble(i) + 0.5d0)
+        xcell = xmin  + delta(1) * (dble(i) + 0.5e0_rt)
 
-        if (xcell < 0.d0) then
+        if (xcell < 0.e0_rt) then
            state(i,j,URHO) = rho0
         
            ! set the composition to be all in the first species
-           state(i,j,UFS:UFS-1+nspec) = 0.d0
+           state(i,j,UFS:UFS-1+nspec) = 0.e0_rt
            state(i,j,UFS  ) = state(i,j,URHO)
 
            state(i,j,UTEMP) = T0
            state(i,j,UMX) = rho0*v0
-           state(i,j,UMY) = 0.0d0
+           state(i,j,UMY) = 0.0e0_rt
         else
            state(i,j,URHO) = rho1
         
            ! set the composition to be all in the first species
-           state(i,j,UFS:UFS-1+nspec) = 0.d0
+           state(i,j,UFS:UFS-1+nspec) = 0.e0_rt
            state(i,j,UFS  ) = state(i,j,URHO)
 
            state(i,j,UTEMP) = T1
            state(i,j,UMX) = rho1*v1
-           state(i,j,UMY) = 0.0d0           
+           state(i,j,UMY) = 0.0e0_rt           
         end if
  
         if (naux > 0) then
@@ -112,7 +114,7 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
         eos_state % rho = state(i,j,URHO)
         eos_state % T   = state(i,j,UTEMP)
 
-        rhoInv = 1.d0 / state(i,j,URHO)
+        rhoInv = 1.e0_rt / state(i,j,URHO)
         eos_state % xn  = state(i,j,UFS:UFS+nspec-1) * rhoInv
         eos_state % aux = state(i,j,UFX:UFX+naux-1) * rhoInv
 
@@ -120,7 +122,7 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
      
         state(i,j,UEINT) = state(i,j,URHO) * eos_state % e
         state(i,j,UEDEN) = state(i,j,UEINT) + &
-             0.5d0*(state(i,j,UMX)**2 + state(i,j,UMY)**2)/state(i,j,URHO)                
+             0.5e0_rt*(state(i,j,UMX)**2 + state(i,j,UMY)**2)/state(i,j,URHO)                
      enddo
   enddo
   
@@ -141,23 +143,24 @@ subroutine ca_initrad(level,time,lo,hi,nrad, &
   use rad_params_module, only : xnu
   use blackbody_module, only : BGroup
   
+  use bl_fort_module, only : rt => c_real
   implicit none
   integer :: level, nrad
   integer :: lo(2), hi(2)
   integer :: rad_state_l1,rad_state_l2,rad_state_h1,rad_state_h2
-  double precision :: xlo(2), xhi(2), time, delta(2)
-  double precision ::  rad_state(rad_state_l1:rad_state_h1,rad_state_l2:rad_state_h2, 0:nrad-1)
+  real(rt)         :: xlo(2), xhi(2), time, delta(2)
+  real(rt)         ::  rad_state(rad_state_l1:rad_state_h1,rad_state_l2:rad_state_h2, 0:nrad-1)
 
   ! local variables
   integer :: i, j, igroup
-  double precision xcell, t
+  real(rt)         xcell, t
 
   do j = lo(2), hi(2)
      do i = lo(1), hi(1)
 
-        xcell = xmin + delta(1) * (dble(i) + 0.5d0)
+        xcell = xmin + delta(1) * (dble(i) + 0.5e0_rt)
    
-        if (xcell < 0.d0) then
+        if (xcell < 0.e0_rt) then
            T = T0
         else
            T = T1

--- a/Exec/radiation_tests/Rad2Tshock/Prob_3d.f90
+++ b/Exec/radiation_tests/Rad2Tshock/Prob_3d.f90
@@ -3,11 +3,12 @@ subroutine probinit(init, name, namlen, problo, probhi)
   use probdata_module
   use network, only : network_init
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer init, namlen
   integer name(namlen)
-  double precision problo(3), probhi(3)
+  real(rt)         problo(3), probhi(3)
   
   integer untin,i
   
@@ -68,47 +69,48 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
   use network, only : nspec, naux
   use eos_module
   
+  use bl_fort_module, only : rt => c_real
   implicit none
   
   integer :: level, nscal
   integer :: lo(3), hi(3)
   integer :: state_l1,state_l2,state_l3,state_h1,state_h2,state_h3
-  double precision :: state(state_l1:state_h1,state_l2:state_h2,state_l3:state_h3, NVAR)
-  double precision :: time, delta(3)
-  double precision :: xlo(3), xhi(3)
+  real(rt)         :: state(state_l1:state_h1,state_l2:state_h2,state_l3:state_h3, NVAR)
+  real(rt)         :: time, delta(3)
+  real(rt)         :: xlo(3), xhi(3)
   
   integer :: i,j,k
-  double precision :: xcell, rhoInv
+  real(rt)         :: xcell, rhoInv
   type(eos_t) :: eos_state
 
   do k = lo(3), hi(3)  
      do j = lo(2), hi(2)
         do i = lo(1), hi(1)
   
-           xcell = xmin  + delta(1) * (dble(i) + 0.5d0)
+           xcell = xmin  + delta(1) * (dble(i) + 0.5e0_rt)
            
-           if (xcell < 0.d0) then
+           if (xcell < 0.e0_rt) then
               state(i,j,k,URHO) = rho0
            
               ! set the composition to be all in the first species
-              state(i,j,k,UFS:UFS-1+nspec) = 0.d0
+              state(i,j,k,UFS:UFS-1+nspec) = 0.e0_rt
               state(i,j,k,UFS  ) = state(i,j,k,URHO)
 
               state(i,j,k,UTEMP) = T0
               state(i,j,k,UMX) = rho0*v0
-              state(i,j,k,UMY) = 0.0d0
-              state(i,j,k,UMZ) = 0.0d0
+              state(i,j,k,UMY) = 0.0e0_rt
+              state(i,j,k,UMZ) = 0.0e0_rt
            else
               state(i,j,k,URHO) = rho1
         
               ! set the composition to be all in the first species
-              state(i,j,k,UFS:UFS-1+nspec) = 0.d0
+              state(i,j,k,UFS:UFS-1+nspec) = 0.e0_rt
               state(i,j,k,UFS  ) = state(i,j,k,URHO)
 
               state(i,j,k,UTEMP) = T1
               state(i,j,k,UMX) = rho1*v1
-              state(i,j,k,UMY) = 0.0d0
-              state(i,j,k,UMZ) = 0.0d0
+              state(i,j,k,UMY) = 0.0e0_rt
+              state(i,j,k,UMZ) = 0.0e0_rt
            end if
  
            if (naux > 0) then
@@ -118,7 +120,7 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
            eos_state % rho = state(i,j,k,URHO)
            eos_state % T   = state(i,j,k,UTEMP)
 
-           rhoInv = 1.d0 / state(i,j,k,URHO)
+           rhoInv = 1.e0_rt / state(i,j,k,URHO)
            eos_state % xn  = state(i,j,k,UFS:UFS+nspec-1) * rhoInv
            eos_state % aux = state(i,j,k,UFX:UFX+naux-1) * rhoInv
            
@@ -126,7 +128,7 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
      
            state(i,j,k,UEINT) = state(i,j,k,URHO) * eos_state % e
            state(i,j,k,UEDEN) = state(i,j,k,UEINT) + &
-                0.5d0*(state(i,j,k,UMX)**2 + &
+                0.5e0_rt*(state(i,j,k,UMX)**2 + &
                        state(i,j,k,UMY)**2 + &
                        state(i,j,k,UMZ)**2)/state(i,j,k,URHO)
         enddo
@@ -150,26 +152,27 @@ subroutine ca_initrad(level,time,lo,hi,nrad, &
   use rad_params_module, only : xnu
   use blackbody_module, only : BGroup
   
+  use bl_fort_module, only : rt => c_real
   implicit none
   integer :: level, nrad
   integer :: lo(3), hi(3)
   integer :: rad_state_l1,rad_state_l2,rad_state_l3,rad_state_h1,rad_state_h2,rad_state_h3
-  double precision :: xlo(3), xhi(3), time, delta(3)
-  double precision ::  rad_state(rad_state_l1:rad_state_h1, &
+  real(rt)         :: xlo(3), xhi(3), time, delta(3)
+  real(rt)         ::  rad_state(rad_state_l1:rad_state_h1, &
                                  rad_state_l2:rad_state_h2, &
                                  rad_state_l3:rad_state_h3, 0:nrad-1)
 
   ! local variables
   integer :: i, j, k, igroup
-  double precision xcell, t
+  real(rt)         xcell, t
 
   do k = lo(3), hi(3)
      do j = lo(2), hi(2)
         do i = lo(1), hi(1)
 
-           xcell = xmin + delta(1) * (dble(i) + 0.5d0)
+           xcell = xmin + delta(1) * (dble(i) + 0.5e0_rt)
    
-           if (xcell < 0.d0) then
+           if (xcell < 0.e0_rt) then
               T = T0
            else
               T = T1

--- a/Exec/radiation_tests/Rad2Tshock/Tools/bc.f90
+++ b/Exec/radiation_tests/Rad2Tshock/Tools/bc.f90
@@ -5,8 +5,8 @@ program bc
   implicit none
 
   integer :: ngroups, igroup
-  double precision, allocatable :: xnu(:)
-  double precision :: T
+  real(rt)        , allocatable :: xnu(:)
+  real(rt)         :: T
 
   integer :: n
   character(len=256) :: line

--- a/Exec/radiation_tests/Rad2Tshock/bc_fill_1d.F90
+++ b/Exec/radiation_tests/Rad2Tshock/bc_fill_1d.F90
@@ -1,5 +1,6 @@
 module bc_fill_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   public
@@ -16,19 +17,20 @@ contains
     use eos_module
     use probdata_module
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     include 'bc_types.fi'
     integer adv_l1,adv_h1
     integer bc(1,2,*)
     integer domlo(1), domhi(1)
-    double precision delta(1), xlo(1), time
-    double precision adv(adv_l1:adv_h1,NVAR)
+    real(rt)         delta(1), xlo(1), time
+    real(rt)         adv(adv_l1:adv_h1,NVAR)
 
     integer i, n
 
     type(eos_t) :: eos_state
-    double precision, save :: eint0, etot0, eint1, etot1
+    real(rt)        , save :: eint0, etot0, eint1, etot1
     logical, save :: first_call = .true.
 
     if (first_call) then
@@ -36,7 +38,7 @@ contains
 
        eos_state % rho = rho0
        eos_state % T   =   T0
-       eos_state % xn  = 1.d0
+       eos_state % xn  = 1.e0_rt
 
        call eos(eos_input_rt, eos_state)
 
@@ -69,8 +71,8 @@ contains
        do i = adv_l1, domlo(1)-1
           adv(i,URHO) = rho0
           adv(i,UMX) = rho0*v0
-          adv(i,UMY) = 0.d0
-          adv(i,UMZ) = 0.d0
+          adv(i,UMY) = 0.e0_rt
+          adv(i,UMZ) = 0.e0_rt
           adv(i,UFS) = adv(i,URHO)
           if (naux>0) then
              adv(i,UFX) = adv(i,URHO)           
@@ -86,8 +88,8 @@ contains
        do i = domhi(1)+1, adv_h1
           adv(i,URHO) = rho1
           adv(i,UMX) = rho1*v1
-          adv(i,UMY) = 0.d0
-          adv(i,UMZ) = 0.d0
+          adv(i,UMY) = 0.e0_rt
+          adv(i,UMZ) = 0.e0_rt
           adv(i,UFS) = adv(i,URHO)
           if (naux>0) then
              adv(i,UFX) = adv(i,URHO)           
@@ -109,13 +111,14 @@ contains
 
     use probdata_module
 
+    use bl_fort_module, only : rt => c_real
     implicit none
     include 'bc_types.fi'
     integer adv_l1,adv_h1
     integer bc(1,2,*)
     integer domlo(1), domhi(1)
-    double precision delta(1), xlo(1), time
-    double precision adv(adv_l1:adv_h1)
+    real(rt)         delta(1), xlo(1), time
+    real(rt)         adv(adv_l1:adv_h1)
     integer i
 
     !     Note: this function should not be needed, technically, but is provided
@@ -148,6 +151,7 @@ contains
   subroutine ca_phigravfill(phi,phi_l1,phi_h1, &
                             domlo,domhi,delta,xlo,time,bc) bind(C, name="ca_phigravfill")
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     include 'bc_types.fi'
@@ -155,8 +159,8 @@ contains
     integer          :: phi_l1,phi_h1
     integer          :: bc(1,2,*)
     integer          :: domlo(1), domhi(1)
-    double precision :: delta(1), xlo(1), time
-    double precision :: phi(phi_l1:phi_h1)
+    real(rt)         :: delta(1), xlo(1), time
+    real(rt)         :: phi(phi_l1:phi_h1)
 
     call filcc(phi,phi_l1,phi_h1, &
          domlo,domhi,delta,xlo,bc)
@@ -172,13 +176,14 @@ contains
 
     use probdata_module
 
+    use bl_fort_module, only : rt => c_real
     implicit none
     include 'bc_types.fi'
     integer adv_l1,adv_h1
     integer bc(1,2,*)
     integer domlo(1), domhi(1)
-    double precision delta(1), xlo(1), time
-    double precision adv(adv_l1:adv_h1)
+    real(rt)         delta(1), xlo(1), time
+    real(rt)         adv(adv_l1:adv_h1)
     integer i
 
     !     Note: this function should not be needed, technically, but is provided

--- a/Exec/radiation_tests/Rad2Tshock/bc_fill_2d.F90
+++ b/Exec/radiation_tests/Rad2Tshock/bc_fill_2d.F90
@@ -1,5 +1,6 @@
 module bc_fill_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   public
@@ -16,19 +17,20 @@ contains
     use eos_module
     use probdata_module
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     include 'bc_types.fi'
     integer adv_l1,adv_l2,adv_h1,adv_h2
     integer bc(2,2,*)
     integer domlo(2), domhi(2)
-    double precision delta(2), xlo(2), time
-    double precision adv(adv_l1:adv_h1,adv_l2:adv_h2,NVAR)
+    real(rt)         delta(2), xlo(2), time
+    real(rt)         adv(adv_l1:adv_h1,adv_l2:adv_h2,NVAR)
 
     integer i, j, n
 
     type(eos_t) :: eos_state
-    double precision, save :: eint0, etot0, eint1, etot1
+    real(rt)        , save :: eint0, etot0, eint1, etot1
     logical, save :: first_call = .true.
 
     if (first_call) then
@@ -36,7 +38,7 @@ contains
 
        eos_state % rho = rho0
        eos_state % T   =   T0
-       eos_state % xn  = 1.d0
+       eos_state % xn  = 1.e0_rt
 
        call eos(eos_input_rt, eos_state)
 
@@ -70,8 +72,8 @@ contains
           do i = adv_l1, domlo(1)-1
              adv(i,j,URHO) = rho0
              adv(i,j,UMX) = rho0*v0
-             adv(i,j,UMY) = 0.d0
-             adv(i,j,UMZ) = 0.d0
+             adv(i,j,UMY) = 0.e0_rt
+             adv(i,j,UMZ) = 0.e0_rt
              adv(i,j,UFS) = adv(i,j,URHO)
              if (naux > 0) then
                 adv(i,j,UFX) = adv(i,j,URHO)           
@@ -89,8 +91,8 @@ contains
           do i = domhi(1)+1, adv_h1
              adv(i,j,URHO) = rho1
              adv(i,j,UMX) = rho1*v1
-             adv(i,j,UMY) = 0.d0
-             adv(i,j,UMZ) = 0.d0
+             adv(i,j,UMY) = 0.e0_rt
+             adv(i,j,UMZ) = 0.e0_rt
              adv(i,j,UFS) = adv(i,j,URHO)
              if (naux > 0) then
                 adv(i,j,UFX) = adv(i,j,URHO)           
@@ -113,13 +115,14 @@ contains
 
     use probdata_module
 
+    use bl_fort_module, only : rt => c_real
     implicit none
     include 'bc_types.fi'
     integer adv_l1,adv_l2,adv_h1,adv_h2
     integer bc(2,2,*)
     integer domlo(2), domhi(2)
-    double precision delta(2), xlo(2), time
-    double precision adv(adv_l1:adv_h1,adv_l2:adv_h2)
+    real(rt)         delta(2), xlo(2), time
+    real(rt)         adv(adv_l1:adv_h1,adv_l2:adv_h2)
     integer i,j
 
     !     Note: this function should not be needed, technically, but is provided
@@ -156,6 +159,7 @@ contains
   subroutine ca_phigravfill(phi,phi_l1,phi_l2,phi_h1,phi_h2, &
                             domlo,domhi,delta,xlo,time,bc) bind(C, name="ca_phigravfill")
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     include 'bc_types.fi'
@@ -163,8 +167,8 @@ contains
     integer          :: phi_l1,phi_l2,phi_h1,phi_h2
     integer          :: bc(2,2,*)
     integer          :: domlo(2), domhi(2)
-    double precision :: delta(2), xlo(2), time
-    double precision :: phi(phi_l1:phi_h1,phi_l2:phi_h2)
+    real(rt)         :: delta(2), xlo(2), time
+    real(rt)         :: phi(phi_l1:phi_h1,phi_l2:phi_h2)
 
     call filcc(phi,phi_l1,phi_l2,phi_h1,phi_h2, &
                domlo,domhi,delta,xlo,bc)
@@ -180,13 +184,14 @@ contains
 
     use probdata_module
 
+    use bl_fort_module, only : rt => c_real
     implicit none
     include 'bc_types.fi'
     integer adv_l1,adv_l2,adv_h1,adv_h2
     integer bc(2,2,*)
     integer domlo(2), domhi(2)
-    double precision delta(2), xlo(2), time
-    double precision adv(adv_l1:adv_h1,adv_l2:adv_h2)
+    real(rt)         delta(2), xlo(2), time
+    real(rt)         adv(adv_l1:adv_h1,adv_l2:adv_h2)
     integer i,j
 
     !     Note: this function should not be needed, technically, but is provided

--- a/Exec/radiation_tests/Rad2Tshock/bc_fill_3d.F90
+++ b/Exec/radiation_tests/Rad2Tshock/bc_fill_3d.F90
@@ -1,5 +1,6 @@
 module bc_fill_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   public
@@ -16,19 +17,20 @@ contains
     use eos_module
     use probdata_module
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     include 'bc_types.fi'
     integer adv_l1,adv_l2,adv_l3,adv_h1,adv_h2,adv_h3
     integer bc(3,2,*)
     integer domlo(3), domhi(3)
-    double precision delta(3), xlo(3), time
-    double precision adv(adv_l1:adv_h1,adv_l2:adv_h2,adv_l3:adv_h3,NVAR)
+    real(rt)         delta(3), xlo(3), time
+    real(rt)         adv(adv_l1:adv_h1,adv_l2:adv_h2,adv_l3:adv_h3,NVAR)
 
     integer i, j, k, n
 
     type(eos_t) :: eos_state
-    double precision, save :: eint0, etot0, eint1, etot1
+    real(rt)        , save :: eint0, etot0, eint1, etot1
     logical, save :: first_call = .true.
 
     if (first_call) then
@@ -36,7 +38,7 @@ contains
 
        eos_state % rho = rho0
        eos_state % T   =   T0
-       eos_state % xn  = 1.d0
+       eos_state % xn  = 1.e0_rt
 
        call eos(eos_input_rt, eos_state)
 
@@ -71,8 +73,8 @@ contains
              do i = adv_l1, domlo(1)-1
                 adv(i,j,k,URHO) = rho0
                 adv(i,j,k,UMX) = rho0*v0
-                adv(i,j,k,UMY) = 0.d0
-                adv(i,j,k,UMZ) = 0.d0
+                adv(i,j,k,UMY) = 0.e0_rt
+                adv(i,j,k,UMZ) = 0.e0_rt
                 adv(i,j,k,UFS) = adv(i,j,k,URHO)
                 if (naux > 0) then
                    adv(i,j,k,UFX) = adv(i,j,k,URHO)           
@@ -92,8 +94,8 @@ contains
              do i = domhi(1)+1, adv_h1
                 adv(i,j,k,URHO) = rho1
                 adv(i,j,k,UMX) = rho1*v1
-                adv(i,j,k,UMY) = 0.d0
-                adv(i,j,k,UMZ) = 0.d0
+                adv(i,j,k,UMY) = 0.e0_rt
+                adv(i,j,k,UMZ) = 0.e0_rt
                 adv(i,j,k,UFS) = adv(i,j,k,URHO)
                 if (naux > 0) then
                    adv(i,j,k,UFX) = adv(i,j,k,URHO)           
@@ -117,13 +119,14 @@ contains
 
     use probdata_module
 
+    use bl_fort_module, only : rt => c_real
     implicit none
     include 'bc_types.fi'
     integer adv_l1,adv_l2,adv_l3,adv_h1,adv_h2,adv_h3
     integer bc(3,2,*)
     integer domlo(3), domhi(3)
-    double precision delta(3), xlo(3), time
-    double precision adv(adv_l1:adv_h1,adv_l2:adv_h2,adv_l3:adv_h3)
+    real(rt)         delta(3), xlo(3), time
+    real(rt)         adv(adv_l1:adv_h1,adv_l2:adv_h2,adv_l3:adv_h3)
     integer i,j,k
 
     !     Note: this function should not be needed, technically, but is provided
@@ -164,6 +167,7 @@ contains
   subroutine ca_phigravfill(phi,phi_l1,phi_l2,phi_l3,phi_h1,phi_h2,phi_h3, &
                             domlo,domhi,delta,xlo,time,bc) bind(C, name="ca_phigravfill")
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     include 'bc_types.fi'
@@ -171,8 +175,8 @@ contains
     integer          :: phi_l1,phi_l2,phi_l3,phi_h1,phi_h2,phi_h3
     integer          :: bc(3,2,*)
     integer          :: domlo(3), domhi(3)
-    double precision :: delta(3), xlo(3), time
-    double precision :: phi(phi_l1:phi_h1,phi_l2:phi_h2,phi_l3:phi_h3)
+    real(rt)         :: delta(3), xlo(3), time
+    real(rt)         :: phi(phi_l1:phi_h1,phi_l2:phi_h2,phi_l3:phi_h3)
 
     call filcc(phi,phi_l1,phi_l2,phi_l3,phi_h1,phi_h2,phi_h3, &
                domlo,domhi,delta,xlo,bc)
@@ -188,13 +192,14 @@ contains
 
     use probdata_module
 
+    use bl_fort_module, only : rt => c_real
     implicit none
     include 'bc_types.fi'
     integer adv_l1,adv_l2,adv_l3,adv_h1,adv_h2,adv_h3
     integer bc(3,2,*)
     integer domlo(3), domhi(3)
-    double precision delta(3), xlo(3), time
-    double precision adv(adv_l1:adv_h1,adv_l2:adv_h2,adv_l3:adv_h3)
+    real(rt)         delta(3), xlo(3), time
+    real(rt)         adv(adv_l1:adv_h1,adv_l2:adv_h2,adv_l3:adv_h3)
     integer i,j,k
 
     !     Note: this function should not be needed, technically, but is provided

--- a/Exec/radiation_tests/Rad2Tshock/probdata.f90
+++ b/Exec/radiation_tests/Rad2Tshock/probdata.f90
@@ -1,16 +1,17 @@
 module probdata_module
   
   ! Ensman test variables -- we set the defaults here
-  double precision, save :: rho0 = 5.4588672836d-13
-  double precision, save :: T0 = 100.d0
-  double precision, save :: v0 = 235435.371882d0
-  double precision, save :: rho1 = 1.24793794736d-12
-  double precision, save :: T1 = 207.756999533d0
-  double precision, save :: v1 = 102986.727159d0
+  use bl_fort_module, only : rt => c_real
+  real(rt)        , save :: rho0 = 5.4588672836e-13_rt
+  real(rt)        , save :: T0 = 100.e0_rt
+  real(rt)        , save :: v0 = 235435.371882e0_rt
+  real(rt)        , save :: rho1 = 1.24793794736e-12_rt
+  real(rt)        , save :: T1 = 207.756999533e0_rt
+  real(rt)        , save :: v1 = 102986.727159e0_rt
   
   namelist /fortin/ rho0, T0, v0, rho1, T1, v1
 
   ! for convenience
-  double precision, save :: xmin, xmax, ymin, ymax, zmin, zmax
+  real(rt)        , save :: xmin, xmax, ymin, ymax, zmin, zmax
   
 end module probdata_module

--- a/Exec/radiation_tests/RadBreakout/Prob_1d.f90
+++ b/Exec/radiation_tests/RadBreakout/Prob_1d.f90
@@ -5,11 +5,12 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
   use network, only : network_init
   use bl_error_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer init, namlen
   integer name(namlen)
-  double precision problo(1), probhi(1)
+  real(rt)         problo(1), probhi(1)
   
   integer untin,i
   character(1) dummy
@@ -36,14 +37,14 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
   
   ! set namelist defaults
   
-  rbasefac = 0.99d0
-  rwind0 = 0.7d14
-  rwind1 = 1.d14
-  rhowind1 = 1.d-14
-  Twind1 = 1.1d3
+  rbasefac = 0.99e0_rt
+  rwind0 = 0.7e14_rt
+  rwind1 = 1.e14_rt
+  rhowind1 = 1.e-14_rt
+  Twind1 = 1.1e3_rt
 
-  filter_rhomax = -1.d20
-  filter_timemax = -1.d20
+  filter_rhomax = -1.e20_rt
+  filter_timemax = -1.e20_rt
 
   xmin = problo(1)
   xmax = probhi(1)
@@ -104,22 +105,23 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
   use interpolate_module
   use fundamental_constants_module, only: k_B, n_A
   
+  use bl_fort_module, only : rt => c_real
   implicit none
   
   integer :: level, nscal
   integer :: lo(1), hi(1)
   integer :: state_l1,state_h1
-  double precision :: state(state_l1:state_h1,NVAR)
-  double precision :: time, delta(1)
-  double precision :: xlo(1), xhi(1)
+  real(rt)         :: state(state_l1:state_h1,NVAR)
+  real(rt)         :: time, delta(1)
+  real(rt)         :: xlo(1), xhi(1)
   
   integer :: i, ii
-  double precision :: rhoInv, xcl, xx, vtot, vsub, rho, T, u, rhosub, Tsub, usub, dx_sub
-  double precision :: rhowind0, rlast, rholast, Twind0, Tlast
+  real(rt)         :: rhoInv, xcl, xx, vtot, vsub, rho, T, u, rhosub, Tsub, usub, dx_sub
+  real(rt)         :: rhowind0, rlast, rholast, Twind0, Tlast
   integer, parameter :: nsub = 16
-  double precision :: rho_tmp, rbase, T_tmp
-  double precision :: Ye, Abar, invmu
-  double precision, parameter :: Tindex=0.5
+  real(rt)         :: rho_tmp, rbase, T_tmp
+  real(rt)         :: Ye, Abar, invmu
+  real(rt)        , parameter :: Tindex=0.5
   type(eos_t) :: eos_state
 
   if (naux .ne. 2) then
@@ -145,14 +147,14 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
   
      xcl = xlo(1) + delta(1) * float(i-lo(1))
      
-     vtot = 0.d0
-     rho = 0.d0
-     T = 0.d0
-     u = 0.d0
-     Ye = 0.d0
-     Abar = 0.d0
+     vtot = 0.e0_rt
+     rho = 0.e0_rt
+     T = 0.e0_rt
+     u = 0.e0_rt
+     Ye = 0.e0_rt
+     Abar = 0.e0_rt
      do ii=0,nsub-1
-        xx = xcl + (dble(ii)+0.5d0) * dx_sub
+        xx = xcl + (dble(ii)+0.5e0_rt) * dx_sub
         vsub = xx**2
         vtot = vtot + vsub
         if (xx .ge. model_r(npts_model)) then
@@ -175,11 +177,11 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
            Ye = Ye + model_Ye(npts_model) * vsub
            Abar = Abar + model_Abar(npts_model) * vsub
 
-           u = u + 0.d0
+           u = u + 0.e0_rt
         else if (xx .le. model_r(1)) then
            rho = rho + model_rho(1) * vsub
            T = T + model_T(1) * vsub
-           u = u + 0.d0
+           u = u + 0.e0_rt
            Ye = Ye + model_Ye(1) * vsub
            Abar = Abar + model_Abar(1) * vsub
         else
@@ -196,20 +198,20 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
      Ye = Ye / vtot
      Abar = Abar / vtot
 
-     invmu = (1.d0+Abar*Ye)/Abar
+     invmu = (1.e0_rt+Abar*Ye)/Abar
 
      state(i,URHO)  = rho
      state(i,UTEMP)  = T
      state(i,UMX)   = rho * u
 
      ! set the composition to be all in the first species
-     state(i,UFS:UFS-1+nspec) = 0.d0
+     state(i,UFS:UFS-1+nspec) = 0.e0_rt
      state(i,UFS  ) = state(i,URHO)
      state(i,UFX) = Ye*rho
      state(i,UFX+1) = invmu*rho
 
      ! set the internal energy via the EOS
-     rhoInv = 1.d0 / state(i,URHO)
+     rhoInv = 1.e0_rt / state(i,URHO)
      eos_state % rho = state(i,URHO)
      eos_state % T   = state(i,UTEMP)
      eos_state % xn  = state(i,UFS:UFS+nspec-1) * rhoInv
@@ -239,20 +241,21 @@ subroutine ca_initrad(level,time,lo,hi,nrad, &
   use rad_params_module, only : xnu
   use blackbody_module, only : BGroup
 
+  use bl_fort_module, only : rt => c_real
   implicit none
   integer :: level, nrad
   integer :: lo(1), hi(1)
   integer :: rad_state_l1,rad_state_h1
-  double precision :: xlo(1), xhi(1), time, delta(1)
-  double precision ::  rad_state(rad_state_l1:rad_state_h1, 0:nrad-1)
+  real(rt)         :: xlo(1), xhi(1), time, delta(1)
+  real(rt)         ::  rad_state(rad_state_l1:rad_state_h1, 0:nrad-1)
 
   ! local variables
   integer :: i,ii,igroup
-  double precision xcl, T, Tsub, xx, vtot, vsub, dx_sub
+  real(rt)         xcl, T, Tsub, xx, vtot, vsub, dx_sub
   integer, parameter :: nsub = 16
 
-  double precision :: rlast, rbase, T_tmp, Twind0, Tlast
-  double precision, parameter :: Tindex=0.5
+  real(rt)         :: rlast, rbase, T_tmp, Twind0, Tlast
+  real(rt)        , parameter :: Tindex=0.5
 
   dx_sub = delta(1) / dble(nsub)
 
@@ -266,10 +269,10 @@ subroutine ca_initrad(level,time,lo,hi,nrad, &
 
      xcl = xlo(1) + delta(1) * float(i-lo(1))
      
-     vtot = 0.d0
-     T = 0.d0
+     vtot = 0.e0_rt
+     T = 0.e0_rt
      do ii=0,nsub-1
-        xx = xcl + (dble(ii)+0.5d0) * dx_sub
+        xx = xcl + (dble(ii)+0.5e0_rt) * dx_sub
         vsub = xx**2
         vtot = vtot + vsub
         if (xx .ge. model_r(npts_model)) then

--- a/Exec/radiation_tests/RadBreakout/filt_prim_1d.f90
+++ b/Exec/radiation_tests/RadBreakout/filt_prim_1d.f90
@@ -12,26 +12,27 @@ subroutine ca_filt_prim(lo, hi, &
        small_temp, small_dens, nadv
   use filter_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: lo(1), hi(1), domlo(1), domhi(1), level
   integer, intent(in) :: filt_T, S
-  double precision, intent(in) :: delta(1), xlo(1), problo(1), time
+  real(rt)        , intent(in) :: delta(1), xlo(1), problo(1), time
   integer, intent(in) ::   Stmp_l1,Stmp_h1
   integer, intent(in) ::   Snew_l1,Snew_h1
   integer, intent(in) ::   mask_l1,mask_h1
-  double precision :: Stmp(Stmp_l1:Stmp_h1,NVAR)
-  double precision :: Snew(Snew_l1:Snew_h1,NVAR)
-  double precision :: mask(mask_l1:mask_h1)
-  ! mask has three possible values: -1.d0, 0.d0, and 1.d0.
-  ! -1.d0 appears only in cells that are covered by neither this level nor the finer level.
+  real(rt)         :: Stmp(Stmp_l1:Stmp_h1,NVAR)
+  real(rt)         :: Snew(Snew_l1:Snew_h1,NVAR)
+  real(rt)         :: mask(mask_l1:mask_h1)
+  ! mask has three possible values: -1.e0_rt, 0.e0_rt, and 1.e0_rt.
+  ! -1.e0_rt appears only in cells that are covered by neither this level nor the finer level.
   !       It can only appear in ghost cells. 
-  !  0.d0 appears only in cells that are covered by only this level, but not the finer level.
-  !  1.d0 appears only in cells that are covered by the finer level.
+  !  0.e0_rt appears only in cells that are covered by only this level, but not the finer level.
+  !  1.e0_rt appears only in cells that are covered by the finer level.
   !       It can appear in either valid cells or ghost cells. 
 
   integer :: i
-  double precision :: rhotmpinv
+  real(rt)         :: rhotmpinv
   type(eos_t) :: eos_state
   logical, allocatable :: filtered(:)
 
@@ -124,7 +125,7 @@ subroutine ca_filt_prim(lo, hi, &
         eos_state % rho = Snew(i,URHO)
         eos_state % T = Snew(i,UTEMP)
 
-        rhotmpInv = 1.d0 / Stmp(i,URHO)
+        rhotmpInv = 1.e0_rt / Stmp(i,URHO)
         eos_state % xn  = Stmp(i,UFS:UFS+nspec-1) * rhotmpInv
         eos_state % aux = Stmp(i,UFX:UFX+naux-1) * rhotmpInv
 

--- a/Exec/radiation_tests/RadBreakout/probdata.f90
+++ b/Exec/radiation_tests/RadBreakout/probdata.f90
@@ -1,16 +1,17 @@
 module probdata_module
   
-  double precision, save :: rwind0, rwind1, rhowind1, Twind1, rbasefac
+  use bl_fort_module, only : rt => c_real
+  real(rt)        , save :: rwind0, rwind1, rhowind1, Twind1, rbasefac
 
-  double precision, save :: xmin,xmax,ymin,ymax,zmin,zmax
+  real(rt)        , save :: xmin,xmax,ymin,ymax,zmin,zmax
 
   integer, save :: npts_model
   integer, parameter :: npts_max = 1000
-  double precision, save :: model_r(npts_max), model_rho(npts_max), &
+  real(rt)        , save :: model_r(npts_max), model_rho(npts_max), &
        model_v(npts_max), model_T(npts_max), model_Ye(npts_max), model_Abar(npts_max)
 
   ! filter is used only when rho or time is below.
-  double precision, save :: filter_rhomax, filter_timemax
+  real(rt)        , save :: filter_rhomax, filter_timemax
 
   character (len=128), save :: model_file
 

--- a/Exec/radiation_tests/RadShestakovBolstad/Prob_1d.f90
+++ b/Exec/radiation_tests/RadShestakovBolstad/Prob_1d.f90
@@ -3,11 +3,12 @@
 
       use probdata_module
       use network, only : network_init
+      use bl_fort_module, only : rt => c_real
       implicit none
 
       integer :: init, namlen
       integer :: name(namlen)
-      double precision :: problo(1), probhi(1)
+      real(rt)         :: problo(1), probhi(1)
 
       integer :: untin,i
 
@@ -33,14 +34,14 @@
          
       ! set namelist defaults
 
-      rho_0 = 1.8212111d-5
-      T_0 = 0.1d0           ! keV
-      kappa_0 = 0.1d0
-      x_jump = 0.5d0
-      R = 1.d0
+      rho_0 = 1.8212111e-5_rt
+      T_0 = 0.1e0_rt           ! keV
+      kappa_0 = 0.1e0_rt
+      x_jump = 0.5e0_rt
+      R = 1.e0_rt
 
-      wref_l1 = 0.d0
-      wref_l2 = 0.d0
+      wref_l1 = 0.e0_rt
+      wref_l2 = 0.e0_rt
 
 !     Read namelists
       untin = 9
@@ -83,41 +84,42 @@
       use meth_params_module, only : NVAR, URHO, UMX, UEDEN, UEINT, UFS, UFX, UTEMP
       use network, only : nspec, naux
       
+      use bl_fort_module, only : rt => c_real
       implicit none
       
       integer level, nscal
       integer lo(1), hi(1)
       integer state_l1,state_h1
-      double precision state(state_l1:state_h1,NVAR)
-      double precision time, delta(1)
-      double precision xlo(1), xhi(1)
+      real(rt)         state(state_l1:state_h1,NVAR)
+      real(rt)         time, delta(1)
+      real(rt)         xlo(1), xhi(1)
       
-      double precision xcen
+      real(rt)         xcen
       integer i
-      double precision Tcgs, B0, nu0, l0, x0, u0
-      double precision pi, rhoe_0
+      real(rt)         Tcgs, B0, nu0, l0, x0, u0
+      real(rt)         pi, rhoe_0
 
-      Tcgs = T_0 * 1.d3 * ev2erg / k_B
+      Tcgs = T_0 * 1.e3_rt * ev2erg / k_B
       
-      pi = 4.0d0*atan(1.0d0)
+      pi = 4.0e0_rt*atan(1.0e0_rt)
       B0 = 8.*pi*hplanck/c_light**3
       nu0 = k_B*Tcgs/hplanck
       l0 = nu0**3/kappa_0
-      x0 = l0/sqrt(3.d0)
+      x0 = l0/sqrt(3.e0_rt)
       u0 = B0*nu0**3
       
 !      rhoe_0 = R * k_B * Tcgs * u0 / hplanck
-      rhoe_0 = 99968636.6828d0 * Tcgs * rho_0
+      rhoe_0 = 99968636.6828e0_rt * Tcgs * rho_0
       !          cv            * T    * rho
 
       do i = lo(1), hi(1)
-         xcen = xlo(1) + delta(1)*(float(i-lo(1)) + 0.5d0)
+         xcen = xlo(1) + delta(1)*(float(i-lo(1)) + 0.5e0_rt)
          
          state(i,URHO ) = rho_0
-         state(i,UMX  ) = 0.d0
+         state(i,UMX  ) = 0.e0_rt
          
          ! set the composition to be all in the first species
-         state(i,UFS:UFS-1+nspec) = 0.d0
+         state(i,UFS:UFS-1+nspec) = 0.e0_rt
          state(i,UFS) = state(i,URHO)
          if (naux > 0) then
             state(i,UFX) = state(i,URHO)
@@ -128,9 +130,9 @@
             state(i,UEINT) = rhoe_0
             state(i,UTEMP) = Tcgs
          else
-            state(i,UEDEN) = 0.d0
-            state(i,UEINT) = 0.d0
-            state(i,UTEMP) = 0.d0
+            state(i,UEDEN) = 0.e0_rt
+            state(i,UEINT) = 0.e0_rt
+            state(i,UTEMP) = 0.e0_rt
          end if
          
       enddo
@@ -146,6 +148,7 @@
 
         use probdata_module
 
+        use bl_fort_module, only : rt => c_real
         implicit none
         integer level, nrad
         integer lo(1), hi(1)
@@ -155,11 +158,11 @@
         real(kind=8) rad_state(rad_state_l1:rad_state_h1,nrad)
 
         ! local variables
-        double precision xcen
+        real(rt)         xcen
         integer i
 
         do i = lo(1), hi(1)  
-           rad_state(i, :) = 0.d0
+           rad_state(i, :) = 0.e0_rt
         enddo
 
       end subroutine ca_initrad

--- a/Exec/radiation_tests/RadShestakovBolstad/probdata.f90
+++ b/Exec/radiation_tests/RadShestakovBolstad/probdata.f90
@@ -1,10 +1,11 @@
 module probdata_module
 
-  double precision, save :: wref_l1, wref_l2
+  use bl_fort_module, only : rt => c_real
+  real(rt)        , save :: wref_l1, wref_l2
 
   ! rad shock parameters
-  double precision, save ::  rho_0, T_0, kappa_0, x_jump, R
+  real(rt)        , save ::  rho_0, T_0, kappa_0, x_jump, R
 
-  double precision, save :: xmin,xmax,ymin,ymax,zmin,zmax
+  real(rt)        , save :: xmin,xmax,ymin,ymax,zmin,zmax
       
 end module probdata_module

--- a/Exec/radiation_tests/RadSlope/Prob_1d.f90
+++ b/Exec/radiation_tests/RadSlope/Prob_1d.f90
@@ -4,11 +4,12 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
   use probdata_module
   use network, only : network_init
   use eos_module, only : gamma_const
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer init, namlen
   integer name(namlen)
-  double precision problo(1), probhi(1)
+  real(rt)         problo(1), probhi(1)
   
   integer untin,i
   
@@ -71,17 +72,18 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
   use meth_params_module, only : NVAR, URHO, UMX, UEDEN, UEINT, UFS, UTEMP
   use network, only : nspec
   
+  use bl_fort_module, only : rt => c_real
   implicit none
   
   integer :: level, nscal
   integer :: lo(1), hi(1)
   integer :: state_l1,state_h1
-  double precision :: state(state_l1:state_h1,NVAR)
-  double precision :: time, delta(1)
-  double precision :: xlo(1), xhi(1)
+  real(rt)         :: state(state_l1:state_h1,NVAR)
+  real(rt)         :: time, delta(1)
+  real(rt)         :: xlo(1), xhi(1)
   
   integer :: i
-  double precision :: c_v, eint
+  real(rt)         :: c_v, eint
 
   do i = lo(1), hi(1)
   
@@ -90,7 +92,7 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
      state(i,UMX) = 0.0
         
      ! set the composition to be all in the first species
-     state(i,UFS:UFS-1+nspec) = 0.d0
+     state(i,UFS:UFS-1+nspec) = 0.e0_rt
      state(i,UFS  ) = state(i,URHO)
      
      state(i,UEINT) = 0.0
@@ -112,12 +114,13 @@ subroutine ca_initrad(level,time,lo,hi,nrad, &
   use probdata_module
   use fundamental_constants_module, only: a_rad
   
+  use bl_fort_module, only : rt => c_real
   implicit none
   integer :: level, nrad
   integer :: lo(1), hi(1)
   integer :: rad_state_l1,rad_state_h1
-  double precision :: xlo(1), xhi(1), time, delta(1)
-  double precision ::  rad_state(rad_state_l1:rad_state_h1, nrad)
+  real(rt)         :: xlo(1), xhi(1), time, delta(1)
+  real(rt)         ::  rad_state(rad_state_l1:rad_state_h1, nrad)
 
   ! local variables
   integer :: i

--- a/Exec/radiation_tests/RadSlope/probdata.f90
+++ b/Exec/radiation_tests/RadSlope/probdata.f90
@@ -1,5 +1,6 @@
 module probdata_module
   
-  double precision, save :: xmin,xmax,ymin,ymax,zmin,zmax
+  use bl_fort_module, only : rt => c_real
+  real(rt)        , save :: xmin,xmax,ymin,ymax,zmin,zmax
   
 end module probdata_module

--- a/Exec/radiation_tests/RadSphere/Prob_1d.f90
+++ b/Exec/radiation_tests/RadSphere/Prob_1d.f90
@@ -6,11 +6,12 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
   use network, only : nspec
   use bl_error_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer :: init, namlen
   integer :: name(namlen)
-  double precision :: problo(1), probhi(1)
+  real(rt)         :: problo(1), probhi(1)
 
   type(eos_t) :: eos_state
 
@@ -45,8 +46,8 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
 
   eos_state % rho = rho_0
   eos_state % T   = T_0
-  eos_state % xn  = 0.d0
-  eos_state % xn(1) = 1.d0
+  eos_state % xn  = 0.e0_rt
+  eos_state % xn(1) = 1.e0_rt
 
   call eos(eos_input_rt, eos_state)
 
@@ -86,28 +87,29 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
   use meth_params_module, only : NVAR, URHO, UMX, UEDEN, UEINT, UFS, UFX, UTEMP
   use network, only : nspec, naux
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer level, nscal
   integer lo(1), hi(1)
   integer state_l1,state_h1
-  double precision state(state_l1:state_h1,NVAR)
-  double precision time, delta(1)
-  double precision xlo(1), xhi(1)
+  real(rt)         state(state_l1:state_h1,NVAR)
+  real(rt)         time, delta(1)
+  real(rt)         xlo(1), xhi(1)
 
-  double precision xcen
+  real(rt)         xcen
   integer i
 
   do i = lo(1), hi(1)
-     xcen = xlo(1) + delta(1)*(float(i-lo(1)) + 0.5d0)
+     xcen = xlo(1) + delta(1)*(float(i-lo(1)) + 0.5e0_rt)
 
      state(i,URHO ) = rho_0
-     state(i,UMX  ) = 0.d0
+     state(i,UMX  ) = 0.e0_rt
      state(i,UEDEN) = rhoe_0 
      state(i,UEINT) = rhoe_0
 
      ! set the composition to be all in the first species
-     state(i,UFS:UFS-1+nspec) = 0.d0
+     state(i,UFS:UFS-1+nspec) = 0.e0_rt
      state(i,UFS) = state(i,URHO)
      if (naux > 0) then
         state(i,UFX) = state(i,URHO)
@@ -131,6 +133,7 @@ subroutine ca_initrad(level,time,lo,hi,nrad, &
   use fundamental_constants_module, only : hplanck, c_light, k_B
   use bl_constants_module, only : ZERO, ONE, HALF, M_PI
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer level, nrad
@@ -141,7 +144,7 @@ subroutine ca_initrad(level,time,lo,hi,nrad, &
   real(kind=8) rad_state(rad_state_l1:rad_state_h1,0:nrad-1)
 
   ! local variables
-  double precision xcen, nu, xx
+  real(rt)         xcen, nu, xx
   integer i, igroup
 
   !        if (nrad .ne. 64) then
@@ -156,13 +159,13 @@ subroutine ca_initrad(level,time,lo,hi,nrad, &
         nu = nugroup(igroup)
 
         xx = hplanck*nu/(k_B*T_0)
-        if (xx > 708.d0) then
+        if (xx > 708.e0_rt) then
            ! exp(708+eps) will give 1.e308 -- the limits of IEEE floating point, 
            ! and generate an overflow exception
            rad_state(i,igroup) = ZERO
         else
            rad_state(i,igroup) =  &
-                (8.d0*M_PI*hplanck*nu**3/c_light**3)/(exp(xx) - ONE) &
+                (8.e0_rt*M_PI*hplanck*nu**3/c_light**3)/(exp(xx) - ONE) &
                 * dnugroup(igroup)
         endif
      end do

--- a/Exec/radiation_tests/RadSphere/Tools/analytic.f90
+++ b/Exec/radiation_tests/RadSphere/Tools/analytic.f90
@@ -8,11 +8,12 @@
 module constants_module
 
   ! fundamental constants
-  double precision, parameter :: h_planck =  6.62606957d-27  ! erg s
-  double precision, parameter :: k_B = 1.3806488d-16  ! erg / K
-  double precision, parameter :: c_light = 2.99792458d10  ! cm / s
-  double precision, parameter :: ev2erg = 1.602176487d-12 ! erg/eV
-  double precision, parameter :: pi = 3.14159265358979323846d0
+  use bl_fort_module, only : rt => c_real
+  real(rt)        , parameter :: h_planck =  6.62606957e-27_rt  ! erg s
+  real(rt)        , parameter :: k_B = 1.3806488e-16_rt  ! erg / K
+  real(rt)        , parameter :: c_light = 2.99792458e10_rt  ! cm / s
+  real(rt)        , parameter :: ev2erg = 1.602176487e-12_rt ! erg/eV
+  real(rt)        , parameter :: pi = 3.14159265358979323846e0_rt
 
   ! problem parameters
 
@@ -25,14 +26,14 @@ module constants_module
   ! says that they used kappa = 1.e13 * (1.5e-6 MeV / E)**3
   !
   ! Converting 1.5e-6 MeV to a frequency gives nu_0 = 3.63e14 Hz
-  double precision, parameter :: nu_0 = 3.6e14  ! ref. freq (Hz)
-  double precision, parameter :: kappa_0 = 1.e13  ! scattering opacity (1/cm)
+  real(rt)        , parameter :: nu_0 = 3.6e14  ! ref. freq (Hz)
+  real(rt)        , parameter :: kappa_0 = 1.e13  ! scattering opacity (1/cm)
 
   ! specify the energy groups.  Ultimately we will work in terms of 
   ! frequency, but we set the limits in terms of energy.  
   integer, parameter :: ngroups_derive = 60          ! number of groups to compute
-  double precision, parameter :: E_min = 0.5d0*ev2erg ! min group energy (erg)
-  double precision, parameter :: E_max = 306d3*ev2erg ! max group energy (erg)
+  real(rt)        , parameter :: E_min = 0.5e0_rt*ev2erg ! min group energy (erg)
+  real(rt)        , parameter :: E_max = 306e3_rt*ev2erg ! max group energy (erg)
 
   ! instead of computing the group structure based on the above, read the group
   ! structure in from group_structure.dat
@@ -40,24 +41,25 @@ module constants_module
 
 
   ! geometry parameters
-  double precision, parameter :: R_sphere = 0.02d0 ! sphere radius (cm)
-  double precision, parameter :: r_obs = 0.06d0  ! observer location (cm)
+  real(rt)        , parameter :: R_sphere = 0.02e0_rt ! sphere radius (cm)
+  real(rt)        , parameter :: r_obs = 0.06e0_rt  ! observer location (cm)
 
   ! physical parameters
-  double precision, parameter :: T_0 = 50.d0*ev2erg/k_B ! ambient temp (K)
-  double precision, parameter :: T_sphere = 1500.d0*ev2erg/k_B ! sphere temp (K
+  real(rt)        , parameter :: T_0 = 50.e0_rt*ev2erg/k_B ! ambient temp (K)
+  real(rt)        , parameter :: T_sphere = 1500.e0_rt*ev2erg/k_B ! sphere temp (K
   
-  ! output time (t_obs = 1.d-12 is a good value to try)
-  double precision, parameter :: t_obs = 1.d-12  ! observation time (s)
+  ! output time (t_obs = 1.e-12_rt is a good value to try)
+  real(rt)        , parameter :: t_obs = 1.e-12_rt  ! observation time (s)
 
 
 end module constants_module
 
 function safe_print(x) result (sx)
+  use bl_fort_module, only : rt => c_real
   implicit none
-  double precision :: x, sx
+  real(rt)         :: x, sx
   sx = x
-  if (x < 1.d-99) sx = 0.d0
+  if (x < 1.e-99_rt) sx = 0.e0_rt
 
   return
 end function safe_print
@@ -75,12 +77,13 @@ function planck(nu,T) result (B)
   ! have units of erg / cm^3 / MeV.  As a result, we have one
   ! less factor of h_planck.
   use constants_module
+  use bl_fort_module, only : rt => c_real
   implicit none
 
-  double precision, intent(in) :: nu, T
-  double precision :: B
+  real(rt)        , intent(in) :: nu, T
+  real(rt)         :: B
 
-  B = (8.d0*pi*h_planck*nu**3/c_light**3)/(exp(h_planck*nu/(k_B*T)) - 1.d0)
+  B = (8.e0_rt*pi*h_planck*nu**3/c_light**3)/(exp(h_planck*nu/(k_B*T)) - 1.e0_rt)
 
 
   return
@@ -97,32 +100,33 @@ function F_radsphere(r,t,nu) result (F)
 
   use constants_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
-  double precision, intent(in) :: r, t, nu
+  real(rt)        , intent(in) :: r, t, nu
 
-  double precision :: E, kappa, erfc_term1, erfc_term2, F
+  real(rt)         :: E, kappa, erfc_term1, erfc_term2, F
 
-  double precision :: sferfc, sfexp, arg1
+  real(rt)         :: sferfc, sfexp, arg1
 
   ! to guard against over/underflows, we define some 'safe' functions
   ! (they come from Eric)
-  sferfc(arg1) = erfc(max(-26.0d0,min(26.0d0,arg1)))
-  sfexp(arg1) = exp(max(-650.0d0,min(650.0d0,arg1)))
+  sferfc(arg1) = erfc(max(-26.0e0_rt,min(26.0e0_rt,arg1)))
+  sfexp(arg1) = exp(max(-650.0e0_rt,min(650.0e0_rt,arg1)))
 
 
   kappa = kappa_0*(nu_0/nu)**3
 
 
-  erfc_term1 = sferfc(sqrt(3.d0*kappa/(4.d0*c_light*t))*(r - R_sphere) - &
+  erfc_term1 = sferfc(sqrt(3.e0_rt*kappa/(4.e0_rt*c_light*t))*(r - R_sphere) - &
                       sqrt(c_light*t*kappa))
 
-  erfc_term2 = sferfc(sqrt(3.d0*kappa/(4.d0*c_light*t))*(r - R_sphere) + &
+  erfc_term2 = sferfc(sqrt(3.e0_rt*kappa/(4.e0_rt*c_light*t))*(r - R_sphere) + &
                     sqrt(c_light*t*kappa))
 
 
-  F = 0.5*(sfexp(-sqrt(3.d0)*kappa*(r - R_sphere))*erfc_term1 + &
-           sfexp( sqrt(3.d0)*kappa*(r - R_sphere))*erfc_term2)
+  F = 0.5*(sfexp(-sqrt(3.e0_rt)*kappa*(r - R_sphere))*erfc_term1 + &
+           sfexp( sqrt(3.e0_rt)*kappa*(r - R_sphere))*erfc_term2)
 
   return
 
@@ -139,11 +143,11 @@ program analytic
   implicit none
 
   integer :: ngroups
-  double precision, allocatable :: nu_groups(:), dnu_groups(:), xnu(:)
-  double precision :: alpha
-  double precision :: E, F
-  double precision :: F_radsphere, planck
-  double precision :: safe_print
+  real(rt)        , allocatable :: nu_groups(:), dnu_groups(:), xnu(:)
+  real(rt)         :: alpha
+  real(rt)         :: E, F
+  real(rt)         :: F_radsphere, planck
+  real(rt)         :: safe_print
   integer :: n
 
   character(len=256) :: header_line
@@ -176,25 +180,25 @@ program analytic
      
      ! do geometrically spaced group BOUNDARIES
      xnu(1) = E_min/h_planck
-     alpha = (E_max/E_min)**(1.d0/(ngroups))
+     alpha = (E_max/E_min)**(1.e0_rt/(ngroups))
 
      do n = 2, ngroups+1
         xnu(n) = alpha*xnu(n-1)
      enddo
 
      do n = 1, ngroups
-        nu_groups(n) = 0.5d0*(xnu(n) + xnu(n+1))
+        nu_groups(n) = 0.5e0_rt*(xnu(n) + xnu(n+1))
      enddo
 
      do n = 1, ngroups
         if (n == 1) then
-           dnu_groups(n) = 0.5d0*(nu_groups(2) - nu_groups(1))
+           dnu_groups(n) = 0.5e0_rt*(nu_groups(2) - nu_groups(1))
 
         else if (n < ngroups) then
-           dnu_groups(n) = 0.5d0*(nu_groups(n+1) - nu_groups(n-1))
+           dnu_groups(n) = 0.5e0_rt*(nu_groups(n+1) - nu_groups(n-1))
 
         else
-           dnu_groups(n) = 0.5d0*(nu_groups(n) - nu_groups(n-1))
+           dnu_groups(n) = 0.5e0_rt*(nu_groups(n) - nu_groups(n-1))
         endif
 
      enddo

--- a/Exec/radiation_tests/RadSphere/Tools/fradsphere.f90
+++ b/Exec/radiation_tests/RadSphere/Tools/fradsphere.f90
@@ -21,9 +21,9 @@ program fradsphere
   integer :: ung
   integer :: cnt, max_points, nvs
 
-  real(kind=dp_t) :: dx(MAX_SPACEDIM)
-  real(kind=dp_t), pointer :: p(:,:,:,:)
-  real(kind=dp_t), allocatable :: sv(:,:)
+  real(rt)        :: dx(MAX_SPACEDIM)
+  real(rt)       , pointer :: p(:,:,:,:)
+  real(rt)       , allocatable :: sv(:,:)
   integer, allocatable :: isv(:)
   logical, allocatable :: imask(:)
   integer :: nspec, lo(MAX_SPACEDIM), hi(MAX_SPACEDIM)
@@ -39,11 +39,11 @@ program fradsphere
 
   character(len=1) :: dirstr
 
-  real(kind=dp_t) :: rmin, rmax
-  real(kind=dp_t) :: radius
+  real(rt)        :: rmin, rmax
+  real(rt)        :: radius
 
   integer :: ngroups
-  real(kind=dp_t), allocatable :: nu_groups(:), dnu_groups(:)
+  real(rt)       , allocatable :: nu_groups(:), dnu_groups(:)
 
   integer :: irad_begin
   integer :: idx_obs
@@ -55,7 +55,7 @@ program fradsphere
   ung =  unit_new()
 
   groupfile = "group_structure.dat"
-  radius = 0.06d0
+  radius = 0.06e0_rt
 
   narg = command_argument_count()
 

--- a/Exec/radiation_tests/RadSphere/Tools/radbc.f90
+++ b/Exec/radiation_tests/RadSphere/Tools/radbc.f90
@@ -12,14 +12,15 @@
 module constants_module
 
   ! fundamental constants
-  double precision, parameter :: h_planck = 6.62606957d-27   ! erg s
-  double precision, parameter :: k_B = 1.3806488d-16  ! erg / K
-  double precision, parameter :: c_light = 2.99792458d10  ! cm / s
-  double precision, parameter :: ev2erg = 1.602176487d-12 ! erg/eV
-  double precision, parameter :: pi = 3.14159265358979323846d0
+  use bl_fort_module, only : rt => c_real
+  real(rt)        , parameter :: h_planck = 6.62606957e-27_rt   ! erg s
+  real(rt)        , parameter :: k_B = 1.3806488e-16_rt  ! erg / K
+  real(rt)        , parameter :: c_light = 2.99792458e10_rt  ! cm / s
+  real(rt)        , parameter :: ev2erg = 1.602176487e-12_rt ! erg/eV
+  real(rt)        , parameter :: pi = 3.14159265358979323846e0_rt
 
   ! physical parameters
-  double precision, parameter :: T_sphere = 1500.d0*ev2erg/k_B ! sphere temp (K
+  real(rt)        , parameter :: T_sphere = 1500.e0_rt*ev2erg/k_B ! sphere temp (K
   
 
 end module constants_module
@@ -38,12 +39,13 @@ function planck(nu,T) result (B)
   ! have units of erg / cm^3 / MeV.  As a result, we have one
   ! less factor of h_planck.
   use constants_module
+  use bl_fort_module, only : rt => c_real
   implicit none
 
-  double precision, intent(in) :: nu, T
-  double precision :: B
+  real(rt)        , intent(in) :: nu, T
+  real(rt)         :: B
 
-  B = (8.d0*pi*h_planck*nu**3/c_light**3)/(exp(h_planck*nu/(k_B*T)) - 1.d0)
+  B = (8.e0_rt*pi*h_planck*nu**3/c_light**3)/(exp(h_planck*nu/(k_B*T)) - 1.e0_rt)
 
   return
 end function planck
@@ -59,8 +61,8 @@ program bc
   implicit none
 
   integer :: ngroups
-  double precision, allocatable :: nu_groups(:), dnu_groups(:)
-  double precision :: planck
+  real(rt)        , allocatable :: nu_groups(:), dnu_groups(:)
+  real(rt)         :: planck
   
   integer :: n
   character(len=256) :: header_line

--- a/Exec/radiation_tests/RadSphere/probdata.f90
+++ b/Exec/radiation_tests/RadSphere/probdata.f90
@@ -1,8 +1,9 @@
 module probdata_module
 
   ! rad shock parameters
-  double precision, save ::  rho_0, T_0, rhoe_0
+  use bl_fort_module, only : rt => c_real
+  real(rt)        , save ::  rho_0, T_0, rhoe_0
   
-  double precision, save :: xmin,xmax,ymin,ymax,zmin,zmax
+  real(rt)        , save :: xmin,xmax,ymin,ymax,zmin,zmax
       
 end module probdata_module

--- a/Exec/radiation_tests/RadSuOlson/Prob_1d.f90
+++ b/Exec/radiation_tests/RadSuOlson/Prob_1d.f90
@@ -4,11 +4,12 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
   use probdata_module
   use network, only : network_init
   use eos_module, only : gamma_const
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer init, namlen
   integer name(namlen)
-  double precision problo(1), probhi(1)
+  real(rt)         problo(1), probhi(1)
   
   integer untin,i
   
@@ -34,7 +35,7 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
   
   ! set namelist defaults
   
-  const_c_v = 8.0744926545150113d-24
+  const_c_v = 8.0744926545150113e-24_rt
   c_v_exp_n = -3.0
 
   xmin = problo(1)
@@ -76,17 +77,18 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
   use meth_params_module, only : NVAR, URHO, UMX, UMY, UEDEN, UEINT, UFS, UTEMP
   use network, only : nspec
   
+  use bl_fort_module, only : rt => c_real
   implicit none
   
   integer :: level, nscal
   integer :: lo(1), hi(1)
   integer :: state_l1,state_h1
-  double precision :: state(state_l1:state_h1,NVAR)
-  double precision :: time, delta(1)
-  double precision :: xlo(1), xhi(1)
+  real(rt)         :: state(state_l1:state_h1,NVAR)
+  real(rt)         :: time, delta(1)
+  real(rt)         :: xlo(1), xhi(1)
   
   integer :: i
-  double precision :: c_v, eint
+  real(rt)         :: c_v, eint
 
   do i = lo(1), hi(1)
   
@@ -95,7 +97,7 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
      state(i,UMX) = 0.0
         
      ! set the composition to be all in the first species
-     state(i,UFS:UFS-1+nspec) = 0.d0
+     state(i,UFS:UFS-1+nspec) = 0.e0_rt
      state(i,UFS  ) = state(i,URHO)
      
      state(i,UEINT) = 0.0
@@ -116,12 +118,13 @@ subroutine ca_initrad(level,time,lo,hi,nrad, &
 
   use probdata_module
   
+  use bl_fort_module, only : rt => c_real
   implicit none
   integer :: level, nrad
   integer :: lo(1), hi(1)
   integer :: rad_state_l1,rad_state_h1
-  double precision :: xlo(1), xhi(1), time, delta(1)
-  double precision ::  rad_state(rad_state_l1:rad_state_h1, nrad)
+  real(rt)         :: xlo(1), xhi(1), time, delta(1)
+  real(rt)         ::  rad_state(rad_state_l1:rad_state_h1, nrad)
 
   ! local variables
   integer :: i

--- a/Exec/radiation_tests/RadSuOlson/probdata.f90
+++ b/Exec/radiation_tests/RadSuOlson/probdata.f90
@@ -1,7 +1,8 @@
 module probdata_module
   
-  double precision, save :: const_c_v, c_v_exp_n
+  use bl_fort_module, only : rt => c_real
+  real(rt)        , save :: const_c_v, c_v_exp_n
   
-  double precision, save :: xmin,xmax,ymin,ymax,zmin,zmax
+  real(rt)        , save :: xmin,xmax,ymin,ymax,zmin,zmax
   
 end module probdata_module

--- a/Exec/radiation_tests/RadSuOlsonMG/Prob_1d.f90
+++ b/Exec/radiation_tests/RadSuOlsonMG/Prob_1d.f90
@@ -4,11 +4,12 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
   use probdata_module
   use network, only : network_init
   use fundamental_constants_module, only : c_light, a_rad
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer init, namlen
   integer name(namlen)
-  double precision problo(1), probhi(1)
+  real(rt)         problo(1), probhi(1)
   
   integer untin,i
   
@@ -33,14 +34,14 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
   end do
   
   ! set defaults
-  x0 = 0.5d0
-  tau0 = 10.0d0
-  Q = 1.d0
-  Temp0 = 1.d6
-  kapbar = 1.d0
-  epsilon = 1.d0
-  p0 = 0.5d0
-  p1 = 0.5d0
+  x0 = 0.5e0_rt
+  tau0 = 10.0e0_rt
+  Q = 1.e0_rt
+  Temp0 = 1.e6_rt
+  kapbar = 1.e0_rt
+  epsilon = 1.e0_rt
+  p0 = 0.5e0_rt
+  p1 = 0.5e0_rt
 
   xmin = problo(1)
   xmax = probhi(1)
@@ -86,17 +87,18 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
   use meth_params_module, only : NVAR, URHO, UMX, UMY, UEDEN, UEINT, UFS, UFX, UTEMP
   use network, only : nspec, naux
   
+  use bl_fort_module, only : rt => c_real
   implicit none
   
   integer :: level, nscal
   integer :: lo(1), hi(1)
   integer :: state_l1,state_h1
-  double precision :: state(state_l1:state_h1,NVAR)
-  double precision :: time, delta(1)
-  double precision :: xlo(1), xhi(1)
+  real(rt)         :: state(state_l1:state_h1,NVAR)
+  real(rt)         :: time, delta(1)
+  real(rt)         :: xlo(1), xhi(1)
   
   integer :: i
-  double precision :: c_v, eint
+  real(rt)         :: c_v, eint
 
   do i = lo(1), hi(1)
   
@@ -105,7 +107,7 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
      state(i,UMX) = 0.0
         
      ! set the composition to be all in the first species
-     state(i,UFS:UFS-1+nspec) = 0.d0
+     state(i,UFS:UFS-1+nspec) = 0.e0_rt
      state(i,UFS  ) = state(i,URHO)
      if (naux > 0) then
         state(i,UFX) = state(i,URHO)
@@ -129,12 +131,13 @@ subroutine ca_initrad(level,time,lo,hi,nrad, &
 
   use probdata_module
   
+  use bl_fort_module, only : rt => c_real
   implicit none
   integer :: level, nrad
   integer :: lo(1), hi(1)
   integer :: rad_state_l1,rad_state_h1
-  double precision :: xlo(1), xhi(1), time, delta(1)
-  double precision ::  rad_state(rad_state_l1:rad_state_h1, nrad)
+  real(rt)         :: xlo(1), xhi(1), time, delta(1)
+  real(rt)         ::  rad_state(rad_state_l1:rad_state_h1, nrad)
 
   ! local variables
   integer :: i,j

--- a/Exec/radiation_tests/RadSuOlsonMG/probdata.f90
+++ b/Exec/radiation_tests/RadSuOlsonMG/probdata.f90
@@ -1,8 +1,9 @@
 module probdata_module
   
-  double precision, save :: x0, tau0, Q, Temp0, kapbar, epsilon, p0, p1
-  double precision, save :: t0, qn(0:1)
+  use bl_fort_module, only : rt => c_real
+  real(rt)        , save :: x0, tau0, Q, Temp0, kapbar, epsilon, p0, p1
+  real(rt)        , save :: t0, qn(0:1)
 
-  double precision, save :: xmin,xmax,ymin,ymax,zmin,zmax
+  real(rt)        , save :: xmin,xmax,ymin,ymax,zmin,zmax
   
 end module probdata_module

--- a/Exec/radiation_tests/RadThermalWave/Prob_1d.f90
+++ b/Exec/radiation_tests/RadThermalWave/Prob_1d.f90
@@ -2,13 +2,14 @@
       subroutine PROBINIT (init,name,namlen,problo,probhi)
       use probdata_module
       use network, only : network_init
+      use bl_fort_module, only : rt => c_real
       implicit none
       integer init, namlen
       integer name(namlen)
-      double precision problo(1), probhi(1)
+      real(rt)         problo(1), probhi(1)
 
       integer untin,i
-      double precision rn
+      real(rt)         rn
 
       namelist /fortin/ rhocv, T0, Eexp, rexp
 
@@ -31,10 +32,10 @@
       end do
 
 !     Set defaults
-      rhocv = -1.0d50
-      T0 = -1.0d50
-      Eexp = -1.d-50
-      rexp = -1.d50
+      rhocv = -1.0e50_rt
+      T0 = -1.0e50_rt
+      Eexp = -1.e-50_rt
+      rexp = -1.e50_rt
 
       ! domain extrema and center
       xmin = problo(1)
@@ -79,29 +80,30 @@
 
       use network, only : nspec
 
+      use bl_fort_module, only : rt => c_real
       implicit none
       integer level, nscal
       integer lo(1), hi(1)
       integer state_l1,state_h1
-      double precision xlo(1), xhi(1), time, delta(1)
-      double precision state(state_l1:state_h1, nscal)
+      real(rt)         xlo(1), xhi(1), time, delta(1)
+      real(rt)         state(state_l1:state_h1, nscal)
 
       integer i
       type(eos_t) :: eos_state
-      double precision :: rho, cv, T, p, eint, xcell
-      double precision :: rhoeexp, Vexp, rhoe0
+      real(rt)         :: rho, cv, T, p, eint, xcell
+      real(rt)         :: rhoeexp, Vexp, rhoe0
 
-      Vexp = 4.d0/3.d0*Pi * rexp**3
+      Vexp = 4.e0_rt/3.e0_rt*Pi * rexp**3
 
       rhoeexp = Eexp / Vexp
 
-      rho = 1.0d0
-      T = 1.0d0
+      rho = 1.0e0_rt
+      T = 1.0e0_rt
 
       eos_state % rho = rho
       eos_state % T   = T
-      eos_state % xn  = 0.d0
-      eos_state % xn(1)  = 1.d0
+      eos_state % xn  = 0.e0_rt
+      eos_state % xn(1)  = 1.e0_rt
 
       call eos(eos_input_rt, eos_state)
 
@@ -115,10 +117,10 @@
       rhoe0 = rho * cv * T0
 
       do i = lo(1), hi(1)   
-         xcell = xlo(1) + delta(1)*(float(i-lo(1)) + 0.5d0)
+         xcell = xlo(1) + delta(1)*(float(i-lo(1)) + 0.5e0_rt)
 
          state(i,URHO) = rho
-         state(i,UMX)  = 0.d0
+         state(i,UMX)  = 0.e0_rt
 
          if (abs(xcell) .lt. rexp) then
             state(i,UTEMP) = T
@@ -144,6 +146,7 @@
 
         use probdata_module
 
+        use bl_fort_module, only : rt => c_real
         implicit none
         integer level, nrad
         integer lo(1), hi(1)
@@ -155,7 +158,7 @@
         integer i
 
         do i = lo(1), hi(1)
-           rad_state(i,:) = 0.d0
+           rad_state(i,:) = 0.e0_rt
         end do
       end subroutine ca_initrad
 

--- a/Exec/radiation_tests/RadThermalWave/Prob_2d.f90
+++ b/Exec/radiation_tests/RadThermalWave/Prob_2d.f90
@@ -2,13 +2,14 @@
       subroutine PROBINIT (init,name,namlen,problo,probhi)
       use probdata_module
       use network, only : network_init
+      use bl_fort_module, only : rt => c_real
       implicit none
       integer init, namlen
       integer name(namlen)
-      double precision problo(2), probhi(2)
+      real(rt)         problo(2), probhi(2)
 
       integer untin,i,j,k,dir
-      double precision rn
+      real(rt)         rn
 
       namelist /fortin/ rhocv, T0, Eexp, rexp
 
@@ -31,10 +32,10 @@
       end do
 
 !     Set defaults
-      rhocv = -1.0d50
-      T0 = -1.0d50
-      Eexp = -1.d-50
-      rexp = -1.d50
+      rhocv = -1.0e50_rt
+      T0 = -1.0e50_rt
+      Eexp = -1.e-50_rt
+      rexp = -1.e50_rt
 
       ! domain extrema
       xmin = problo(1)
@@ -82,35 +83,36 @@
 
       use network, only : nspec
 
+      use bl_fort_module, only : rt => c_real
       implicit none
       integer level, nscal
       integer lo(2), hi(2)
       integer state_l1,state_l2,state_h1,state_h2
-      double precision xlo(2), xhi(2), time, delta(2)
-      double precision state(state_l1:state_h1,state_l2:state_h2, &
+      real(rt)         xlo(2), xhi(2), time, delta(2)
+      real(rt)         state(state_l1:state_h1,state_l2:state_h2, &
           nscal)
 
       integer i,j, ii,jj
       type(eos_t) :: eos_state
-      double precision :: rho, cv, T, p, eint
-      double precision :: rhoeexp, Vexp, rhoe0
-      double precision :: xx, xcl, xcr, dx_sub
-      double precision :: yy, ycl, ycr, dy_sub 
-      double precision :: rr2, xcmin, xcmax, ycmin, ycmax, rcmin, rcmax
-      double precision :: vol_pert, vol_ambient, T_zone, rhoe_zone
+      real(rt)         :: rho, cv, T, p, eint
+      real(rt)         :: rhoeexp, Vexp, rhoe0
+      real(rt)         :: xx, xcl, xcr, dx_sub
+      real(rt)         :: yy, ycl, ycr, dy_sub 
+      real(rt)         :: rr2, xcmin, xcmax, ycmin, ycmax, rcmin, rcmax
+      real(rt)         :: vol_pert, vol_ambient, T_zone, rhoe_zone
       integer, parameter :: nsub = 64
 
-      Vexp = 4.d0/3.d0*Pi * rexp**3
+      Vexp = 4.e0_rt/3.e0_rt*Pi * rexp**3
 
       rhoeexp = Eexp / Vexp
 
-      rho = 1.0d0
-      T = 1.0d0
+      rho = 1.0e0_rt
+      T = 1.0e0_rt
 
       eos_state % rho = rho
       eos_state % T   = T
-      eos_state % xn  = 0.d0
-      eos_state % xn(1)  = 1.d0
+      eos_state % xn  = 0.e0_rt
+      eos_state % xn(1)  = 1.e0_rt
 
       call eos(eos_input_rt, eos_state)
 
@@ -144,8 +146,8 @@
             rcmax = sqrt(xcmax**2+ycmax**2)
 
             state(i,j,URHO) = rho
-            state(i,j,UMX)  = 0.d0
-            state(i,j,UMY)  = 0.d0
+            state(i,j,UMX)  = 0.e0_rt
+            state(i,j,UMY)  = 0.e0_rt
 
             if (rcmin .ge. rexp) then
                T_zone = T0
@@ -155,13 +157,13 @@
                rhoe_zone = rhoeexp
             else 
 
-               vol_pert    = 0.d0
-               vol_ambient = 0.d0
+               vol_pert    = 0.e0_rt
+               vol_ambient = 0.e0_rt
 
                do jj = 0, nsub-1
-                  yy = ycl + (dble(jj) + 0.5d0) * dy_sub
+                  yy = ycl + (dble(jj) + 0.5e0_rt) * dy_sub
                   do ii = 0, nsub-1
-                     xx = xcl + (dble(ii) + 0.5d0) * dx_sub
+                     xx = xcl + (dble(ii) + 0.5e0_rt) * dx_sub
                            
                      rr2 = xx**2 + yy**2
                            
@@ -200,6 +202,7 @@
 
         use probdata_module
 
+        use bl_fort_module, only : rt => c_real
         implicit none
         integer level, nrad
         integer lo(2), hi(2)
@@ -213,7 +216,7 @@
 
         do j = lo(2), hi(2)
            do i = lo(1), hi(1)
-              rad_state(i,j,:) = 0.d0
+              rad_state(i,j,:) = 0.e0_rt
            end do
         end do
       end subroutine ca_initrad

--- a/Exec/radiation_tests/RadThermalWave/Prob_3d.f90
+++ b/Exec/radiation_tests/RadThermalWave/Prob_3d.f90
@@ -2,13 +2,14 @@
       subroutine PROBINIT (init,name,namlen,problo,probhi)
       use probdata_module
       use network, only : network_init
+      use bl_fort_module, only : rt => c_real
       implicit none
       integer init, namlen
       integer name(namlen)
-      double precision problo(3), probhi(3)
+      real(rt)         problo(3), probhi(3)
 
       integer untin,i,j,k,dir
-      double precision rn
+      real(rt)         rn
 
       namelist /fortin/ rhocv, T0, Eexp, rexp
 
@@ -31,10 +32,10 @@
       end do
 
 !     Set defaults
-      rhocv = -1.0d50
-      T0 = -1.0d50
-      Eexp = -1.d-50
-      rexp = -1.d50
+      rhocv = -1.0e50_rt
+      T0 = -1.0e50_rt
+      Eexp = -1.e-50_rt
+      rexp = -1.e50_rt
 
       ! domain extrema and center
       xmin = problo(1)
@@ -86,36 +87,37 @@
       use network, only : nspec
       use eos_module
 
+      use bl_fort_module, only : rt => c_real
       implicit none
       integer level, nscal
       integer lo(3), hi(3)
       integer state_l1,state_l2,state_l3,state_h1,state_h2,state_h3
-      double precision xlo(3), xhi(3), time, delta(3)
-      double precision state(state_l1:state_h1,state_l2:state_h2,state_l3:state_h3, &
+      real(rt)         xlo(3), xhi(3), time, delta(3)
+      real(rt)         state(state_l1:state_h1,state_l2:state_h2,state_l3:state_h3, &
           nscal)
 
       integer i,j,k, ii, jj, kk
       type(eos_t) :: eos_state
-      double precision :: rho, cv, T, p, eint
-      double precision :: rhoeexp, Vexp, rhoe0
-      double precision :: xx, xcl, xcr, dx_sub
-      double precision :: yy, ycl, ycr, dy_sub 
-      double precision :: zz, zcl, zcr, dz_sub 
-      double precision :: rr2, xcmin, xcmax, ycmin, ycmax, zcmin, zcmax , rcmin, rcmax
-      double precision :: vol_pert, vol_ambient, T_zone, rhoe_zone
+      real(rt)         :: rho, cv, T, p, eint
+      real(rt)         :: rhoeexp, Vexp, rhoe0
+      real(rt)         :: xx, xcl, xcr, dx_sub
+      real(rt)         :: yy, ycl, ycr, dy_sub 
+      real(rt)         :: zz, zcl, zcr, dz_sub 
+      real(rt)         :: rr2, xcmin, xcmax, ycmin, ycmax, zcmin, zcmax , rcmin, rcmax
+      real(rt)         :: vol_pert, vol_ambient, T_zone, rhoe_zone
       integer, parameter :: nsub = 64
 
-      Vexp = 4.d0/3.d0*Pi * rexp**3
+      Vexp = 4.e0_rt/3.e0_rt*Pi * rexp**3
 
       rhoeexp = Eexp / Vexp
 
-      rho = 1.0d0
-      T = 1.0d0
+      rho = 1.0e0_rt
+      T = 1.0e0_rt
 
       eos_state % rho = rho
       eos_state % T   = T
-      eos_state % xn  = 0.d0
-      eos_state % xn(1)  = 1.d0
+      eos_state % xn  = 0.e0_rt
+      eos_state % xn(1)  = 1.e0_rt
       
       call eos(eos_input_rt, eos_state)
 
@@ -157,9 +159,9 @@
                rcmax = sqrt(xcmax**2+ycmax**2+zcmax**2)
                
                state(i,j,k,URHO) = rho
-               state(i,j,k,UMX)  = 0.d0
-               state(i,j,k,UMY)  = 0.d0
-               state(i,j,k,UMZ)  = 0.d0
+               state(i,j,k,UMX)  = 0.e0_rt
+               state(i,j,k,UMY)  = 0.e0_rt
+               state(i,j,k,UMZ)  = 0.e0_rt
 
                if (rcmin .ge. rexp) then
                   T_zone = T0
@@ -168,22 +170,22 @@
                   T_zone = T
                   rhoe_zone = rhoeexp
                else 
-                  vol_pert    = 0.d0
-                  vol_ambient = 0.d0
+                  vol_pert    = 0.e0_rt
+                  vol_ambient = 0.e0_rt
                   
                   do kk = 0, nsub-1
-                     zz = zcl + (dble(kk) + 0.5d0) * dz_sub
+                     zz = zcl + (dble(kk) + 0.5e0_rt) * dz_sub
                      do jj = 0, nsub-1
-                        yy = ycl + (dble(jj) + 0.5d0) * dy_sub
+                        yy = ycl + (dble(jj) + 0.5e0_rt) * dy_sub
                         do ii = 0, nsub-1
-                           xx = xcl + (dble(ii) + 0.5d0) * dx_sub
+                           xx = xcl + (dble(ii) + 0.5e0_rt) * dx_sub
                            
                            rr2 = xx**2 + yy**2 + zz**2
                            
                            if (rr2 <= rexp**2) then
-                              vol_pert = vol_pert + 1.d0
+                              vol_pert = vol_pert + 1.e0_rt
                            else
-                              vol_ambient = vol_ambient + 1.d0
+                              vol_ambient = vol_ambient + 1.e0_rt
                            endif
                         end do
                      end do
@@ -213,6 +215,7 @@
 
         use probdata_module
 
+        use bl_fort_module, only : rt => c_real
         implicit none
         integer level, nrad
         integer lo(1), hi(1)
@@ -223,7 +226,7 @@
              rad_state_l2:rad_state_h2, & 
              rad_state_l3:rad_state_h3,nrad)
 
-        rad_state = 0.d0
+        rad_state = 0.e0_rt
 
       end subroutine ca_initrad
 

--- a/Exec/radiation_tests/RadThermalWave/Tagging_nd.f90
+++ b/Exec/radiation_tests/RadThermalWave/Tagging_nd.f90
@@ -1,13 +1,14 @@
 module tagging_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
-  double precision, save ::    denerr,   dengrad
-  double precision, save ::    enterr,   entgrad
-  double precision, save ::    velerr,   velgrad
-  double precision, save ::   temperr,  tempgrad
-  double precision, save ::  presserr, pressgrad
-  double precision, save ::    raderr,   radgrad
+  real(rt)        , save ::    denerr,   dengrad
+  real(rt)        , save ::    enterr,   entgrad
+  real(rt)        , save ::    velerr,   velgrad
+  real(rt)        , save ::   temperr,  tempgrad
+  real(rt)        , save ::  presserr, pressgrad
+  real(rt)        , save ::    raderr,   radgrad
   integer         , save ::  max_denerr_lev,   max_dengrad_lev
   integer         , save ::  max_enterr_lev,   max_entgrad_lev
   integer         , save ::  max_velerr_lev,   max_velgrad_lev
@@ -51,6 +52,7 @@ contains
 
     use prob_params_module, only: dim
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer          :: set, clear, np, level
@@ -58,10 +60,10 @@ contains
     integer          :: templo(3), temphi(3)
     integer          :: lo(3), hi(3), domlo(3), domhi(3)
     integer          :: tag(taglo(1):taghi(1),taglo(2):taghi(2),taglo(3):taghi(3))
-    double precision :: temp(templo(1):temphi(1),templo(2):temphi(2),templo(3):temphi(3),np)
-    double precision :: delta(3), xlo(3), problo(3), time
+    real(rt)         :: temp(templo(1):temphi(1),templo(2):temphi(2),templo(3):temphi(3),np)
+    real(rt)         :: delta(3), xlo(3), problo(3), time
 
-    double precision :: ax, ay, az, gradT
+    real(rt)         :: ax, ay, az, gradT
     integer          :: i, j, k
 
     !     Tag on regions of high temperature

--- a/Exec/radiation_tests/RadThermalWave/probdata.f90
+++ b/Exec/radiation_tests/RadThermalWave/probdata.f90
@@ -1,10 +1,11 @@
 module probdata_module
 
-      double precision Pi
-      parameter (Pi=3.1415926535897932384d0)
+      use bl_fort_module, only : rt => c_real
+      real(rt)         Pi
+      parameter (Pi=3.1415926535897932384e0_rt)
 
-      double precision, save :: rhocv, T0, Eexp, rexp
+      real(rt)        , save :: rhocv, T0, Eexp, rexp
       
-      double precision, save :: xmin,xmax,ymin,ymax,zmin,zmax
+      real(rt)        , save :: xmin,xmax,ymin,ymax,zmin,zmax
 
 end module probdata_module

--- a/Exec/science/Detonation/Prob_1d.f90
+++ b/Exec/science/Detonation/Prob_1d.f90
@@ -3,11 +3,12 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
   use probdata_module
   use network   , only : network_species_index, nspec
   use bl_error_module
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer init, namlen
   integer name(namlen)
-  double precision problo(1), probhi(1)
+  real(rt)         problo(1), probhi(1)
 
   integer untin,i
 
@@ -31,25 +32,25 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
          
   ! set namelist defaults
   
-  T_l = 1.d9
-  T_r = 5.d7
-  dens = 1.d8
+  T_l = 1.e9_rt
+  T_r = 5.e7_rt
+  dens = 1.e8_rt
 
   idir = 1                ! direction across which to jump
   frac = 0.5              ! fraction of the domain for the interface
   cfrac = 0.5
 
-  denerr = 1.d20
-  dengrad = 1.d20
+  denerr = 1.e20_rt
+  dengrad = 1.e20_rt
   max_denerr_lev = -1
   max_dengrad_lev = -1
 
-  presserr = 1.d20
-  pressgrad = 1.d20
+  presserr = 1.e20_rt
+  pressgrad = 1.e20_rt
   max_presserr_lev = -1
   max_pressgrad_lev = -1
 
-  velgrad = 1.d20
+  velgrad = 1.e20_rt
   max_velgrad_lev = -1
   
 !     Read namelists
@@ -61,7 +62,7 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
   xmin = problo(1)
   xmax = probhi(1)
 
-  center(1) = 0.5d0*(problo(1)+probhi(1))
+  center(1) = 0.5e0_rt*(problo(1)+probhi(1))
 
   ! get the species indices
   ihe4 = network_species_index("helium-4")
@@ -74,16 +75,16 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
 
 
   ! make sure that the carbon fraction falls between 0 and 1
-  if (cfrac > 1.d0 .or. cfrac < 0.d0) then
+  if (cfrac > 1.e0_rt .or. cfrac < 0.e0_rt) then
      call bl_error("ERROR: cfrac must fall between 0 and 1")
   endif
 
   ! set the default mass fractions
   allocate(xn(nspec))
 
-  xn(:) = 0.d0
+  xn(:) = 0.e0_rt
   xn(ic12) = cfrac
-  xn(ihe4) = 1.d0 - cfrac
+  xn(ihe4) = 1.e0_rt - cfrac
   
 end subroutine PROBINIT
 
@@ -117,26 +118,27 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
   use probdata_module
   use meth_params_module, only : NVAR, URHO, UMX, UEDEN, UEINT, UTEMP, UFS
 
+  use bl_fort_module, only : rt => c_real
   implicit none
   integer level, nscal
   integer lo(1), hi(1)
   integer state_l1,state_h1
-  double precision state(state_l1:state_h1,NVAR)
-  double precision time, delta(1)
-  double precision xlo(1), xhi(1)
+  real(rt)         state(state_l1:state_h1,NVAR)
+  real(rt)         time, delta(1)
+  real(rt)         xlo(1), xhi(1)
   
-  double precision xcen
-  double precision p_temp, eint_temp
+  real(rt)         xcen
+  real(rt)         p_temp, eint_temp
   integer i
 
-  double precision :: L_x
+  real(rt)         :: L_x
 
   type (eos_t) :: eos_state
 
   L_x = xmax - xmin
 
   do i = lo(1), hi(1)
-     xcen = xmin + delta(1)*(dble(i) + 0.5d0)
+     xcen = xmin + delta(1)*(dble(i) + 0.5e0_rt)
 
      state(i,URHO ) = dens
             
@@ -154,7 +156,7 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
 
      call eos(eos_input_rt, eos_state)
     
-     state(i,UMX  ) = 0.d0
+     state(i,UMX  ) = 0.e0_rt
      state(i,UEDEN) = state(i,URHO)*eos_state%e  ! if vel /= 0, then KE needs to be added
      state(i,UEINT) = state(i,URHO)*eos_state%e
             

--- a/Exec/science/Detonation/Prob_2d.f90
+++ b/Exec/science/Detonation/Prob_2d.f90
@@ -4,11 +4,12 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
   use network   , only : network_species_index, nspec
   use bl_error_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer init, namlen
   integer name(namlen)
-  double precision problo(2), probhi(2)
+  real(rt)         problo(2), probhi(2)
   
   integer untin,i
 
@@ -31,25 +32,25 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
          
 ! set namelist defaults
 
-  T_l = 1.d9
-  T_r = 5.d7
-  dens = 1.d8
+  T_l = 1.e9_rt
+  T_r = 5.e7_rt
+  dens = 1.e8_rt
   
   idir = 1                ! direction across which to jump
   frac = 0.5              ! fraction of the domain for the interface
   cfrac = 0.5
 
-  denerr = 1.d20
-  dengrad = 1.d20
+  denerr = 1.e20_rt
+  dengrad = 1.e20_rt
   max_denerr_lev = -1
   max_dengrad_lev = -1
   
-  presserr = 1.d20
-  pressgrad = 1.d20
+  presserr = 1.e20_rt
+  pressgrad = 1.e20_rt
   max_presserr_lev = -1
   max_pressgrad_lev = -1
   
-  velgrad = 1.d20
+  velgrad = 1.e20_rt
   max_velgrad_lev = -1
   
 !     Read namelists
@@ -77,16 +78,16 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
 
 
   ! make sure that the carbon fraction falls between 0 and 1
-  if (cfrac > 1.d0 .or. cfrac < 0.d0) then
+  if (cfrac > 1.e0_rt .or. cfrac < 0.e0_rt) then
      call bl_error("ERROR: cfrac must fall between 0 and 1")
   endif
 
   ! set the default mass fractions
   allocate(xn(nspec))
 
-  xn(:) = 0.d0
+  xn(:) = 0.e0_rt
   xn(ic12) = cfrac
-  xn(io16) = 1.d0 - cfrac
+  xn(io16) = 1.e0_rt - cfrac
 
 
 end subroutine PROBINIT
@@ -122,30 +123,31 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
   use probdata_module
   use meth_params_module, only : NVAR, URHO, UMX, UMY, UEDEN, UEINT, UFS, UTEMP
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer level, nscal
   integer lo(2), hi(2)
   integer state_l1,state_l2,state_h1,state_h2
-  double precision state(state_l1:state_h1,state_l2:state_h2,NVAR)
-  double precision time, delta(2)
-  double precision xlo(2), xhi(2)
+  real(rt)         state(state_l1:state_h1,state_l2:state_h2,NVAR)
+  real(rt)         time, delta(2)
+  real(rt)         xlo(2), xhi(2)
 
-  double precision xcen, ycen
-  double precision p_temp, eint_temp
+  real(rt)         xcen, ycen
+  real(rt)         p_temp, eint_temp
   integer i,j
 
   type (eos_t) :: eos_state
 
   do j = lo(2), hi(2)
-     ycen = ymin + delta(2)*(dble(j) + 0.5d0)
+     ycen = ymin + delta(2)*(dble(j) + 0.5e0_rt)
          
      do i = lo(1), hi(1)
-        xcen = xmin + delta(1)*(dble(i) + 0.5d0)
+        xcen = xmin + delta(1)*(dble(i) + 0.5e0_rt)
             
         state(i,j,URHO ) = dens
 
-        if (xcen <= frac*(xmin + 0.5d0*(xmax-xmin))) then
+        if (xcen <= frac*(xmin + 0.5e0_rt*(xmax-xmin))) then
            state(i,j,UTEMP) = T_l
         else
            state(i,j,UTEMP) = T_r
@@ -159,8 +161,8 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
 
         call eos(eos_input_rt, eos_state)
 
-        state(i,j,UMX  ) = 0.d0
-        state(i,j,UMY  ) = 0.d0
+        state(i,j,UMX  ) = 0.e0_rt
+        state(i,j,UMY  ) = 0.e0_rt
         state(i,j,UEDEN) = state(i,j,URHO)*eos_state%e
         state(i,j,UEINT) = state(i,j,URHO)*eos_state%e
         

--- a/Exec/science/Detonation/probdata.f90
+++ b/Exec/science/Detonation/probdata.f90
@@ -1,11 +1,12 @@
 module probdata_module
 
 !     These determine the refinement criteria
-      double precision, save :: denerr,  dengrad
-      double precision, save :: velerr,  velgrad
-      double precision, save :: presserr,pressgrad
-      double precision, save :: temperr,tempgrad
-      double precision, save :: raderr,radgrad
+      use bl_fort_module, only : rt => c_real
+      real(rt)        , save :: denerr,  dengrad
+      real(rt)        , save :: velerr,  velgrad
+      real(rt)        , save :: presserr,pressgrad
+      real(rt)        , save :: temperr,tempgrad
+      real(rt)        , save :: raderr,radgrad
       integer         , save :: max_denerr_lev   ,max_dengrad_lev
       integer         , save :: max_velerr_lev   ,max_velgrad_lev
       integer         , save :: max_presserr_lev, max_pressgrad_lev
@@ -13,16 +14,16 @@ module probdata_module
       integer         , save :: max_raderr_lev, max_radgrad_lev
 
 !     Sod variables
-      double precision, save ::  T_l, T_r, dens, frac, cfrac
+      real(rt)        , save ::  T_l, T_r, dens, frac, cfrac
 
 
 !     These help specify which specific problem
       integer        , save ::  probtype,idir
 
-      double precision, save ::  center(3)
-      double precision, save :: xmin, xmax, ymin, ymax, zmin, zmax
+      real(rt)        , save ::  center(3)
+      real(rt)        , save :: xmin, xmax, ymin, ymax, zmin, zmax
       
       integer, save :: ihe4, ic12, io16
-      double precision, save, allocatable :: xn(:)
+      real(rt)        , save, allocatable :: xn(:)
 
 end module probdata_module

--- a/Exec/science/bwp-rad/Prob_2d.f90
+++ b/Exec/science/bwp-rad/Prob_2d.f90
@@ -5,10 +5,11 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
   use bl_error_module
   use prob_params_module, only : center
 
+  use bl_fort_module, only : rt => c_real
   implicit none
   integer init, namlen
   integer name(namlen)
-  double precision problo(2), probhi(2)
+  real(rt)         problo(2), probhi(2)
 
   integer untin,i,j,k,dir
 
@@ -42,8 +43,8 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
   call read_model_file(model_name)
 
   ! assume axisymmetric
-  center(1) = 0.d0
-  center(2) = 0.5d0*(problo(2)+probhi(2))
+  center(1) = 0.e0_rt
+  center(2) = 0.5e0_rt*(problo(2)+probhi(2))
 
 end subroutine PROBINIT
 
@@ -83,24 +84,25 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
   use eos_type_module
   use eos_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer level, nscal
   integer lo(2), hi(2)
   integer state_l1,state_l2,state_h1,state_h2
-  double precision xlo(2), xhi(2), time, delta(2)
-  double precision state(state_l1:state_h1,state_l2:state_h2,NVAR)
+  real(rt)         xlo(2), xhi(2), time, delta(2)
+  real(rt)         state(state_l1:state_h1,state_l2:state_h2,NVAR)
 
-  double precision xcen,ycen,dist,pres
+  real(rt)         xcen,ycen,dist,pres
   integer i,j,n
 
   type(eos_t) :: eos_state
 
   do j = lo(2), hi(2)
-     ycen = xlo(2) + delta(2)*(float(j-lo(2)) + 0.5d0) - center(2)
+     ycen = xlo(2) + delta(2)*(float(j-lo(2)) + 0.5e0_rt) - center(2)
 
      do i = lo(1), hi(1)   
-        xcen = xlo(1) + delta(1)*(float(i-lo(1)) + 0.5d0) - center(1)
+        xcen = xlo(1) + delta(1)*(float(i-lo(1)) + 0.5e0_rt) - center(1)
 
         dist = sqrt(xcen**2 + ycen**2)
 
@@ -135,7 +137,7 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
   enddo
 
   ! Initial velocities = 0
-  state(:,:,UMX:UMY) = 0.d0
+  state(:,:,UMX:UMY) = 0.e0_rt
 
 end subroutine ca_initdata
 
@@ -150,25 +152,26 @@ subroutine ca_initrad(level,time,lo,hi,nrad, &
   use model_parser_module
   use prob_params_module, only : center
 
+  use bl_fort_module, only : rt => c_real
   integer level, nrad
   integer lo(2), hi(2)
   integer rad_state_l1,rad_state_l2
   integer rad_state_h1,rad_state_h2
-  double precision ::  xlo(2), xhi(2), time, delta(2)
-  double precision :: rad_state(rad_state_l1:rad_state_h1, &
+  real(rt)         ::  xlo(2), xhi(2), time, delta(2)
+  real(rt)         :: rad_state(rad_state_l1:rad_state_h1, &
                                 rad_state_l2:rad_state_h2, nrad)
 
-  double precision xcen, ycen, dist, T
+  real(rt)         xcen, ycen, dist, T
   integer i,j
 
   do j = lo(2), hi(2)
-     ycen = xlo(2) + delta(2)*(float(j-lo(2)) + 0.5d0) - center(2)
+     ycen = xlo(2) + delta(2)*(float(j-lo(2)) + 0.5e0_rt) - center(2)
 
      do i = lo(1), hi(1)
-        xcen = xlo(1) + delta(1)*(float(i-lo(1)) + 0.5d0) - center(1)
+        xcen = xlo(1) + delta(1)*(float(i-lo(1)) + 0.5e0_rt) - center(1)
 
         dist = sqrt(xcen**2 + ycen**2)
-        rad_state(i,j,:) = 0.d0
+        rad_state(i,j,:) = 0.e0_rt
 
         !T  = interpolate(dist,npts_model,model_r,model_state(:,itemp_model))
         !rad_state(i,j,:) = a_rad*T**4                                        

--- a/Exec/science/bwp-rad/Prob_3d.f90
+++ b/Exec/science/bwp-rad/Prob_3d.f90
@@ -5,10 +5,11 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
   use bl_error_module
   use prob_params_module, only : center
 
+  use bl_fort_module, only : rt => c_real
   implicit none
   integer init, namlen
   integer name(namlen)
-  double precision problo(3), probhi(3)
+  real(rt)         problo(3), probhi(3)
 
   integer untin,i,j,k,dir
 
@@ -42,9 +43,9 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
   call read_model_file(model_name)
 
   
-  center(1) = 0.5d0*(problo(1)+probhi(1))
-  center(2) = 0.5d0*(problo(2)+probhi(2))
-  center(3) = 0.5d0*(problo(3)+probhi(3))
+  center(1) = 0.5e0_rt*(problo(1)+probhi(1))
+  center(2) = 0.5e0_rt*(problo(2)+probhi(2))
+  center(3) = 0.5e0_rt*(problo(3)+probhi(3))
 
 
 end subroutine PROBINIT
@@ -85,27 +86,28 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
   use eos_type_module
   use eos_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer level, nscal
   integer lo(3), hi(3)
   integer state_l1,state_l2, state_l3,state_h1,state_h2, state_h3
-  double precision xlo(3), xhi(3), time, delta(3)
-  double precision state(state_l1:state_h1,state_l2:state_h2,state_l3:state_h3,NVAR)
+  real(rt)         xlo(3), xhi(3), time, delta(3)
+  real(rt)         state(state_l1:state_h1,state_l2:state_h2,state_l3:state_h3,NVAR)
 
-  double precision xcen,ycen,zcen,dist,pres
+  real(rt)         xcen,ycen,zcen,dist,pres
   integer i,j,k,n
 
   type(eos_t) :: eos_state
 
   do k = lo(3), hi(3)
-     zcen = xlo(3) + delta(3)*(float(k-lo(3)) + 0.5d0) - center(3)
+     zcen = xlo(3) + delta(3)*(float(k-lo(3)) + 0.5e0_rt) - center(3)
 
      do j = lo(2), hi(2)
-        ycen = xlo(2) + delta(2)*(float(j-lo(2)) + 0.5d0) - center(2)
+        ycen = xlo(2) + delta(2)*(float(j-lo(2)) + 0.5e0_rt) - center(2)
 
         do i = lo(1), hi(1)
-           xcen = xlo(1) + delta(1)*(float(i-lo(1)) + 0.5d0) - center(1)
+           xcen = xlo(1) + delta(1)*(float(i-lo(1)) + 0.5e0_rt) - center(1)
 
            dist = sqrt(xcen**2 + ycen**2 + zcen**2)
 
@@ -149,7 +151,7 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
   enddo
 
   ! Initial velocities = 0
-  state(:,:,:,UMX:UMZ) = 0.d0
+  state(:,:,:,UMX:UMZ) = 0.e0_rt
 
       
 
@@ -166,29 +168,30 @@ subroutine ca_initrad(level,time,lo,hi,nrad, &
   use model_parser_module
   use prob_params_module, only : center
 
+  use bl_fort_module, only : rt => c_real
   integer level, nrad
   integer lo(3), hi(3)
   integer rad_state_l1,rad_state_l2, rad_state_l3
   integer rad_state_h1,rad_state_h2, rad_state_h3
-  double precision ::  xlo(3), xhi(3), time, delta(3)
-  double precision :: rad_state(rad_state_l1:rad_state_h1, &
+  real(rt)         ::  xlo(3), xhi(3), time, delta(3)
+  real(rt)         :: rad_state(rad_state_l1:rad_state_h1, &
                                 rad_state_l2:rad_state_h2, rad_state_l3:rad_state_h3, nrad)
 
-  double precision xcen, ycen, zcen, dist, T
+  real(rt)         xcen, ycen, zcen, dist, T
   integer i,j,k
 
 
   do k = lo(3), hi(3)
-     zcen = xlo(3) + delta(3)*(float(k-lo(3)) + 0.5d0) - center(3)
+     zcen = xlo(3) + delta(3)*(float(k-lo(3)) + 0.5e0_rt) - center(3)
         
      do j = lo(2), hi(2)
-        ycen = xlo(2) + delta(2)*(float(j-lo(2)) + 0.5d0) - center(2)
+        ycen = xlo(2) + delta(2)*(float(j-lo(2)) + 0.5e0_rt) - center(2)
 
         do i = lo(1), hi(1)
-           xcen = xlo(1) + delta(1)*(float(i-lo(1)) + 0.5d0) - center(1)
+           xcen = xlo(1) + delta(1)*(float(i-lo(1)) + 0.5e0_rt) - center(1)
 
            dist = sqrt(xcen**2 + ycen**2 + zcen**2)
-           rad_state(i,j,k,:) = 0.d0
+           rad_state(i,j,k,:) = 0.e0_rt
 
         end do                            
 

--- a/Exec/science/bwp-rad/probdata.f90
+++ b/Exec/science/bwp-rad/probdata.f90
@@ -1,6 +1,7 @@
 module probdata_module
 
 !     These determine the refinement criteria
+      use bl_fort_module, only : rt => c_real
       character (len=80), save  :: model_name
 
 end module probdata_module

--- a/Exec/science/bwp/Prob_2d.f90
+++ b/Exec/science/bwp/Prob_2d.f90
@@ -5,10 +5,11 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
   use bl_error_module
   use prob_params_module, only : center
 
+  use bl_fort_module, only : rt => c_real
   implicit none
   integer init, namlen
   integer name(namlen)
-  double precision problo(2), probhi(2)
+  real(rt)         problo(2), probhi(2)
 
   integer untin,i,j,k,dir
 
@@ -42,8 +43,8 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
   call read_model_file(model_name)
 
   ! assume axisymmetric
-  center(1) = 0.d0
-  center(2) = 0.5d0*(problo(2)+probhi(2))
+  center(1) = 0.e0_rt
+  center(2) = 0.5e0_rt*(problo(2)+probhi(2))
 
 end subroutine PROBINIT
 
@@ -83,24 +84,25 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
   use eos_type_module
   use eos_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer level, nscal
   integer lo(2), hi(2)
   integer state_l1,state_l2,state_h1,state_h2
-  double precision xlo(2), xhi(2), time, delta(2)
-  double precision state(state_l1:state_h1,state_l2:state_h2,NVAR)
+  real(rt)         xlo(2), xhi(2), time, delta(2)
+  real(rt)         state(state_l1:state_h1,state_l2:state_h2,NVAR)
 
-  double precision xcen,ycen,dist,pres
+  real(rt)         xcen,ycen,dist,pres
   integer i,j,n
 
   type(eos_t) :: eos_state
 
   do j = lo(2), hi(2)
-     ycen = xlo(2) + delta(2)*(float(j-lo(2)) + 0.5d0) - center(2)
+     ycen = xlo(2) + delta(2)*(float(j-lo(2)) + 0.5e0_rt) - center(2)
 
      do i = lo(1), hi(1)   
-        xcen = xlo(1) + delta(1)*(float(i-lo(1)) + 0.5d0) - center(1)
+        xcen = xlo(1) + delta(1)*(float(i-lo(1)) + 0.5e0_rt) - center(1)
 
         dist = sqrt(xcen**2 + ycen**2)
 
@@ -135,6 +137,6 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
   enddo
 
   ! Initial velocities = 0
-  state(:,:,UMX:UMY) = 0.d0
+  state(:,:,UMX:UMY) = 0.e0_rt
 
 end subroutine ca_initdata

--- a/Exec/science/bwp/probdata.f90
+++ b/Exec/science/bwp/probdata.f90
@@ -1,6 +1,7 @@
 module probdata_module
 
 !     These determine the refinement criteria
+      use bl_fort_module, only : rt => c_real
       character (len=80), save  :: model_name
 
 end module probdata_module

--- a/Exec/science/convective_flame/Prob_2d.f90
+++ b/Exec/science/convective_flame/Prob_2d.f90
@@ -9,11 +9,12 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
   use eos_type_module
   use eos_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer :: init, namlen
   integer :: name(namlen)
-  double precision :: problo(2), probhi(2)
+  real(rt)         :: problo(2), probhi(2)
 
   type (eos_t) :: eos_state
 
@@ -37,7 +38,7 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
   ! set namelist defaults here
   zero_vels = .false.
   x_pert_loc = ONE
-  pert_width = 0.1_dp_t
+  pert_width = 0.1_rt
   pert_factor = ONE
   refine_cutoff_height = HALF*(problo(2)+probhi(2))
   
@@ -105,18 +106,19 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
   use eos_type_module
   use network, only: nspec, network_species_index
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer :: level, nscal
   integer :: lo(2), hi(2)
   integer :: state_l1, state_l2, state_h1, state_h2
-  double precision :: xlo(2), xhi(2), time, delta(2)
-  double precision :: state(state_l1:state_h1,state_l2:state_h2,NVAR)
+  real(rt)         :: xlo(2), xhi(2), time, delta(2)
+  real(rt)         :: state(state_l1:state_h1,state_l2:state_h2,NVAR)
 
   integer :: i, j, n
-  double precision :: x, y
+  real(rt)         :: x, y
 
-  double precision :: dens, temp, pres
+  real(rt)         :: dens, temp, pres
 
   type (eos_t) :: eos_state
   
@@ -145,7 +147,7 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
                 interpolate(y,npts_model,model_r, model_state(:,ispec_model-1+n))
         enddo
 
-        if (dens > cutoff_density .and. state(i,j,UFS-1+ifuel) > 0.99d0) then
+        if (dens > cutoff_density .and. state(i,j,UFS-1+ifuel) > 0.99e0_rt) then
            state(i,j,UTEMP) = temp * (ONE + (pert_factor * &
                 (ONE + tanh((x_pert_loc-x)/pert_width)) ) )
         else

--- a/Exec/science/convective_flame/Prob_3d.f90
+++ b/Exec/science/convective_flame/Prob_3d.f90
@@ -7,11 +7,12 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
   use probdata_module
   use prob_params_module, only: center
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer :: init, namlen
   integer :: name(namlen)
-  double precision :: problo(3), probhi(3)
+  real(rt)         :: problo(3), probhi(3)
 
   integer :: untin,i
 
@@ -33,7 +34,7 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
   ! set namelist defaults here
   zero_vels = .false.
   x_pert_loc = ONE
-  pert_width = 0.1_dp_t
+  pert_width = 0.1_rt
   pert_factor = ONE
 
   ! Read namelists
@@ -87,19 +88,20 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
   use eos_type_module
   use network, only: nspec, network_species_index
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer :: level, nscal
   integer :: lo(3), hi(3)
   integer :: state_l1,state_l2,state_l3,state_h1,state_h2,state_h3
-  double precision xlo(3), xhi(3), time, delta(3)
-  double precision state(state_l1:state_h1, &
+  real(rt)         xlo(3), xhi(3), time, delta(3)
+  real(rt)         state(state_l1:state_h1, &
                          state_l2:state_h2, &
                          state_l3:state_h3,NVAR)
 
   integer :: i, j, k, n
-  double precision :: x, y, z
-  double precision :: dens, temp, pres
+  real(rt)         :: x, y, z
+  real(rt)         :: dens, temp, pres
 
   type (eos_t) :: eos_state
 
@@ -130,7 +132,7 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
                    interpolate(z,npts_model,model_r, model_state(:,ispec_model-1+n))
            enddo
 
-           if (dens > cutoff_density .and. state(i,j,k,UFS-1+ifuel) > 0.99d0) then
+           if (dens > cutoff_density .and. state(i,j,k,UFS-1+ifuel) > 0.99e0_rt) then
               state(i,j,k,UTEMP) = temp * (ONE + (pert_factor * &
                    (ONE + tanh((x_pert_loc-x)/pert_width)) ) )
            else

--- a/Exec/science/convective_flame/bc_fill_2d.F90
+++ b/Exec/science/convective_flame/bc_fill_2d.F90
@@ -1,5 +1,6 @@
 module bc_fill_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   public
@@ -12,6 +13,7 @@ contains
     use meth_params_module, only : NVAR
     use hse_bc_module
 
+    use bl_fort_module, only : rt => c_real
     implicit none
     
     include 'bc_types.fi'
@@ -19,8 +21,8 @@ contains
     integer          :: adv_l1,adv_l2,adv_h1,adv_h2
     integer          :: bc(2,2,*)
     integer          :: domlo(2), domhi(2)
-    double precision :: delta(2), xlo(2), time
-    double precision :: adv(adv_l1:adv_h1,adv_l2:adv_h2,NVAR)
+    real(rt)         :: delta(2), xlo(2), time
+    real(rt)         :: adv(adv_l1:adv_h1,adv_l2:adv_h2,NVAR)
 
     integer :: n
 
@@ -52,6 +54,7 @@ contains
     use probdata_module
     use hse_bc_module
 
+    use bl_fort_module, only : rt => c_real
     implicit none
     
     include 'bc_types.fi'
@@ -59,8 +62,8 @@ contains
     integer          :: adv_l1,adv_l2,adv_h1,adv_h2
     integer          :: bc(2,2,*)
     integer          :: domlo(2), domhi(2)
-    double precision :: delta(2), xlo(2), time
-    double precision :: adv(adv_l1:adv_h1,adv_l2:adv_h2)
+    real(rt)         :: delta(2), xlo(2), time
+    real(rt)         :: adv(adv_l1:adv_h1,adv_l2:adv_h2)
 
     ! Note: this function should not be needed, technically, but is
     ! provided to filpatch because there are many times in the algorithm
@@ -92,6 +95,7 @@ contains
 
     use probdata_module
     
+    use bl_fort_module, only : rt => c_real
     implicit none
     
     include 'bc_types.fi'
@@ -99,8 +103,8 @@ contains
     integer :: grav_l1,grav_l2,grav_h1,grav_h2
     integer :: bc(2,2,*)
     integer :: domlo(2), domhi(2)
-    double precision delta(2), xlo(2), time
-    double precision grav(grav_l1:grav_h1,grav_l2:grav_h2)
+    real(rt)         delta(2), xlo(2), time
+    real(rt)         grav(grav_l1:grav_h1,grav_l2:grav_h2)
 
     integer :: bc_temp(2,2)
 
@@ -123,6 +127,7 @@ contains
 
     use probdata_module
 
+    use bl_fort_module, only : rt => c_real
     implicit none
     
     include 'bc_types.fi'
@@ -130,8 +135,8 @@ contains
     integer :: grav_l1,grav_l2,grav_h1,grav_h2
     integer :: bc(2,2,*)
     integer :: domlo(2), domhi(2)
-    double precision delta(2), xlo(2), time
-    double precision grav(grav_l1:grav_h1,grav_l2:grav_h2)
+    real(rt)         delta(2), xlo(2), time
+    real(rt)         grav(grav_l1:grav_h1,grav_l2:grav_h2)
 
     integer :: bc_temp(2,2)
 
@@ -154,6 +159,7 @@ contains
 
     use probdata_module
     
+    use bl_fort_module, only : rt => c_real
     implicit none
     
     include 'bc_types.fi'
@@ -161,8 +167,8 @@ contains
     integer :: grav_l1,grav_l2,grav_h1,grav_h2
     integer :: bc(2,2,*)
     integer :: domlo(2), domhi(2)
-    double precision delta(2), xlo(2), time
-    double precision grav(grav_l1:grav_h1,grav_l2:grav_h2)
+    real(rt)         delta(2), xlo(2), time
+    real(rt)         grav(grav_l1:grav_h1,grav_l2:grav_h2)
 
     integer :: bc_temp(2,2)
 
@@ -183,6 +189,7 @@ contains
                             phi_h1,phi_h2,domlo,domhi,delta,xlo,time,bc) &
                             bind(C, name="ca_phigravfill")
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     include 'bc_types.fi'
@@ -190,8 +197,8 @@ contains
     integer          :: phi_l1,phi_l2,phi_h1,phi_h2
     integer          :: bc(2,2,*)
     integer          :: domlo(2), domhi(2)
-    double precision :: delta(2), xlo(2), time
-    double precision :: phi(phi_l1:phi_h1,phi_l2:phi_h2)
+    real(rt)         :: delta(2), xlo(2), time
+    real(rt)         :: phi(phi_l1:phi_h1,phi_l2:phi_h2)
 
     integer :: bc_temp(2,2)
 
@@ -214,6 +221,7 @@ contains
 
     use probdata_module
     
+    use bl_fort_module, only : rt => c_real
     implicit none
     
     include 'bc_types.fi'
@@ -221,8 +229,8 @@ contains
     integer :: rot_l1,rot_l2,rot_h1,rot_h2
     integer :: bc(2,2,*)
     integer :: domlo(2), domhi(2)
-    double precision delta(2), xlo(2), time
-    double precision rot(rot_l1:rot_h1,rot_l2:rot_h2)
+    real(rt)         delta(2), xlo(2), time
+    real(rt)         rot(rot_l1:rot_h1,rot_l2:rot_h2)
 
     integer :: bc_temp(2,2)
 
@@ -245,6 +253,7 @@ contains
 
     use probdata_module
 
+    use bl_fort_module, only : rt => c_real
     implicit none
     
     include 'bc_types.fi'
@@ -252,8 +261,8 @@ contains
     integer :: rot_l1,rot_l2,rot_h1,rot_h2
     integer :: bc(2,2,*)
     integer :: domlo(2), domhi(2)
-    double precision delta(2), xlo(2), time
-    double precision rot(rot_l1:rot_h1,rot_l2:rot_h2)
+    real(rt)         delta(2), xlo(2), time
+    real(rt)         rot(rot_l1:rot_h1,rot_l2:rot_h2)
 
     integer :: bc_temp(2,2)
 
@@ -276,6 +285,7 @@ contains
 
     use probdata_module
     
+    use bl_fort_module, only : rt => c_real
     implicit none
     
     include 'bc_types.fi'
@@ -283,8 +293,8 @@ contains
     integer :: rot_l1,rot_l2,rot_h1,rot_h2
     integer :: bc(2,2,*)
     integer :: domlo(2), domhi(2)
-    double precision delta(2), xlo(2), time
-    double precision rot(rot_l1:rot_h1,rot_l2:rot_h2)
+    real(rt)         delta(2), xlo(2), time
+    real(rt)         rot(rot_l1:rot_h1,rot_l2:rot_h2)
 
     integer :: bc_temp(2,2)
 
@@ -305,6 +315,7 @@ contains
                            phi_h1,phi_h2,domlo,domhi,delta,xlo,time,bc) &
                            bind(C, name="ca_phirotfill")
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     include 'bc_types.fi'
@@ -312,8 +323,8 @@ contains
     integer          :: phi_l1,phi_l2,phi_h1,phi_h2
     integer          :: bc(2,2,*)
     integer          :: domlo(2), domhi(2)
-    double precision :: delta(2), xlo(2), time
-    double precision :: phi(phi_l1:phi_h1,phi_l2:phi_h2)
+    real(rt)         :: delta(2), xlo(2), time
+    real(rt)         :: phi(phi_l1:phi_h1,phi_l2:phi_h2)
 
     integer :: bc_temp(2,2)
 
@@ -334,6 +345,7 @@ contains
                           react_h1,react_h2,domlo,domhi,delta,xlo,time,bc) &
                           bind(C, name="ca_reactfill")
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     include 'bc_types.fi'
@@ -341,8 +353,8 @@ contains
     integer          :: react_l1,react_l2,react_h1,react_h2
     integer          :: bc(2,2,*)
     integer          :: domlo(2), domhi(2)
-    double precision :: delta(2), xlo(2), time
-    double precision :: react(react_l1:react_h1,react_l2:react_h2)
+    real(rt)         :: delta(2), xlo(2), time
+    real(rt)         :: react(react_l1:react_h1,react_l2:react_h2)
 
     integer :: bc_temp(2,2)
 

--- a/Exec/science/convective_flame/bc_fill_3d.F90
+++ b/Exec/science/convective_flame/bc_fill_3d.F90
@@ -1,5 +1,6 @@
 module bc_fill_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   public
@@ -12,6 +13,7 @@ contains
     use meth_params_module, only: NVAR
     use hse_bc_module
 
+    use bl_fort_module, only : rt => c_real
     implicit none
     
     include 'bc_types.fi'
@@ -19,8 +21,8 @@ contains
     integer          :: adv_l1,adv_l2,adv_l3,adv_h1,adv_h2,adv_h3
     integer          :: bc(3,2,*)
     integer          :: domlo(3), domhi(3)
-    double precision :: delta(3), xlo(3), time
-    double precision :: adv(adv_l1:adv_h1,adv_l2:adv_h2,adv_l3:adv_h3,NVAR)
+    real(rt)         :: delta(3), xlo(3), time
+    real(rt)         :: adv(adv_l1:adv_h1,adv_l2:adv_h2,adv_l3:adv_h3,NVAR)
 
     integer :: n
 
@@ -52,6 +54,7 @@ contains
     use probdata_module
     use hse_bc_module
 
+    use bl_fort_module, only : rt => c_real
     implicit none
     
     include 'bc_types.fi'
@@ -59,8 +62,8 @@ contains
     integer          :: adv_l1,adv_l2,adv_l3,adv_h1,adv_h2,adv_h3
     integer          :: bc(3,2,*)
     integer          :: domlo(3), domhi(3)
-    double precision :: delta(3), xlo(3), time
-    double precision :: adv(adv_l1:adv_h1,adv_l2:adv_h2,adv_l3:adv_h3)
+    real(rt)         :: delta(3), xlo(3), time
+    real(rt)         :: adv(adv_l1:adv_h1,adv_l2:adv_h2,adv_l3:adv_h3)
 
     ! Note: this function should not be needed, technically, but is
     ! provided to filpatch because there are many times in the algorithm
@@ -90,6 +93,7 @@ contains
   subroutine ca_gravxfill(grav,grav_l1,grav_l2,grav_l3,grav_h1,grav_h2,grav_h3, &
                           domlo,domhi,delta,xlo,time,bc) bind(C, name="ca_gravxfill")
 
+    use bl_fort_module, only : rt => c_real
     implicit none
     
     include 'bc_types.fi'
@@ -97,8 +101,8 @@ contains
     integer          :: grav_l1,grav_l2,grav_l3,grav_h1,grav_h2,grav_h3
     integer          :: bc(3,2,*)
     integer          :: domlo(3), domhi(3)
-    double precision :: delta(3), xlo(3), time
-    double precision :: grav(grav_l1:grav_h1,grav_l2:grav_h2,grav_l3:grav_h3)
+    real(rt)         :: delta(3), xlo(3), time
+    real(rt)         :: grav(grav_l1:grav_h1,grav_l2:grav_h2,grav_l3:grav_h3)
 
     integer :: bc_temp(3,2)
 
@@ -118,6 +122,7 @@ contains
   subroutine ca_gravyfill(grav,grav_l1,grav_l2,grav_l3,grav_h1,grav_h2,grav_h3, &
                           domlo,domhi,delta,xlo,time,bc) bind(C, name="ca_gravyfill")
 
+    use bl_fort_module, only : rt => c_real
     implicit none
     
     include 'bc_types.fi'
@@ -125,8 +130,8 @@ contains
     integer          :: grav_l1,grav_l2,grav_l3,grav_h1,grav_h2,grav_h3
     integer          :: bc(3,2,*)
     integer          :: domlo(3), domhi(3)
-    double precision :: delta(3), xlo(3), time
-    double precision :: grav(grav_l1:grav_h1,grav_l2:grav_h2,grav_l3:grav_h3)
+    real(rt)         :: delta(3), xlo(3), time
+    real(rt)         :: grav(grav_l1:grav_h1,grav_l2:grav_h2,grav_l3:grav_h3)
 
     integer :: bc_temp(3,2)
 
@@ -146,6 +151,7 @@ contains
   subroutine ca_gravzfill(grav,grav_l1,grav_l2,grav_l3,grav_h1,grav_h2,grav_h3, &
                           domlo,domhi,delta,xlo,time,bc) bind(C, name="ca_gravzfill")
 
+    use bl_fort_module, only : rt => c_real
     implicit none
     
     include 'bc_types.fi'
@@ -153,8 +159,8 @@ contains
     integer          :: grav_l1,grav_l2,grav_l3,grav_h1,grav_h2,grav_h3
     integer          :: bc(3,2,*)
     integer          :: domlo(3), domhi(3)
-    double precision :: delta(3), xlo(3), time
-    double precision :: grav(grav_l1:grav_h1,grav_l2:grav_h2,grav_l3:grav_h3)
+    real(rt)         :: delta(3), xlo(3), time
+    real(rt)         :: grav(grav_l1:grav_h1,grav_l2:grav_h2,grav_l3:grav_h3)
 
     integer :: bc_temp(3,2)
 
@@ -175,6 +181,7 @@ contains
                             phi_h1,phi_h2,phi_h3,domlo,domhi,delta,xlo,time,bc) &
                             bind(C, name="ca_phigravfill")
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     include 'bc_types.fi'
@@ -182,8 +189,8 @@ contains
     integer          :: phi_l1,phi_l2,phi_l3,phi_h1,phi_h2,phi_h3
     integer          :: bc(3,2,*)
     integer          :: domlo(3), domhi(3)
-    double precision :: delta(3), xlo(3), time
-    double precision :: phi(phi_l1:phi_h1,phi_l2:phi_h2,phi_l3:phi_h3)
+    real(rt)         :: delta(3), xlo(3), time
+    real(rt)         :: phi(phi_l1:phi_h1,phi_l2:phi_h2,phi_l3:phi_h3)
 
     integer :: bc_temp(3,2)
 
@@ -203,6 +210,7 @@ contains
   subroutine ca_rotxfill(rot,rot_l1,rot_l2,rot_l3,rot_h1,rot_h2,rot_h3, &
                          domlo,domhi,delta,xlo,time,bc) bind(C, name="ca_rotxfill")
 
+    use bl_fort_module, only : rt => c_real
     implicit none
     
     include 'bc_types.fi'
@@ -210,8 +218,8 @@ contains
     integer          :: rot_l1,rot_l2,rot_l3,rot_h1,rot_h2,rot_h3
     integer          :: bc(3,2,*)
     integer          :: domlo(3), domhi(3)
-    double precision :: delta(3), xlo(3), time
-    double precision :: rot(rot_l1:rot_h1,rot_l2:rot_h2,rot_l3:rot_h3)
+    real(rt)         :: delta(3), xlo(3), time
+    real(rt)         :: rot(rot_l1:rot_h1,rot_l2:rot_h2,rot_l3:rot_h3)
 
     integer :: bc_temp(3,2)
 
@@ -231,6 +239,7 @@ contains
   subroutine ca_rotyfill(rot,rot_l1,rot_l2,rot_l3,rot_h1,rot_h2,rot_h3, &
                          domlo,domhi,delta,xlo,time,bc) bind(C, name="ca_rotyfill")
 
+    use bl_fort_module, only : rt => c_real
     implicit none
     
     include 'bc_types.fi'
@@ -238,8 +247,8 @@ contains
     integer          :: rot_l1,rot_l2,rot_l3,rot_h1,rot_h2,rot_h3
     integer          :: bc(3,2,*)
     integer          :: domlo(3), domhi(3)
-    double precision :: delta(3), xlo(3), time
-    double precision :: rot(rot_l1:rot_h1,rot_l2:rot_h2,rot_l3:rot_h3)
+    real(rt)         :: delta(3), xlo(3), time
+    real(rt)         :: rot(rot_l1:rot_h1,rot_l2:rot_h2,rot_l3:rot_h3)
 
     integer :: bc_temp(3,2)
 
@@ -259,6 +268,7 @@ contains
   subroutine ca_rotzfill(rot,rot_l1,rot_l2,rot_l3,rot_h1,rot_h2,rot_h3, &
                          domlo,domhi,delta,xlo,time,bc) bind(C, name="ca_rotzfill")
 
+    use bl_fort_module, only : rt => c_real
     implicit none
     
     include 'bc_types.fi'
@@ -266,8 +276,8 @@ contains
     integer          :: rot_l1,rot_l2,rot_l3,rot_h1,rot_h2,rot_h3
     integer          :: bc(3,2,*)
     integer          :: domlo(3), domhi(3)
-    double precision :: delta(3), xlo(3), time
-    double precision :: rot(rot_l1:rot_h1,rot_l2:rot_h2,rot_l3:rot_h3)
+    real(rt)         :: delta(3), xlo(3), time
+    real(rt)         :: rot(rot_l1:rot_h1,rot_l2:rot_h2,rot_l3:rot_h3)
 
     integer :: bc_temp(3,2)
 
@@ -288,6 +298,7 @@ contains
                            phi_h1,phi_h2,phi_h3,domlo,domhi,delta,xlo,time,bc) &
                            bind(C, name="ca_phirotfill")
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     include 'bc_types.fi'
@@ -295,8 +306,8 @@ contains
     integer          :: phi_l1,phi_l2,phi_l3,phi_h1,phi_h2,phi_h3
     integer          :: bc(3,2,*)
     integer          :: domlo(3), domhi(3)
-    double precision :: delta(3), xlo(3), time
-    double precision :: phi(phi_l1:phi_h1,phi_l2:phi_h2,phi_l3:phi_h3)
+    real(rt)         :: delta(3), xlo(3), time
+    real(rt)         :: phi(phi_l1:phi_h1,phi_l2:phi_h2,phi_l3:phi_h3)
 
     integer :: bc_temp(3,2)
 
@@ -317,6 +328,7 @@ contains
                           react_h1,react_h2,react_h3,domlo,domhi,delta,xlo,time,bc) &
                           bind(C, name="ca_reactfill")
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     include 'bc_types.fi'
@@ -324,8 +336,8 @@ contains
     integer          :: react_l1,react_l2,react_l3,react_h1,react_h2,react_h3
     integer          :: bc(3,2,*)
     integer          :: domlo(3), domhi(3)
-    double precision :: delta(3), xlo(3), time
-    double precision :: react(react_l1:react_h1,react_l2:react_h2,react_l3:react_h3)
+    real(rt)         :: delta(3), xlo(3), time
+    real(rt)         :: react(react_l1:react_h1,react_l2:react_h2,react_l3:react_h3)
 
     integer :: bc_temp(3,2)
 
@@ -346,6 +358,7 @@ contains
                         rad_h1,rad_h2,rad_h3,domlo,domhi,delta,xlo,time,bc) &
                         bind(C, name="ca_radfill")
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     include 'bc_types.fi'
@@ -353,8 +366,8 @@ contains
     integer          :: rad_l1,rad_l2,rad_l3,rad_h1,rad_h2,rad_h3
     integer          :: bc(3,2,*)
     integer          :: domlo(3), domhi(3)
-    double precision :: delta(3), xlo(3), time
-    double precision :: rad(rad_l1:rad_h1,rad_l2:rad_h2,rad_l3:rad_h3)
+    real(rt)         :: delta(3), xlo(3), time
+    real(rt)         :: rad(rad_l1:rad_h1,rad_l2:rad_h2,rad_l3:rad_h3)
 
     integer :: bc_temp(3,2)
 

--- a/Exec/science/convective_flame/hydrostatic_bc_2d.f90
+++ b/Exec/science/convective_flame/hydrostatic_bc_2d.f90
@@ -4,10 +4,11 @@ module hse_bc_module
   use bl_error_module
   use prob_params_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, parameter :: MAX_ITER = 100
-  double precision, parameter :: TOL = 1.e-8_dp_t
+  real(rt)        , parameter :: TOL = 1.e-8_rt
   
 contains
 
@@ -21,18 +22,19 @@ contains
     use eos_module
     use network, only: nspec
 
+    use bl_fort_module, only : rt => c_real
     implicit none
     integer :: adv_l1, adv_l2, adv_h1, adv_h2
     integer :: bc(2,2,*)
     integer :: domlo(2), domhi(2)
-    double precision :: delta(2), xlo(2), time
-    double precision :: adv(adv_l1:adv_h1,adv_l2:adv_h2,NVAR)
+    real(rt)         :: delta(2), xlo(2), time
+    real(rt)         :: adv(adv_l1:adv_h1,adv_l2:adv_h2,NVAR)
     logical, intent(in), optional :: density_only
 
     integer :: i, j, iter
-    double precision :: y, y0, slope
-    double precision :: pres_above, p_want, pres_zone, A
-    double precision :: drho,dpdr, temp_zone, eint, X_zone(nspec), dens_zone
+    real(rt)         :: y, y0, slope
+    real(rt)         :: pres_above, p_want, pres_zone, A
+    real(rt)         :: drho,dpdr, temp_zone, eint, X_zone(nspec), dens_zone
 
     logical :: just_density
 
@@ -111,8 +113,8 @@ contains
              A = p_want - pres_zone
              drho = A/(dpdr + HALF*delta(2)*const_grav)
 
-             dens_zone = max(0.9_dp_t*dens_zone, &
-                             min(dens_zone + drho, 1.1_dp_t*dens_zone))
+             dens_zone = max(0.9_rt*dens_zone, &
+                             min(dens_zone + drho, 1.1_rt*dens_zone))
 
              ! convergence?
              if (abs(drho) < TOL*dens_zone) then
@@ -175,12 +177,13 @@ contains
     use eos_module
     use network, only: nspec
 
+    use bl_fort_module, only : rt => c_real
     implicit none
     integer adv_l1,adv_l2,adv_h1,adv_h2
     integer bc(2,2,*)
     integer domlo(2), domhi(2)
-    double precision delta(2), xlo(2), time
-    double precision adv(adv_l1:adv_h1,adv_l2:adv_h2,NVAR)
+    real(rt)         delta(2), xlo(2), time
+    real(rt)         adv(adv_l1:adv_h1,adv_l2:adv_h2,NVAR)
     logical, intent(in), optional :: density_only
 
     integer i,j

--- a/Exec/science/convective_flame/hydrostatic_bc_3d.f90
+++ b/Exec/science/convective_flame/hydrostatic_bc_3d.f90
@@ -4,10 +4,11 @@ module hse_bc_module
   use bl_error_module
   use prob_params_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, parameter :: MAX_ITER = 100
-  double precision, parameter :: TOL = 1.e-8_dp_t
+  real(rt)        , parameter :: TOL = 1.e-8_rt
   
 contains
 
@@ -21,18 +22,19 @@ contains
     use eos_module
     use network, only: nspec
 
+    use bl_fort_module, only : rt => c_real
     implicit none
     integer :: adv_l1, adv_l2, adv_l3, adv_h1, adv_h2, adv_h3
     integer :: bc(3,2,*)
     integer :: domlo(3), domhi(3)
-    double precision :: delta(3), xlo(3), time
-    double precision :: adv(adv_l1:adv_h1,adv_l2:adv_h2,adv_l3:adv_h3,NVAR)
+    real(rt)         :: delta(3), xlo(3), time
+    real(rt)         :: adv(adv_l1:adv_h1,adv_l2:adv_h2,adv_l3:adv_h3,NVAR)
     logical, intent(in), optional :: density_only
 
     integer :: i, j, k, iter
-    double precision :: z, z0, slope
-    double precision :: pres_above, p_want, pres_zone, A
-    double precision :: drho,dpdr, temp_zone, eint, X_zone(nspec), dens_zone
+    real(rt)         :: z, z0, slope
+    real(rt)         :: pres_above, p_want, pres_zone, A
+    real(rt)         :: drho,dpdr, temp_zone, eint, X_zone(nspec), dens_zone
 
     logical :: just_density
 
@@ -111,8 +113,8 @@ contains
                 A = p_want - pres_zone
                 drho = A/(dpdr + HALF*delta(3)*const_grav)
 
-                dens_zone = max(0.9_dp_t*dens_zone, &
-                                min(dens_zone + drho, 1.1_dp_t*dens_zone))
+                dens_zone = max(0.9_rt*dens_zone, &
+                                min(dens_zone + drho, 1.1_rt*dens_zone))
 
                 ! convergence?
                 if (abs(drho) < TOL*dens_zone) then
@@ -176,12 +178,13 @@ contains
     use eos_module
     use network, only: nspec
 
+    use bl_fort_module, only : rt => c_real
     implicit none
     integer adv_l1,adv_l2,adv_l3,adv_h1,adv_h2,adv_h3
     integer bc(3,2,*)
     integer domlo(3), domhi(3)
-    double precision delta(3), xlo(3), time
-    double precision adv(adv_l1:adv_h1,adv_l2:adv_h2,adv_l3:adv_h3,NVAR)
+    real(rt)         delta(3), xlo(3), time
+    real(rt)         adv(adv_l1:adv_h1,adv_l2:adv_h2,adv_l3:adv_h3,NVAR)
     logical, intent(in), optional :: density_only
 
     integer i,j,k

--- a/Exec/science/convective_flame/probdata.f90
+++ b/Exec/science/convective_flame/probdata.f90
@@ -2,19 +2,20 @@ module probdata_module
 
   use network, only : nspec
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   character(len=80), save :: model_name
 
-  double precision, save :: pert_factor, x_pert_loc, pert_width
-  double precision, save :: cutoff_density
+  real(rt)        , save :: pert_factor, x_pert_loc, pert_width
+  real(rt)        , save :: cutoff_density
 
-  double precision, save :: thermal_conductivity
+  real(rt)        , save :: thermal_conductivity
 
   logical         , save :: zero_vels
 
-  double precision, save :: rho_ambient, T_ambient, e_ambient, xn_ambient(nspec)
+  real(rt)        , save :: rho_ambient, T_ambient, e_ambient, xn_ambient(nspec)
 
-  double precision, save :: refine_cutoff_height
+  real(rt)        , save :: refine_cutoff_height
   
 end module probdata_module

--- a/Exec/science/convective_flame/problem_tagging_2d.f90
+++ b/Exec/science/convective_flame/problem_tagging_2d.f90
@@ -1,5 +1,6 @@
 module problem_tagging_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   public
@@ -16,22 +17,23 @@ contains
     use probdata_module, only: refine_cutoff_height
     use meth_params_module, only: NVAR
     
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer         ,intent(in   ) :: lo(2),hi(2)
     integer         ,intent(in   ) :: state_l1,state_l2,state_h1,state_h2
     integer         ,intent(in   ) :: tagl1,tagl2,tagh1,tagh2
-    double precision,intent(in   ) :: state(state_l1:state_h1,state_l2:state_h2, NVAR)
+    real(rt)        ,intent(in   ) :: state(state_l1:state_h1,state_l2:state_h2, NVAR)
     integer         ,intent(inout) :: tag(tagl1:tagh1,tagl2:tagh2)
-    double precision,intent(in   ) :: problo(2),dx(2),time
+    real(rt)        ,intent(in   ) :: problo(2),dx(2),time
     integer         ,intent(in   ) :: level,set,clear
 
     integer :: i, j
 
-    double precision :: y
+    real(rt)         :: y
     
     do j = lo(2), hi(2)
-       y = problo(2) + dble(j + 0.5d0)*dx(2)
+       y = problo(2) + dble(j + 0.5e0_rt)*dx(2)
        do i = lo(1), hi(1)
           if (y > refine_cutoff_height) then
              tag(i,j) = clear

--- a/Exec/science/flame_wave/Prob_2d.f90
+++ b/Exec/science/flame_wave/Prob_2d.f90
@@ -4,11 +4,12 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
   use model_parser_module
   use bl_error_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer init, namlen
   integer name(namlen)
-  double precision problo(2), probhi(2)
+  real(rt)         problo(2), probhi(2)
 
   integer untin,i
   
@@ -29,13 +30,13 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
   end do
 
   ! Namelist defaults
-  H_min = 1.d-4
-  cutoff_density = 500.d0
+  H_min = 1.e-4_rt
+  cutoff_density = 500.e0_rt
   
   
-  dtemp = 3.81d8
-  x_half_max = 1.2d5
-  x_half_width = 3.6d4
+  dtemp = 3.81e8_rt
+  x_half_max = 1.2e5_rt
+  x_half_width = 3.6e4_rt
   
   interp_BC = .false.
   zero_vels = .false.
@@ -82,20 +83,21 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
   use network, only: nspec
   use model_parser_module
   
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer level, nscal
   integer lo(2), hi(2)
   integer state_l1,state_l2,state_h1,state_h2
-  double precision xlo(2), xhi(2), time, delta(2)
-  double precision state(state_l1:state_h1,state_l2:state_h2,NVAR)
+  real(rt)         xlo(2), xhi(2), time, delta(2)
+  real(rt)         state(state_l1:state_h1,state_l2:state_h2,NVAR)
 
-  double precision dist,x,y
+  real(rt)         dist,x,y
   integer i,j,n
 
-  double precision t0,x1,y1,r1,temp
+  real(rt)         t0,x1,y1,r1,temp
 
-  double precision temppres(state_l1:state_h1,state_l2:state_h2)
+  real(rt)         temppres(state_l1:state_h1,state_l2:state_h2)
 
   type (eos_t) :: eos_state
 
@@ -144,7 +146,7 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
   enddo
 
   ! Initial velocities = 0
-  state(:,:,UMX:UMZ) = 0.d0 
+  state(:,:,UMX:UMZ) = 0.e0_rt 
 
   ! Now add the perturbation
   do j = lo(2), hi(2)
@@ -153,7 +155,7 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
      do i = lo(1), hi(1)
         x = problo(1) + (dble(i)+HALF)*delta(1)
         
-        if (state(i,j,UFS) > 0.1 .and. state(i,j,URHO) > 1.0d5) then
+        if (state(i,j,UFS) > 0.1 .and. state(i,j,URHO) > 1.0e5_rt) then
            state(i,j,UTEMP)=state(i,j,UTEMP) + dtemp / &
                 (ONE + exp((x-x_half_max)/x_half_width))   
         end if 

--- a/Exec/science/flame_wave/probdata.f90
+++ b/Exec/science/flame_wave/probdata.f90
@@ -1,10 +1,11 @@
 module probdata_module
 
+  use bl_fort_module, only : rt => c_real
   character(len=80), save :: model_name
 
-  double precision, save :: dtemp, x_half_max, x_half_width
+  real(rt)        , save :: dtemp, x_half_max, x_half_width
 
-  double precision, save :: H_min, cutoff_density
+  real(rt)        , save :: H_min, cutoff_density
   ! lower boundary
   logical         , save :: interp_BC, zero_vels
 

--- a/Exec/science/flame_wave/problem_tagging_2d.f90
+++ b/Exec/science/flame_wave/problem_tagging_2d.f90
@@ -1,5 +1,6 @@
 module problem_tagging_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   public
@@ -15,14 +16,15 @@ contains
     use meth_params_module, only: URHO, NVAR, UFS
     use probdata_module, only: H_min, cutoff_density
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer         ,intent(in   ) :: lo(2),hi(2)
     integer         ,intent(in   ) :: state_l1,state_l2,state_h1,state_h2
     integer         ,intent(in   ) :: tagl1,tagl2,tagh1,tagh2
-    double precision,intent(in   ) :: state(state_l1:state_h1,state_l2:state_h2, NVAR)
+    real(rt)        ,intent(in   ) :: state(state_l1:state_h1,state_l2:state_h2, NVAR)
     integer         ,intent(inout) :: tag(tagl1:tagh1,tagl2:tagh2)
-    double precision,intent(in   ) :: problo(2),dx(2),time
+    real(rt)        ,intent(in   ) :: problo(2),dx(2),time
     integer         ,intent(in   ) :: level,set,clear
 
     integer :: i, j

--- a/Exec/science/xrb_mixed/Prob_2d.f90
+++ b/Exec/science/xrb_mixed/Prob_2d.f90
@@ -4,13 +4,14 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
   use model_parser_module
   use bl_error_module
   
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer init, namlen
   integer name(namlen)
-  double precision problo(2), probhi(2)
+  real(rt)         problo(2), probhi(2)
 
-  double precision offset
+  real(rt)         offset
   integer untin,i
 
   namelist /fortin/ model_name, apply_vel_field, &
@@ -32,12 +33,12 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
 
   ! Namelist defaults
   apply_vel_field = .false.
-  velpert_scale = 1.0d2
-  velpert_amplitude = 1.0d2
-  velpert_height_loc = 6.5d3
+  velpert_scale = 1.0e2_rt
+  velpert_amplitude = 1.0e2_rt
+  velpert_height_loc = 6.5e3_rt
   num_vortices = 1
-  H_min = 1.d-4
-  cutoff_density = 50.d0
+  H_min = 1.e-4_rt
+  cutoff_density = 50.e0_rt
   
   ! Read namelists
   untin = 9
@@ -98,23 +99,24 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
   use network, only: nspec
   use model_parser_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
         
   integer level, nscal
   integer lo(2), hi(2)
   integer state_l1,state_l2,state_h1,state_h2
-  double precision xlo(2), xhi(2), time, delta(2)
-  double precision state(state_l1:state_h1,state_l2:state_h2,NVAR)
+  real(rt)         xlo(2), xhi(2), time, delta(2)
+  real(rt)         state(state_l1:state_h1,state_l2:state_h2,NVAR)
   
-  double precision xdist,ydist,x,y,r,upert(2)
+  real(rt)         xdist,ydist,x,y,r,upert(2)
   integer i,j,n,vortex
 
-  double precision temppres(state_l1:state_h1,state_l2:state_h2)
+  real(rt)         temppres(state_l1:state_h1,state_l2:state_h2)
         
   type (eos_t) :: eos_state
 
   do j = lo(2), hi(2)
-     y = xlo(2) + delta(2)*(dble(j-lo(2)) + 0.5d0)
+     y = xlo(2) + delta(2)*(dble(j-lo(2)) + 0.5e0_rt)
 
      do i = lo(1), hi(1)   
 
@@ -158,19 +160,19 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
   enddo
 
   ! Initial velocities = 0
-  state(:,:,UMX:UMZ) = 0.d0
+  state(:,:,UMX:UMZ) = 0.e0_rt
 
   ! Now add the velocity perturbation
   if (apply_vel_field) then
 
      do j = lo(2), hi(2)
-        y = xlo(2) + delta(2)*(dble(j-lo(2)) + 0.5d0)
+        y = xlo(2) + delta(2)*(dble(j-lo(2)) + 0.5e0_rt)
         ydist = y - velpert_height_loc
         
         do i = lo(1), hi(1)   
-           x = xlo(1) + delta(1)*(dble(i-lo(1)) + 0.5d0)
+           x = xlo(1) + delta(1)*(dble(i-lo(1)) + 0.5e0_rt)
 
-           upert = 0.d0
+           upert = 0.e0_rt
 
            ! loop over each vortex
            do vortex = 1, num_vortices
@@ -180,12 +182,12 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
               r = sqrt(xdist**2 + ydist**2)
               
               upert(1) = upert(1) - ydist * &
-                   velpert_amplitude * exp( -r**2/(2.d0*velpert_scale)) &
-                   * (-1.d0)**vortex
+                   velpert_amplitude * exp( -r**2/(2.e0_rt*velpert_scale)) &
+                   * (-1.e0_rt)**vortex
               
               upert(2) = upert(2) + xdist * &
-                   velpert_amplitude * exp(-r**2/(2.d0*velpert_scale)) &
-                   * (-1.d0)**vortex
+                   velpert_amplitude * exp(-r**2/(2.e0_rt*velpert_scale)) &
+                   * (-1.e0_rt)**vortex
            enddo
            
            state(i,j,UMX) = state(i,j,URHO) * upert(1)

--- a/Exec/science/xrb_mixed/probdata.f90
+++ b/Exec/science/xrb_mixed/probdata.f90
@@ -1,15 +1,16 @@
 module probdata_module
 
-  double precision, save :: H_min, cutoff_density
+  use bl_fort_module, only : rt => c_real
+  real(rt)        , save :: H_min, cutoff_density
 
   character(len=80), save :: model_name
 
   ! Velocity perturbation
   logical         , save :: apply_vel_field
 
-  double precision, save :: velpert_scale, velpert_amplitude, velpert_height_loc
+  real(rt)        , save :: velpert_scale, velpert_amplitude, velpert_height_loc
   integer         , save :: num_vortices
 
-  double precision, allocatable, save :: xloc_vortices(:)
+  real(rt)        , allocatable, save :: xloc_vortices(:)
 
 end module probdata_module

--- a/Exec/science/xrb_mixed/problem_tagging_2d.f90
+++ b/Exec/science/xrb_mixed/problem_tagging_2d.f90
@@ -1,5 +1,6 @@
 module problem_tagging_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   public
@@ -15,14 +16,15 @@ contains
     use meth_params_module, only: URHO, NVAR, UFS
     use probdata_module, only: H_min, cutoff_density
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer         ,intent(in   ) :: lo(2),hi(2)
     integer         ,intent(in   ) :: state_l1,state_l2,state_h1,state_h2
     integer         ,intent(in   ) :: tagl1,tagl2,tagh1,tagh2
-    double precision,intent(in   ) :: state(state_l1:state_h1,state_l2:state_h2, NVAR)
+    real(rt)        ,intent(in   ) :: state(state_l1:state_h1,state_l2:state_h2, NVAR)
     integer         ,intent(inout) :: tag(tagl1:tagh1,tagl2:tagh2)
-    double precision,intent(in   ) :: problo(2),dx(2),time
+    real(rt)        ,intent(in   ) :: problo(2),dx(2),time
     integer         ,intent(in   ) :: level,set,clear
 
     integer :: i, j

--- a/Exec/unit_tests/diffusion_test/Prob_2d.f90
+++ b/Exec/unit_tests/diffusion_test/Prob_2d.f90
@@ -9,11 +9,12 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
   use network, only : nspec
   use extern_probin_module, only: const_conductivity
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer init, namlen
   integer name(namlen)
-  double precision problo(2), probhi(2)
+  real(rt)         problo(2), probhi(2)
 
   integer untin,i
 
@@ -23,7 +24,7 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
 
   integer, parameter :: maxlen = 256
   character probin*(maxlen)
-  real (kind=dp_t) :: X(nspec)
+  real(rt)         :: X(nspec)
 
   type (eos_t) :: eos_state
 
@@ -34,14 +35,14 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
   end do
          
   ! Set namelist defaults
-  T1 = 1.0_dp_t
-  T2 = 2.0_dp_t
-  t_0 = 0.001_dp_t
-  diff_coeff = 1.0_dp_t
+  T1 = 1.0_rt
+  T2 = 2.0_rt
+  t_0 = 0.001_rt
+  diff_coeff = 1.0_rt
 
   ! set center, domain extrema
-  center(1) = (problo(1)+probhi(1))/2.d0
-  center(2) = (problo(2)+probhi(2))/2.d0
+  center(1) = (problo(1)+probhi(1))/2.e0_rt
+  center(2) = (problo(2)+probhi(2))/2.e0_rt
 
   ! Read namelists
   untin = 9
@@ -56,8 +57,8 @@ subroutine PROBINIT (init,name,namlen,problo,probhi)
   ! free parameter we have to play with is rho.  Note that for an
   ! ideal gas, c_v does not depend on rho, so we can call it the EOS
   ! with any density.
-  X(:) = 0.d0
-  X(1) = 1.d0
+  X(:) = 0.e0_rt
+  X(1) = 1.e0_rt
 
   eos_state%T = T1
   eos_state%rho = 1.0
@@ -105,24 +106,25 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
   use meth_params_module, only : NVAR, URHO, UMX, UMY, UEDEN, UEINT, UFS, UTEMP
   use prob_params_module, only : problo, center
   
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer :: level, nscal
   integer :: lo(2), hi(2)
   integer :: state_l1,state_l2,state_h1,state_h2
-  double precision :: xlo(2), xhi(2), time, delta(2)
-  double precision :: state(state_l1:state_h1,state_l2:state_h2,NVAR)
+  real(rt)         :: xlo(2), xhi(2), time, delta(2)
+  real(rt)         :: state(state_l1:state_h1,state_l2:state_h2,NVAR)
 
-  double precision :: xc, yc
-  double precision :: X(nspec), temp
-  double precision :: dist2
+  real(rt)         :: xc, yc
+  real(rt)         :: X(nspec), temp
+  real(rt)         :: dist2
   integer :: i,j
 
   type (eos_t) :: eos_state
 
   ! set the composition
-  X(:) = 0.d0
-  X(1) = 1.d0
+  X(:) = 0.e0_rt
+  X(1) = 1.e0_rt
 
   do j = lo(2), hi(2)
      yc = problo(2) + delta(2)*(dble(j) + HALF)
@@ -134,7 +136,7 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
 
         dist2 = (xc - center(1))**2 + (yc - center(2))**2
 
-        temp = (T2 - T1)*exp(-0.25_dp_t*dist2/(diff_coeff*t_0) ) + T1
+        temp = (T2 - T1)*exp(-0.25_rt*dist2/(diff_coeff*t_0) ) + T1
         state(i,j,UTEMP) = temp
 
         ! compute the internal energy and temperature
@@ -148,7 +150,7 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
         state(i,j,UMY) = ZERO
 
         state(i,j,UEDEN) = rho0*eos_state%e +  &
-             0.5d0*(state(i,j,UMX)**2/state(i,j,URHO) + &
+             0.5e0_rt*(state(i,j,UMX)**2/state(i,j,URHO) + &
                     state(i,j,UMY)**2/state(i,j,URHO))
 
         state(i,j,UEINT) = rho0*eos_state%e

--- a/Exec/unit_tests/diffusion_test/probdata.f90
+++ b/Exec/unit_tests/diffusion_test/probdata.f90
@@ -1,9 +1,10 @@
 module probdata_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
-  double precision, save :: thermal_conductivity, diff_coeff
-  double precision, save :: T1, T2, rho0
-  double precision, save :: t_0
+  real(rt)        , save :: thermal_conductivity, diff_coeff
+  real(rt)        , save :: T1, T2, rho0
+  real(rt)        , save :: t_0
 
 end module probdata_module

--- a/Exec/unit_tests/test_react/testburn.f90
+++ b/Exec/unit_tests/test_react/testburn.f90
@@ -9,24 +9,25 @@ subroutine do_burn() bind(C)
   use reactions_module, only: ca_react_state
   use extern_probin_module, only: ncell, dt, dens_min, dens_max, temp_min, temp_max
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, parameter :: nv = 7 + nspec
 
-  double precision, parameter :: time = 0.0d0
+  real(rt)        , parameter :: time = 0.0e0_rt
 
   integer :: lo(3), hi(3), w(3)
 
-  double precision :: dlogrho, dlogT
+  real(rt)         :: dlogrho, dlogT
 
-  double precision, allocatable :: state(:,:,:,:), reactions(:,:,:,:)
+  real(rt)        , allocatable :: state(:,:,:,:), reactions(:,:,:,:)
   integer, allocatable :: mask(:,:,:)
 
   integer :: i, j, k
 
   type (eos_t) :: eos_state
 
-  double precision :: start, finish
+  real(rt)         :: start, finish
 
   character (len=32) :: probin_file
   integer :: probin_pass(32)
@@ -78,10 +79,10 @@ subroutine do_burn() bind(C)
 
            state(i,j,k,:) = ZERO
 
-           eos_state % rho = 10.0d0**(log10(dens_min) + dble(i)*dlogrho)
-           eos_state % T   = 10.0d0**(log10(temp_min) + dble(j)*dlogT  )
-           eos_state % xn  = 1.d-12
-           eos_state % xn(1 + INT( (dble(k) / w(3)) * nspec)) = ONE  - (nspec - 1) * 1.d-12
+           eos_state % rho = 10.0e0_rt**(log10(dens_min) + dble(i)*dlogrho)
+           eos_state % T   = 10.0e0_rt**(log10(temp_min) + dble(j)*dlogT  )
+           eos_state % xn  = 1.e-12_rt
+           eos_state % xn(1 + INT( (dble(k) / w(3)) * nspec)) = ONE  - (nspec - 1) * 1.e-12_rt
 
            call eos(eos_input_rt, eos_state)
 

--- a/Source/Radiation/RadSrc_1d/CastroRad_1d.f90
+++ b/Source/Radiation/RadSrc_1d/CastroRad_1d.f90
@@ -8,21 +8,22 @@ subroutine ca_compute_lamborder(Er, Er_l1, Er_h1, &
   use fluxlimiter_module, only : FLDlambda
   use filter_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: Er_l1, Er_h1, kap_l1, kap_h1, lam_l1, lam_h1
   integer, intent(in) :: ngrow, limiter, filter_T, S
-  double precision, intent(in) :: dx
-  double precision, intent(in) :: kap(kap_l1:kap_h1, 0:ngroups-1)
-  double precision, intent(in) :: Er(Er_l1:Er_h1, 0:ngroups-1)
-  double precision, intent(out) :: lam(lam_l1:lam_h1, 0:ngroups-1)
+  real(rt)        , intent(in) :: dx
+  real(rt)        , intent(in) :: kap(kap_l1:kap_h1, 0:ngroups-1)
+  real(rt)        , intent(in) :: Er(Er_l1:Er_h1, 0:ngroups-1)
+  real(rt)        , intent(out) :: lam(lam_l1:lam_h1, 0:ngroups-1)
 
   integer :: i, reg_l1, reg_h1, g
-  double precision :: r
+  real(rt)         :: r
 
-  double precision, allocatable :: lamfil(:)
+  real(rt)        , allocatable :: lamfil(:)
 
-  lam = -1.d50
+  lam = -1.e50_rt
 
   reg_l1 = lam_l1 + ngrow
   reg_h1 = lam_h1 - ngrow
@@ -34,19 +35,19 @@ subroutine ca_compute_lamborder(Er, Er_l1, Er_h1, &
   do g = 0, ngroups-1
      do i=lam_l1, lam_h1
         r = abs(Er(i+1,g) - Er(i-1,g)) / (2.*dx)
-        r = r / (kap(i,g) * max(Er(i,g), 1.d-50))
+        r = r / (kap(i,g) * max(Er(i,g), 1.e-50_rt))
         lam(i,g) = FLDlambda(r, limiter)
      end do
 
-     if (Er(reg_l1-1,g) .eq. -1.d0) then
+     if (Er(reg_l1-1,g) .eq. -1.e0_rt) then
         r = abs(Er(reg_l1+1,g) - Er(reg_l1,g)) / dx
-        r = r / (kap(reg_l1,g) * max(Er(reg_l1,g), 1.d-50))
+        r = r / (kap(reg_l1,g) * max(Er(reg_l1,g), 1.e-50_rt))
         lam(reg_l1,g) = FLDlambda(r, limiter)
      end if
 
-     if (Er(reg_h1+1,g) .eq. -1.d0) then
+     if (Er(reg_h1+1,g) .eq. -1.e0_rt) then
         r = abs(Er(reg_h1,g) - Er(reg_h1-1,g)) / dx
-        r = r / (kap(reg_h1,g) * max(Er(reg_h1,g), 1.d-50))
+        r = r / (kap(reg_h1,g) * max(Er(reg_h1,g), 1.e-50_rt))
         lam(reg_h1,g) = FLDlambda(r, limiter)
      end if
 
@@ -56,19 +57,19 @@ subroutine ca_compute_lamborder(Er, Er_l1, Er_h1, &
         do i=reg_l1, reg_h1
            lamfil(i) = ff1(0) * lam(i,g) &
                 &    + ff1(1) * (lam(i-1,g)+lam(i+1,g))
-           lamfil(i) = min(1.d0/3.d0, max(1.d-25, lamfil(i)))
+           lamfil(i) = min(1.e0_rt/3.e0_rt, max(1.e-25_rt, lamfil(i)))
          end do
 
-         if (Er(reg_l1-1,g) .eq. -1.d0) then
+         if (Er(reg_l1-1,g) .eq. -1.e0_rt) then
             i = reg_l1
             lamfil(i) = dot_product(ff1b, lam(i:i+1,g))
-            lamfil(i) = min(1.d0/3.d0, max(1.d-25, lamfil(i)))
+            lamfil(i) = min(1.e0_rt/3.e0_rt, max(1.e-25_rt, lamfil(i)))
          end if
 
-         if (Er(reg_h1+1,g) .eq. -1.d0) then
+         if (Er(reg_h1+1,g) .eq. -1.e0_rt) then
             i = reg_h1
             lamfil(i) = dot_product(ff1b(1:0:-1), lam(i-1:i,g))
-            lamfil(i) = min(1.d0/3.d0, max(1.d-25, lamfil(i)))
+            lamfil(i) = min(1.e0_rt/3.e0_rt, max(1.e-25_rt, lamfil(i)))
          end if
 
          lam(reg_l1:reg_h1,g) = lamfil(reg_l1:reg_h1)
@@ -79,27 +80,27 @@ subroutine ca_compute_lamborder(Er, Er_l1, Er_h1, &
             lamfil(i) = ff2(0,S) * lam(i,g) &
                  &    + ff2(1,S) * (lam(i-1,g)+lam(i+1,g)) &
                  &    + ff2(2,S) * (lam(i-2,g)+lam(i+2,g))
-            lamfil(i) = min(1.d0/3.d0, max(1.d-25, lamfil(i)))
+            lamfil(i) = min(1.e0_rt/3.e0_rt, max(1.e-25_rt, lamfil(i)))
          end do
 
-         if (Er(reg_l1-1,g) .eq. -1.d0) then
+         if (Er(reg_l1-1,g) .eq. -1.e0_rt) then
             i = reg_l1
             lamfil(i) = dot_product(ff2b0, lam(i:i+2,g))
-            lamfil(i) = min(1.d0/3.d0, max(1.d-25, lamfil(i)))
+            lamfil(i) = min(1.e0_rt/3.e0_rt, max(1.e-25_rt, lamfil(i)))
 
             i = reg_l1 + 1
             lamfil(i) = dot_product(ff2b1, lam(i-1:i+2,g))
-            lamfil(i) = min(1.d0/3.d0, max(1.d-25, lamfil(i)))
+            lamfil(i) = min(1.e0_rt/3.e0_rt, max(1.e-25_rt, lamfil(i)))
          end if
 
-         if (Er(reg_h1+1,g) .eq. -1.d0) then
+         if (Er(reg_h1+1,g) .eq. -1.e0_rt) then
             i = reg_h1-1
             lamfil(i) = dot_product(ff2b1(2:-1:-1), lam(i-2:i+1,g))
-            lamfil(i) = min(1.d0/3.d0, max(1.d-25, lamfil(i)))
+            lamfil(i) = min(1.e0_rt/3.e0_rt, max(1.e-25_rt, lamfil(i)))
 
             i = reg_h1
             lamfil(i) = dot_product(ff2b0(2:0:-1), lam(i-2:i,g))
-            lamfil(i) = min(1.d0/3.d0, max(1.d-25, lamfil(i)))
+            lamfil(i) = min(1.e0_rt/3.e0_rt, max(1.e-25_rt, lamfil(i)))
          end if
 
          lam(reg_l1:reg_h1,g) = lamfil(reg_l1:reg_h1)
@@ -111,35 +112,35 @@ subroutine ca_compute_lamborder(Er, Er_l1, Er_h1, &
                  &    + ff3(1,S) * (lam(i-1,g)+lam(i+1,g)) &
                  &    + ff3(2,S) * (lam(i-2,g)+lam(i+2,g)) &
                  &    + ff3(3,S) * (lam(i-3,g)+lam(i+3,g))
-            lamfil(i) = min(1.d0/3.d0, max(1.d-25, lamfil(i)))
+            lamfil(i) = min(1.e0_rt/3.e0_rt, max(1.e-25_rt, lamfil(i)))
          end do
 
-         if (Er(reg_l1-1,g) .eq. -1.d0) then
+         if (Er(reg_l1-1,g) .eq. -1.e0_rt) then
             i = reg_l1
             lamfil(i) = dot_product(ff3b0, lam(i:i+3,g))
-            lamfil(i) = min(1.d0/3.d0, max(1.d-25, lamfil(i)))
+            lamfil(i) = min(1.e0_rt/3.e0_rt, max(1.e-25_rt, lamfil(i)))
 
             i = reg_l1 + 1
             lamfil(i) = dot_product(ff3b1, lam(i-1:i+3,g))
-            lamfil(i) = min(1.d0/3.d0, max(1.d-25, lamfil(i)))
+            lamfil(i) = min(1.e0_rt/3.e0_rt, max(1.e-25_rt, lamfil(i)))
 
             i = reg_l1 + 2
             lamfil(i) = dot_product(ff3b2, lam(i-2:i+3,g))
-            lamfil(i) = min(1.d0/3.d0, max(1.d-25, lamfil(i)))
+            lamfil(i) = min(1.e0_rt/3.e0_rt, max(1.e-25_rt, lamfil(i)))
          end if
 
-         if (Er(reg_h1+1,g) .eq. -1.d0) then
+         if (Er(reg_h1+1,g) .eq. -1.e0_rt) then
             i = reg_h1 - 2
             lamfil(i) = dot_product(ff3b2(3:-2:-1), lam(i-3:i+2,g))
-            lamfil(i) = min(1.d0/3.d0, max(1.d-25, lamfil(i)))
+            lamfil(i) = min(1.e0_rt/3.e0_rt, max(1.e-25_rt, lamfil(i)))
 
             i = reg_h1 - 1
             lamfil(i) = dot_product(ff3b1(3:-1:-1), lam(i-3:i+1,g))
-            lamfil(i) = min(1.d0/3.d0, max(1.d-25, lamfil(i)))
+            lamfil(i) = min(1.e0_rt/3.e0_rt, max(1.e-25_rt, lamfil(i)))
 
             i = reg_h1
             lamfil(i) = dot_product(ff3b0(3:0:-1), lam(i-3:i,g))
-            lamfil(i) = min(1.d0/3.d0, max(1.d-25, lamfil(i)))
+            lamfil(i) = min(1.e0_rt/3.e0_rt, max(1.e-25_rt, lamfil(i)))
          end if
 
          lam(reg_l1:reg_h1,g) = lamfil(reg_l1:reg_h1)
@@ -152,43 +153,43 @@ subroutine ca_compute_lamborder(Er, Er_l1, Er_h1, &
                  &    + ff4(2,S) * (lam(i-2,g)+lam(i+2,g)) &
                  &    + ff4(3,S) * (lam(i-3,g)+lam(i+3,g)) &
                  &    + ff4(4,S) * (lam(i-4,g)+lam(i+4,g))
-            lamfil(i) = min(1.d0/3.d0, max(1.d-25, lamfil(i)))
+            lamfil(i) = min(1.e0_rt/3.e0_rt, max(1.e-25_rt, lamfil(i)))
          end do
 
-         if (Er(reg_l1-1,g) .eq. -1.d0) then
+         if (Er(reg_l1-1,g) .eq. -1.e0_rt) then
             i = reg_l1
             lamfil(i) = dot_product(ff4b0, lam(i:i+4,g))
-            lamfil(i) = min(1.d0/3.d0, max(1.d-25, lamfil(i)))
+            lamfil(i) = min(1.e0_rt/3.e0_rt, max(1.e-25_rt, lamfil(i)))
 
             i = reg_l1 + 1
             lamfil(i) = dot_product(ff4b1, lam(i-1:i+4,g))
-            lamfil(i) = min(1.d0/3.d0, max(1.d-25, lamfil(i)))
+            lamfil(i) = min(1.e0_rt/3.e0_rt, max(1.e-25_rt, lamfil(i)))
 
             i = reg_l1 + 2
             lamfil(i) = dot_product(ff4b2, lam(i-2:i+4,g))
-            lamfil(i) = min(1.d0/3.d0, max(1.d-25, lamfil(i)))
+            lamfil(i) = min(1.e0_rt/3.e0_rt, max(1.e-25_rt, lamfil(i)))
 
             i = reg_l1 + 3
             lamfil(i) = dot_product(ff4b3, lam(i-3:i+4,g))
-            lamfil(i) = min(1.d0/3.d0, max(1.d-25, lamfil(i)))
+            lamfil(i) = min(1.e0_rt/3.e0_rt, max(1.e-25_rt, lamfil(i)))
          end if
 
-         if (Er(reg_h1+1,g) .eq. -1.d0) then
+         if (Er(reg_h1+1,g) .eq. -1.e0_rt) then
             i = reg_h1 - 3
             lamfil(i) = dot_product(ff4b3(4:-3:-1), lam(i-4:i+3,g))
-            lamfil(i) = min(1.d0/3.d0, max(1.d-25, lamfil(i)))
+            lamfil(i) = min(1.e0_rt/3.e0_rt, max(1.e-25_rt, lamfil(i)))
 
             i = reg_h1 - 2
             lamfil(i) = dot_product(ff4b2(4:-2:-1), lam(i-4:i+2,g))
-            lamfil(i) = min(1.d0/3.d0, max(1.d-25, lamfil(i)))
+            lamfil(i) = min(1.e0_rt/3.e0_rt, max(1.e-25_rt, lamfil(i)))
 
             i = reg_h1 - 1
             lamfil(i) = dot_product(ff4b1(4:-1:-1), lam(i-4:i+1,g))
-            lamfil(i) = min(1.d0/3.d0, max(1.d-25, lamfil(i)))
+            lamfil(i) = min(1.e0_rt/3.e0_rt, max(1.e-25_rt, lamfil(i)))
 
             i = reg_h1
             lamfil(i) = dot_product(ff4b0(4:0:-1), lam(i-4:i,g))
-            lamfil(i) = min(1.d0/3.d0, max(1.d-25, lamfil(i)))
+            lamfil(i) = min(1.e0_rt/3.e0_rt, max(1.e-25_rt, lamfil(i)))
          end if
 
          lam(reg_l1:reg_h1,g) = lamfil(reg_l1:reg_h1)
@@ -197,13 +198,13 @@ subroutine ca_compute_lamborder(Er, Er_l1, Er_h1, &
 
      ! boundary
 
-     if (Er(reg_l1-1,g) .eq. -1.d0) then
+     if (Er(reg_l1-1,g) .eq. -1.e0_rt) then
         do i=lam_l1, reg_l1-1
            lam(i,g) = lam(reg_l1,g)
         end do
      end if
 
-     if (Er(reg_h1+1,g) .eq. -1.d0) then
+     if (Er(reg_h1+1,g) .eq. -1.e0_rt) then
         do i=reg_h1+1, lam_h1
            lam(i,g) = lam(reg_h1,g)
         end do
@@ -232,27 +233,28 @@ subroutine ca_get_v_dcf( lo, hi, &
 
   use meth_params_module, only : NVAR, URHO, UMX
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: lo(1), hi(1)
   integer, intent(in) :: er_l1,er_h1,s_l1,s_h1,T_l1,T_h1,c_v_l1,c_v_h1
   integer, intent(in) :: kr_l1,kr_h1,kp_l1,kp_h1,kp2_l1,kp2_h1
   integer, intent(in) :: v_l1,v_h1,dcf_l1,dcf_h1
-  double precision, intent(in)  ::  er( er_l1: er_h1)
-  double precision, intent(in)  ::   s(  s_l1:  s_h1, NVAR)
-  double precision, intent(in)  ::   T(  T_l1:  T_h1)
-  double precision, intent(in)  :: c_v(c_v_l1:c_v_h1)
-  double precision, intent(in ) ::  kr( kr_l1: kr_h1)
-  double precision, intent(in ) ::  kp( kp_l1: kp_h1)
-  double precision, intent(in ) :: kp2(kp2_l1:kp2_h1)
-  double precision, intent(in) :: dtemp, dtime, sigma, c
-  double precision ::   v(  v_l1:  v_h1)
-  double precision :: dcf(dcf_l1:dcf_h1)
+  real(rt)        , intent(in)  ::  er( er_l1: er_h1)
+  real(rt)        , intent(in)  ::   s(  s_l1:  s_h1, NVAR)
+  real(rt)        , intent(in)  ::   T(  T_l1:  T_h1)
+  real(rt)        , intent(in)  :: c_v(c_v_l1:c_v_h1)
+  real(rt)        , intent(in ) ::  kr( kr_l1: kr_h1)
+  real(rt)        , intent(in ) ::  kp( kp_l1: kp_h1)
+  real(rt)        , intent(in ) :: kp2(kp2_l1:kp2_h1)
+  real(rt)        , intent(in) :: dtemp, dtime, sigma, c
+  real(rt)         ::   v(  v_l1:  v_h1)
+  real(rt)         :: dcf(dcf_l1:dcf_h1)
 
   integer :: i
-  double precision :: etainv, fac0, fac2, alpha, frc
+  real(rt)         :: etainv, fac0, fac2, alpha, frc
 
-  fac0 = 4.d0 * sigma * dtime / dtemp
+  fac0 = 4.e0_rt * sigma * dtime / dtemp
   fac2 = c * dtime / dtemp
 
   do i=lo(1),hi(1)
@@ -262,10 +264,10 @@ subroutine ca_get_v_dcf( lo, hi, &
           -          kp (i) * (T(i)        ) ** 4)   &
           -  fac2 * (kp2(i) - kp(i)) * er(i)
 
-     frc = s(i,URHO) * c_v(i) + 1.0d-50
+     frc = s(i,URHO) * c_v(i) + 1.0e-50_rt
      etainv = frc / (alpha + frc)
 
-     dcf(i) = 2.d0 * etainv * (kp(i) / kr(i))
+     dcf(i) = 2.e0_rt * etainv * (kp(i) / kr(i))
   end do
 
 end subroutine ca_get_v_dcf
@@ -278,6 +280,7 @@ subroutine ca_compute_dcoefs( lo, hi, &
      dcf, dcf_l1, dcf_h1, &
      r, idir)
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: lo(1), hi(1)
@@ -287,18 +290,18 @@ subroutine ca_compute_dcoefs( lo, hi, &
        & dcf_l1, dcf_h1, &
        idir
 
-  double precision              ::   d(  d_l1:  d_h1)
-  double precision, intent(in)  :: lam(lam_l1:lam_h1)
-  double precision, intent(in)  ::   v(  v_l1:  v_h1)
-  double precision, intent(in)  :: dcf(dcf_l1:dcf_h1)
-  double precision, intent(in)  ::   r( lo(1): hi(1))
+  real(rt)                      ::   d(  d_l1:  d_h1)
+  real(rt)        , intent(in)  :: lam(lam_l1:lam_h1)
+  real(rt)        , intent(in)  ::   v(  v_l1:  v_h1)
+  real(rt)        , intent(in)  :: dcf(dcf_l1:dcf_h1)
+  real(rt)        , intent(in)  ::   r( lo(1): hi(1))
 
   integer :: i
 
   do i = lo(1), hi(1)
-     if (v(i-1) + v(i) .gt. 0.d0) then
+     if (v(i-1) + v(i) .gt. 0.e0_rt) then
         d(i) = dcf(i-1) * v(i-1) * lam(i)
-     else if (v(i-1) + v(i) .lt. 0.d0) then
+     else if (v(i-1) + v(i) .lt. 0.e0_rt) then
         d(i) = dcf(i) * v(i) * lam(i)
      else
         d(i) = 0.0
@@ -314,20 +317,21 @@ subroutine ca_update_dcf(lo, hi, &
      etainv, eti_l1, eti_h1, &
      kp, kp_l1, kp_h1, kr, kr_l1, kr_h1) bind(C, name="ca_update_dcf")
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: lo(1), hi(1)
   integer, intent(in) :: dcf_l1, dcf_h1, eti_l1, eti_h1, &
        kp_l1, kp_h1, kr_l1, kr_h1
-  double precision, intent(in) :: etainv(eti_l1:eti_h1)
-  double precision, intent(in) :: kp(kp_l1:kp_h1)
-  double precision, intent(in) :: kr(kr_l1:kr_h1)
-  double precision             :: dcf(dcf_l1:dcf_h1)
+  real(rt)        , intent(in) :: etainv(eti_l1:eti_h1)
+  real(rt)        , intent(in) :: kp(kp_l1:kp_h1)
+  real(rt)        , intent(in) :: kr(kr_l1:kr_h1)
+  real(rt)                     :: dcf(dcf_l1:dcf_h1)
 
   integer :: i
 
   do i=lo(1),hi(1)
-     dcf(i) = 2.d0 * etainv(i) * (kp(i)/kr(i))
+     dcf(i) = 2.e0_rt * etainv(i) * (kp(i)/kr(i))
   end do
 
 end subroutine ca_update_dcf
@@ -335,14 +339,15 @@ end subroutine ca_update_dcf
 subroutine ca_set_dterm_face( lo, hi, &
      Er, Er_l1, Er_h1, dc, dc_l1, dc_h1, &
      dtf, dtf_l1, dtf_h1, dx, idir)
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: lo(1), hi(1)
   integer, intent(in) :: Er_l1, Er_h1, dc_l1, dc_h1, dtf_l1, dtf_h1, idir
-  double precision, intent(in) :: dx
-  double precision, intent(in) :: Er(Er_l1:Er_h1)
-  double precision, intent(in) :: dc(dc_l1:dc_h1)
-  double precision             :: dtf(dtf_l1:dtf_h1)
+  real(rt)        , intent(in) :: dx
+  real(rt)        , intent(in) :: Er(Er_l1:Er_h1)
+  real(rt)        , intent(in) :: dc(dc_l1:dc_h1)
+  real(rt)                     :: dtf(dtf_l1:dtf_h1)
   integer :: i
 
   do i=lo(1),hi(1)
@@ -356,19 +361,20 @@ subroutine ca_face2center( lo, hi, &
      foox, foox_l1, foox_h1, &
      fooc, fooc_l1, fooc_h1)
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: lo(1), hi(1), scomp,dcomp,ncomp,nx,nc
   integer, intent(in) :: foox_l1, foox_h1
   integer, intent(in) :: fooc_l1, fooc_h1
-  double precision, intent(in) :: foox(foox_l1:foox_h1,0:nx-1)
-  double precision             :: fooc(fooc_l1:fooc_h1,0:nc-1)
+  real(rt)        , intent(in) :: foox(foox_l1:foox_h1,0:nx-1)
+  real(rt)                     :: fooc(fooc_l1:fooc_h1,0:nc-1)
 
   integer :: i, n
 
   do n = 0, ncomp-1
      do i=lo(1), hi(1)
-        fooc(i,dcomp+n) = (foox(i,scomp+n) + foox(i+1,scomp+n)) * 0.5d0;
+        fooc(i,dcomp+n) = (foox(i,scomp+n) + foox(i+1,scomp+n)) * 0.5e0_rt;
      end do
   end do
 
@@ -378,16 +384,17 @@ end subroutine ca_face2center
 subroutine ca_correct_dterm(dfx, dfx_l1, dfx_h1, &
      re, rc)
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: dfx_l1, dfx_h1
-  double precision, intent(inout) :: dfx(dfx_l1:dfx_h1)
-  double precision, intent(in) :: re(dfx_l1:dfx_h1), rc(1)
+  real(rt)        , intent(inout) :: dfx(dfx_l1:dfx_h1)
+  real(rt)        , intent(in) :: re(dfx_l1:dfx_h1), rc(1)
 
   integer :: i
 
   do i=dfx_l1, dfx_h1
-     dfx(i) = dfx(i) / (re(i) + 1.d-50)
+     dfx(i) = dfx(i) / (re(i) + 1.e-50_rt)
   end do
 
 end subroutine ca_correct_dterm
@@ -399,23 +406,24 @@ subroutine ca_estdt_rad(u,u_l1,u_h1, gpr,gpr_l1,gpr_h1, &
   use eos_module
   use meth_params_module, only : NVAR, URHO, UMX, UEINT, UTEMP, UFS, UFX, &
        allow_negative_energy
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer u_l1,u_h1
   integer gpr_l1,gpr_h1
   integer lo(1), hi(1)
-  double precision u(u_l1:u_h1,NVAR)
-  double precision gpr(gpr_l1:gpr_h1)
-  double precision dx(1), dt
+  real(rt)         u(u_l1:u_h1,NVAR)
+  real(rt)         gpr(gpr_l1:gpr_h1)
+  real(rt)         dx(1), dt
 
-  double precision :: rhoInv,ux,dt1,c
+  real(rt)         :: rhoInv,ux,dt1,c
   integer          :: i
   type(eos_t) :: eos_state
 
   !     Translate to primitive variables, compute sound speed (call eos), get dtmax
   do i = lo(1),hi(1)
 
-     rhoInv = 1.d0 / u(i,URHO)
+     rhoInv = 1.e0_rt / u(i,URHO)
 
      eos_state % rho = u(i,URHO)
      eos_state % T   = u(i,UTEMP)
@@ -424,11 +432,11 @@ subroutine ca_estdt_rad(u,u_l1,u_h1, gpr,gpr_l1,gpr_h1, &
      eos_state % aux = u(i,UFX:UFX+naux-1) * rhoInv
 
      ! Protect against negative e
-     if (eos_state % e .gt. 0.d0 .or. allow_negative_energy .eq. 1) then
+     if (eos_state % e .gt. 0.e0_rt .or. allow_negative_energy .eq. 1) then
         call eos(eos_input_re, eos_state)
         c = eos_state % cs
      else
-        c = 0.d0
+        c = 0.e0_rt
      end if
 
      c = sqrt(c**2 + gpr(i)*rhoInv)
@@ -448,19 +456,20 @@ subroutine ca_est_gpr0(Er, Er_l1, Er_h1, gPr, gPr_l1, gPr_h1)
 
   use rad_params_module, only : ngroups
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: Er_l1, Er_h1, gpr_l1, gpr_h1
-  double precision, intent(in) :: Er(Er_l1:Er_h1, 0:ngroups-1)
-  double precision, intent(out) :: gPr(gPr_l1:gPr_h1)
+  real(rt)        , intent(in) :: Er(Er_l1:Er_h1, 0:ngroups-1)
+  real(rt)        , intent(out) :: gPr(gPr_l1:gPr_h1)
 
   integer :: i, g
 
-  gPr = 0.d0
+  gPr = 0.e0_rt
 
   do g = 0, ngroups-1
      do i = gPr_l1, gPr_h1
-        gPr(i) = gPr(i) + 4.d0/9.d0*Er(i,g)
+        gPr(i) = gPr(i) + 4.e0_rt/9.e0_rt*Er(i,g)
      end do
   end do
 
@@ -474,6 +483,7 @@ subroutine ca_est_gpr2(kap, kap_l1, kap_h1, Er, Er_l1, Er_h1, &
   use rad_params_module, only : ngroups
   use fluxlimiter_module, only : FLDlambda, Edd_factor
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: kap_l1, kap_h1
@@ -481,69 +491,69 @@ subroutine ca_est_gpr2(kap, kap_l1, kap_h1, Er, Er_l1, Er_h1, &
   integer, intent(in) :: gPr_l1, gPr_h1
   integer, intent(in) :: vlo(1), vhi(1)  ! region with valid Er
   integer, intent(in) :: limiter, comoving
-  double precision, intent(in) :: dx
-  double precision, intent(in) ::  kap(kap_l1:kap_h1, 0:ngroups-1)
-  double precision, intent(in) ::   Er( Er_l1: Er_h1, 0:ngroups-1)
-  double precision, intent(out) :: gPr(gPr_l1:gPr_h1)
+  real(rt)        , intent(in) :: dx
+  real(rt)        , intent(in) ::  kap(kap_l1:kap_h1, 0:ngroups-1)
+  real(rt)        , intent(in) ::   Er( Er_l1: Er_h1, 0:ngroups-1)
+  real(rt)        , intent(out) :: gPr(gPr_l1:gPr_h1)
 
   integer :: i, g
-  double precision :: r, lam, f, gamr
+  real(rt)         :: r, lam, f, gamr
   integer :: im, ip
-  double precision :: xm, xp
+  real(rt)         :: xm, xp
 
   if (gPr_l1-1 .ge. vlo(1)) then
      im = 1
-     xm = 2.d0
+     xm = 2.e0_rt
   else
      im = 0
-     xm = 1.d0
+     xm = 1.e0_rt
   end if
 
   if (gPr_h1+1 .le. vhi(1)) then
      ip = 1
-     xp = 2.d0
+     xp = 2.e0_rt
   else
      ip = 0
-     xp = 1.d0
+     xp = 1.e0_rt
   end if
 
-  gPr = 0.0d0
+  gPr = 0.0e0_rt
 
   do g = 0, ngroups-1
      i = gPr_l1
      r = abs(Er(i+1,g) - Er(i-im,g)) / (xm*dx)
-     r = r / (kap(i,g) * max(Er(i,g), 1.d-50))
+     r = r / (kap(i,g) * max(Er(i,g), 1.e-50_rt))
      lam = FLDlambda(r, limiter)
      if (comoving .eq. 1) then
         f = Edd_factor(lam)
-        gamr = (3.d0-f)/2.d0
+        gamr = (3.e0_rt-f)/2.e0_rt
      else
-        gamr = lam + 1.d0
+        gamr = lam + 1.e0_rt
      end if
      gPr(i) = gPr(i) + gamr * lam * Er(i,g)
 
      do i = gPr_l1+1, gPr_h1-1
-        r = abs(Er(i+1,g) - Er(i-1,g)) / (2.d0*dx)
-        r = r / (kap(i,g) * max(Er(i,g), 1.d-50))
+        r = abs(Er(i+1,g) - Er(i-1,g)) / (2.e0_rt*dx)
+        r = r / (kap(i,g) * max(Er(i,g), 1.e-50_rt))
         lam = FLDlambda(r, limiter)
         if (comoving .eq. 1) then
            f = Edd_factor(lam)
-           gamr = (3.d0-f)/2.d0
+           gamr = (3.e0_rt-f)/2.e0_rt
         else
-           gamr = lam + 1.d0
+           gamr = lam + 1.e0_rt
         end if
         gPr(i) = gPr(i) + gamr * lam * Er(i,g)
      end do
 
      i = gPr_h1
      r = abs(Er(i+ip,g) - Er(i-1,g)) / (xp*dx)
-     r = r / (kap(i,g) * max(Er(i,g), 1.d-50))
+     r = r / (kap(i,g) * max(Er(i,g), 1.e-50_rt))
      lam = FLDlambda(r, limiter)
      if (comoving .eq. 1) then
         f = Edd_factor(lam)
-        gamr = (3.d0-f)/2.d0
+        gamr = (3.e0_rt-f)/2.e0_rt
      else
-        gamr = lam + 1.d0
+        gamr = lam + 1.e0_rt
      end if
      gPr(i) = gPr(i) + gamr * lam * Er(i,g)
   end do

--- a/Source/Radiation/RadSrc_1d/HABEC_1D.F90
+++ b/Source/Radiation/RadSrc_1d/HABEC_1D.F90
@@ -10,6 +10,7 @@ module habec_module
 
   use bl_types
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
 contains
@@ -19,15 +20,16 @@ subroutine hacoef(mat, a, &
                   DIMS(reg), &
                   alpha) bind(C, name="hacoef")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(abox)
   integer :: DIMDEC(reg)
-  real*8 :: a(DIMV(abox))
-  real*8 :: mat(0:1, DIMV(reg))
-  real*8 :: alpha
+  real(rt)         :: a(DIMV(abox))
+  real(rt)         :: mat(0:1, DIMV(reg))
+  real(rt)         :: alpha
   integer :: i
-  if (alpha == 0.d0) then
+  if (alpha == 0.e0_rt) then
      do i = reg_l1, reg_h1
-        mat(1,i) = 0.d0
+        mat(1,i) = 0.e0_rt
      enddo
   else
      do i = reg_l1, reg_h1
@@ -41,13 +43,14 @@ subroutine hbcoef(mat, b, &
                   DIMS(reg), &
                   beta, dx, n) bind(C, name="hbcoef")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(bbox)
   integer :: DIMDEC(reg)
   integer :: n
-  real*8 :: b(DIMV(bbox))
-  real*8 :: mat(0:1, DIMV(reg))
-  real*8 :: beta, dx(1)
-  real*8 :: fac
+  real(rt)         :: b(DIMV(bbox))
+  real(rt)         :: mat(0:1, DIMV(reg))
+  real(rt)         :: beta, dx(1)
+  real(rt)         :: fac
   integer :: i
   fac = beta / (dx(1)**2)
   do i = reg_l1, reg_h1
@@ -63,20 +66,21 @@ subroutine hbmat(mat, &
                  b, DIMS(bbox), &
                  beta, dx) bind(C, name="hbmat")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(reg)
   integer :: DIMDEC(msk)
   integer :: DIMDEC(bbox)
   integer :: cdir, bct
-  real*8 :: bcl, beta, dx(1)
-  real*8 :: mat(0:1, DIMV(reg))
+  real(rt)         :: bcl, beta, dx(1)
+  real(rt)         :: mat(0:1, DIMV(reg))
   integer :: mask(DIMV(msk))
-  real*8 :: b(DIMV(bbox))
-  real*8 :: h, fac, bfm, bfv
+  real(rt)         :: b(DIMV(bbox))
+  real(rt)         :: h, fac, bfm, bfv
   integer :: i
   h = dx(1)
   fac = beta / (h**2)
   if (bct == LO_DIRICHLET) then
-     bfv = fac * h / (0.5d0 * h + bcl)
+     bfv = fac * h / (0.5e0_rt * h + bcl)
      bfm = bfv - fac
   else if (bct == LO_NEUMANN) then
      bfv = beta / h
@@ -90,7 +94,7 @@ subroutine hbmat(mat, &
      i = reg_l1
      if (mask(i-1) > 0) then
         mat(1,i) = mat(1,i) + bfm * b(i)
-        mat(0,i) = 0.d0
+        mat(0,i) = 0.e0_rt
      endif
   else if (cdir == 1) then
      ! Right face of grid
@@ -112,19 +116,20 @@ subroutine hbmat3(mat, &
                   beta, dx, c, r, &
                   spa, DIMS(spabox)) bind(C, name="hbmat3")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(reg)
   integer :: DIMDEC(bcv)
   integer :: DIMDEC(msk)
   integer :: DIMDEC(bbox)
   integer :: DIMDEC(spabox)
   integer :: cdir, bctype, tf(DIMV(bcv))
-  real*8 :: bcl, beta, dx(1), c
-  real*8 :: mat(0:1, DIMV(reg))
+  real(rt)         :: bcl, beta, dx(1), c
+  real(rt)         :: mat(0:1, DIMV(reg))
   integer :: mask(DIMV(msk))
-  real*8 :: b(DIMV(bbox))
-  real*8 :: spa(DIMV(spabox))
-  real*8 :: r(1)
-  real*8 :: h, fac, bfm, bfv, r0
+  real(rt)         :: b(DIMV(bbox))
+  real(rt)         :: spa(DIMV(spabox))
+  real(rt)         :: r(1)
+  real(rt)         :: h, fac, bfm, bfv, r0
   integer :: i, bct
   h = dx(1)
   ! r is passed as an array but actually has only one element, which is
@@ -143,22 +148,22 @@ subroutine hbmat3(mat, &
            bct = bctype
         endif
         if (bct == LO_DIRICHLET) then
-           bfv = fac * h / (0.5d0 * h + bcl)
+           bfv = fac * h / (0.5e0_rt * h + bcl)
            bfm = bfv * b(i)
         else if (bct == LO_NEUMANN) then
-           bfm = 0.d0
+           bfm = 0.e0_rt
         else if (bct == LO_MARSHAK) then
-           bfv = 2.d0 * beta * r0 / h
-           bfm = 0.25d0 * c * bfv
+           bfv = 2.e0_rt * beta * r0 / h
+           bfm = 0.25e0_rt * c * bfv
         else if (bct == LO_SANCHEZ_POMRANING) then
-           bfv = 2.d0 * beta * r0 / h
+           bfv = 2.e0_rt * beta * r0 / h
            bfm = spa(i) * c * bfv
         else
            print *, "hbmat3: unsupported boundary type"
            stop
         endif
         mat(1,i) = mat(1,i) + bfm - fac * b(i)
-        mat(0,i) = 0.d0
+        mat(0,i) = 0.e0_rt
      endif
   else if (cdir == 1) then
      ! Right face of grid
@@ -170,15 +175,15 @@ subroutine hbmat3(mat, &
            bct = bctype
         endif
         if (bct == LO_DIRICHLET) then
-           bfv = fac * h / (0.5d0 * h + bcl)
+           bfv = fac * h / (0.5e0_rt * h + bcl)
            bfm = bfv * b(i+1)
         else if (bct == LO_NEUMANN) then
-           bfm = 0.d0
+           bfm = 0.e0_rt
         else if (bct == LO_MARSHAK) then
-           bfv = 2.d0 * beta * r0 / h
-           bfm = 0.25d0 * c * bfv
+           bfv = 2.e0_rt * beta * r0 / h
+           bfm = 0.25e0_rt * c * bfv
         else if (bct == LO_SANCHEZ_POMRANING) then
-           bfv = 2.d0 * beta * r0 / h
+           bfv = 2.e0_rt * beta * r0 / h
            bfm = spa(i) * c * bfv
         else
            print *, "hbmat3: unsupported boundary type"
@@ -199,27 +204,28 @@ subroutine hbvec(vec, &
                  b, DIMS(bbox), &
                  beta, dx) bind(C, name="hbvec")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(reg)
   integer :: DIMDEC(bcv)
   integer :: DIMDEC(msk)
   integer :: DIMDEC(bbox)
   integer :: cdir, bct, bho
-  real*8 :: bcl, beta, dx(1)
-  real*8 :: vec(DIMV(reg))
-  real*8 :: bcval(DIMV(bcv))
+  real(rt)         :: bcl, beta, dx(1)
+  real(rt)         :: vec(DIMV(reg))
+  real(rt)         :: bcval(DIMV(bcv))
   integer :: mask(DIMV(msk))
-  real*8 :: b(DIMV(bbox))
-  real*8 :: h, bfv
-  real*8 :: h2, th2
+  real(rt)         :: b(DIMV(bbox))
+  real(rt)         :: h, bfv
+  real(rt)         :: h2, th2
   integer :: i
   h = dx(1)
   if (bct == LO_DIRICHLET) then
      if (bho >= 1) then
-        h2 = 0.5d0 * h
-        th2 = 3.d0 * h2
-        bfv = 2.d0 * beta / ((bcl + h2) * (bcl + th2))
+        h2 = 0.5e0_rt * h
+        th2 = 3.e0_rt * h2
+        bfv = 2.e0_rt * beta / ((bcl + h2) * (bcl + th2))
      else
-        bfv = (beta / h) / (0.5d0 * h + bcl)
+        bfv = (beta / h) / (0.5e0_rt * h + bcl)
      endif
   else if (bct == LO_NEUMANN) then
      bfv = beta / h
@@ -252,19 +258,20 @@ subroutine hbvec3(vec, &
                   b, DIMS(bbox), &
                   beta, dx, r) bind(C, name="hbvec3")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(reg)
   integer :: DIMDEC(bcv)
   integer :: DIMDEC(msk)
   integer :: DIMDEC(bbox)
   integer :: cdir, bctype, tf(DIMV(bcv)), bho
-  real*8 :: bcl, beta, dx(1)
-  real*8 :: vec(DIMV(reg))
-  real*8 :: bcval(DIMV(bcv))
+  real(rt)         :: bcl, beta, dx(1)
+  real(rt)         :: vec(DIMV(reg))
+  real(rt)         :: bcval(DIMV(bcv))
   integer :: mask(DIMV(msk))
-  real*8 :: b(DIMV(bbox))
-  real*8 :: r(1)
-  real*8 :: h, bfv, r0
-  real*8 :: h2, th2
+  real(rt)         :: b(DIMV(bbox))
+  real(rt)         :: r(1)
+  real(rt)         :: h, bfv, r0
+  real(rt)         :: h2, th2
   integer :: i, bct
   h = dx(1)
   ! r is passed as an array but actually has only one element, which is
@@ -281,18 +288,18 @@ subroutine hbvec3(vec, &
         endif
         if (bct == LO_DIRICHLET) then
            if (bho >= 1) then
-              h2 = 0.5d0 * h
-              th2 = 3.d0 * h2
-              bfv = 2.d0 * beta / ((bcl + h2) * (bcl + th2))
+              h2 = 0.5e0_rt * h
+              th2 = 3.e0_rt * h2
+              bfv = 2.e0_rt * beta / ((bcl + h2) * (bcl + th2))
            else
-              bfv = (beta / h) / (0.5d0 * h + bcl)
+              bfv = (beta / h) / (0.5e0_rt * h + bcl)
            endif
            bfv = bfv * b(i)
         else if (bct == LO_NEUMANN) then
            bfv = beta * r0 / h
         else if (bct == LO_MARSHAK .OR. &
              bct == LO_SANCHEZ_POMRANING) then
-           bfv = 2.d0 * beta * r0 / h
+           bfv = 2.e0_rt * beta * r0 / h
         else
            print *, "hbvec3: unsupported boundary type"
            stop
@@ -310,18 +317,18 @@ subroutine hbvec3(vec, &
         endif
         if (bct == LO_DIRICHLET) then
            if (bho >= 1) then
-              h2 = 0.5d0 * h
-              th2 = 3.d0 * h2
-              bfv = 2.d0 * beta / ((bcl + h2) * (bcl + th2))
+              h2 = 0.5e0_rt * h
+              th2 = 3.e0_rt * h2
+              bfv = 2.e0_rt * beta / ((bcl + h2) * (bcl + th2))
            else
-              bfv = (beta / h) / (0.5d0 * h + bcl)
+              bfv = (beta / h) / (0.5e0_rt * h + bcl)
            endif
            bfv = bfv * b(i+1)
         else if (bct == LO_NEUMANN) then
            bfv = beta * r0 / h
         else if (bct == LO_MARSHAK .OR. &
              bct == LO_SANCHEZ_POMRANING) then
-           bfv = 2.d0 * beta * r0 / h
+           bfv = 2.e0_rt * beta * r0 / h
         else
            print *, "hbvec3: unsupported boundary type"
            stop
@@ -343,6 +350,7 @@ subroutine hbflx(flux, &
                  b, DIMS(bbox), &
                  beta, dx, inhom) bind(C, name="hbflx")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(fbox)
   integer :: DIMDEC(ebox)
   integer :: DIMDEC(reg)
@@ -350,25 +358,25 @@ subroutine hbflx(flux, &
   integer :: DIMDEC(msk)
   integer :: DIMDEC(bbox)
   integer :: cdir, bct, bho, inhom
-  real*8 :: bcl, beta, dx(1)
-  real*8 :: flux(DIMV(fbox))
-  real*8 :: er(DIMV(ebox))
-  real*8 :: bcval(DIMV(bcv))
+  real(rt)         :: bcl, beta, dx(1)
+  real(rt)         :: flux(DIMV(fbox))
+  real(rt)         :: er(DIMV(ebox))
+  real(rt)         :: bcval(DIMV(bcv))
   integer :: mask(DIMV(msk))
-  real*8 :: b(DIMV(bbox))
-  real*8 :: h, bfm, bfv
-  real*8 :: bfm2, h2, th2
+  real(rt)         :: b(DIMV(bbox))
+  real(rt)         :: h, bfm, bfv
+  real(rt)         :: bfm2, h2, th2
   integer :: i
   h = dx(1)
   if (bct == LO_DIRICHLET) then
      if (bho >= 1) then
-        h2 = 0.5d0 * h
-        th2 = 3.d0 * h2
-        bfv = 2.d0 * beta * h / ((bcl + h2) * (bcl + th2))
+        h2 = 0.5e0_rt * h
+        th2 = 3.e0_rt * h2
+        bfv = 2.e0_rt * beta * h / ((bcl + h2) * (bcl + th2))
         bfm = (beta / h) * (th2 - bcl) / (bcl + h2)
         bfm2 = (beta / h) * (bcl - h2) / (bcl + th2)
      else
-        bfv = beta / (0.5d0 * h + bcl)
+        bfv = beta / (0.5e0_rt * h + bcl)
         bfm = bfv
      endif
   else
@@ -376,7 +384,7 @@ subroutine hbflx(flux, &
      stop
   endif
   if (inhom == 0) then
-     bfv = 0.d0
+     bfv = 0.e0_rt
   endif
   if (cdir == 0) then
      ! Left face of grid
@@ -412,6 +420,7 @@ subroutine hbflx3(flux, &
                   beta, dx, c, r, inhom, &
                   spa, DIMS(spabox)) bind(C, name="hbflx3")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(fbox)
   integer :: DIMDEC(ebox)
   integer :: DIMDEC(reg)
@@ -420,16 +429,16 @@ subroutine hbflx3(flux, &
   integer :: DIMDEC(bbox)
   integer :: DIMDEC(spabox)
   integer :: cdir, bctype, tf(DIMV(bcv)), bho, inhom
-  real*8 :: bcl, beta, dx(1), c
-  real*8 :: flux(DIMV(fbox))
-  real*8 :: er(DIMV(ebox))
-  real*8 :: bcval(DIMV(bcv))
+  real(rt)         :: bcl, beta, dx(1), c
+  real(rt)         :: flux(DIMV(fbox))
+  real(rt)         :: er(DIMV(ebox))
+  real(rt)         :: bcval(DIMV(bcv))
   integer :: mask(DIMV(msk))
-  real*8 :: b(DIMV(bbox))
-  real*8 :: spa(DIMV(spabox))
-  real*8 :: r(1)
-  real*8 :: h, bfm, bfv, r0
-  real*8 :: bfm2, h2, th2
+  real(rt)         :: b(DIMV(bbox))
+  real(rt)         :: spa(DIMV(spabox))
+  real(rt)         :: r(1)
+  real(rt)         :: h, bfm, bfv, r0
+  real(rt)         :: bfm2, h2, th2
   integer :: i, bct
   h = dx(1)
   ! r is passed as an array but actually has only one element, which is
@@ -446,32 +455,32 @@ subroutine hbflx3(flux, &
         endif
         if (bct == LO_DIRICHLET) then
            if (bho >= 1) then
-              h2 = 0.5d0 * h
-              th2 = 3.d0 * h2
-              bfv = 2.d0 * beta * h / ((bcl + h2) * (bcl + th2)) * b(i)
+              h2 = 0.5e0_rt * h
+              th2 = 3.e0_rt * h2
+              bfv = 2.e0_rt * beta * h / ((bcl + h2) * (bcl + th2)) * b(i)
               bfm = (beta / h) * (th2 - bcl) / (bcl + h2)  * b(i)
               bfm2 = (beta / h) * (bcl - h2) / (bcl + th2) * b(i)
            else
-              bfv = beta / (0.5d0 * h + bcl) * b(i)
+              bfv = beta / (0.5e0_rt * h + bcl) * b(i)
               bfm = bfv
            endif
         else if (bct == LO_NEUMANN) then
            bfv  = beta * r0
-           bfm  = 0.d0
-           bfm2 = 0.d0
+           bfm  = 0.e0_rt
+           bfm2 = 0.e0_rt
         else if (bct == LO_MARSHAK) then
-           bfv = 2.d0 * beta * r0
+           bfv = 2.e0_rt * beta * r0
            if (bho >= 1) then
-              bfm  =  0.375d0 * c * bfv
-              bfm2 = -0.125d0 * c * bfv
+              bfm  =  0.375e0_rt * c * bfv
+              bfm2 = -0.125e0_rt * c * bfv
            else
-              bfm = 0.25d0 * c * bfv
+              bfm = 0.25e0_rt * c * bfv
            endif
         else if (bct == LO_SANCHEZ_POMRANING) then
-           bfv = 2.d0 * beta * r0
+           bfv = 2.e0_rt * beta * r0
            if (bho >= 1) then
-              bfm  =  1.5d0 * spa(i) * c * bfv
-              bfm2 = -0.5d0 * spa(i) * c * bfv
+              bfm  =  1.5e0_rt * spa(i) * c * bfv
+              bfm2 = -0.5e0_rt * spa(i) * c * bfv
            else
               bfm = spa(i) * c * bfv
            endif
@@ -480,7 +489,7 @@ subroutine hbflx3(flux, &
            stop
         endif
         if (inhom == 0) then
-           bfv = 0.d0
+           bfv = 0.e0_rt
         endif
         flux(i) = (bfv * bcval(i-1) - bfm * er(i))
         if (bho >= 1) then
@@ -498,32 +507,32 @@ subroutine hbflx3(flux, &
         endif
         if (bct == LO_DIRICHLET) then
            if (bho >= 1) then
-              h2 = 0.5d0 * h
-              th2 = 3.d0 * h2
-              bfv = 2.d0 * beta * h / ((bcl + h2) * (bcl + th2)) * b(i+1)
+              h2 = 0.5e0_rt * h
+              th2 = 3.e0_rt * h2
+              bfv = 2.e0_rt * beta * h / ((bcl + h2) * (bcl + th2)) * b(i+1)
               bfm = (beta / h) * (th2 - bcl) / (bcl + h2)  * b(i+1)
               bfm2 = (beta / h) * (bcl - h2) / (bcl + th2) * b(i+1)
            else
-              bfv = beta / (0.5d0 * h + bcl) * b(i+1)
+              bfv = beta / (0.5e0_rt * h + bcl) * b(i+1)
               bfm = bfv
            endif
         else if (bct == LO_NEUMANN) then
            bfv  = beta * r0
-           bfm  = 0.d0
-           bfm2 = 0.d0
+           bfm  = 0.e0_rt
+           bfm2 = 0.e0_rt
         else if (bct == LO_MARSHAK) then
-           bfv = 2.d0 * beta * r0
+           bfv = 2.e0_rt * beta * r0
            if (bho >= 1) then
-              bfm  =  0.375d0 * c * bfv
-              bfm2 = -0.125d0 * c * bfv
+              bfm  =  0.375e0_rt * c * bfv
+              bfm2 = -0.125e0_rt * c * bfv
            else
-              bfm = 0.25d0 * c * bfv
+              bfm = 0.25e0_rt * c * bfv
            endif
         else if (bct == LO_SANCHEZ_POMRANING) then
-           bfv = 2.d0 * beta * r0
+           bfv = 2.e0_rt * beta * r0
            if (bho >= 1) then
-              bfm  =  1.5d0 * spa(i) * c * bfv
-              bfm2 = -0.5d0 * spa(i) * c * bfv
+              bfm  =  1.5e0_rt * spa(i) * c * bfv
+              bfm2 = -0.5e0_rt * spa(i) * c * bfv
            else
               bfm = spa(i) * c * bfv
            endif
@@ -532,7 +541,7 @@ subroutine hbflx3(flux, &
            stop
         endif
         if (inhom == 0) then
-           bfv = 0.d0
+           bfv = 0.e0_rt
         endif
         flux(i+1) = -(bfv * bcval(i+1) - bfm * er(i))
         if (bho >= 1) then
@@ -554,6 +563,7 @@ subroutine hdterm(dterm, &
                   d, DIMS(dbox), &
                   dx) bind(C, name="hdterm")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(dtbox)
   integer :: DIMDEC(ebox)
   integer :: DIMDEC(reg)
@@ -561,13 +571,13 @@ subroutine hdterm(dterm, &
   integer :: DIMDEC(msk)
   integer :: DIMDEC(dbox)
   integer :: cdir, bct
-  real*8 :: bcl, dx(1)
-  real*8 :: dterm(DIMV(dtbox))
-  real*8 :: er(DIMV(ebox))
-  real*8 :: bcval(DIMV(bcv))
+  real(rt)         :: bcl, dx(1)
+  real(rt)         :: dterm(DIMV(dtbox))
+  real(rt)         :: er(DIMV(ebox))
+  real(rt)         :: bcval(DIMV(bcv))
   integer :: mask(DIMV(msk))
-  real*8 :: d(DIMV(dbox))
-  real*8 :: h
+  real(rt)         :: d(DIMV(dbox))
+  real(rt)         :: h
   integer :: i
   h = dx(1)
   if (bct == LO_DIRICHLET) then
@@ -575,13 +585,13 @@ subroutine hdterm(dterm, &
         !     Left face of grid
         i = reg_l1
         if (mask(i-1) > 0) then
-           dterm(i) = d(i)*(er(i) - bcval(i-1))/(0.5d0*h+bcl)
+           dterm(i) = d(i)*(er(i) - bcval(i-1))/(0.5e0_rt*h+bcl)
         endif
      else if (cdir == 1) then
         !     Right face of grid
         i = reg_h1
         if (mask(i+1) > 0) then
-           dterm(i+1) = d(i+1)*(bcval(i+1)-er(i))/(0.5d0*h+bcl)
+           dterm(i+1) = d(i+1)*(bcval(i+1)-er(i))/(0.5e0_rt*h+bcl)
         endif
      else
         print *, "hdterm: impossible face orientation"
@@ -602,6 +612,7 @@ subroutine hdterm3(dterm, &
                    d, DIMS(dbox), &
                    dx) bind(C, name="hdterm3")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(dtbox)
   integer :: DIMDEC(ebox)
   integer :: DIMDEC(reg)
@@ -609,13 +620,13 @@ subroutine hdterm3(dterm, &
   integer :: DIMDEC(msk)
   integer :: DIMDEC(dbox)
   integer :: cdir, bctype, tf(DIMV(bcv))
-  real*8 :: bcl, dx(1)
-  real*8 :: dterm(DIMV(dtbox))
-  real*8 :: er(DIMV(ebox))
-  real*8 :: bcval(DIMV(bcv))
+  real(rt)         :: bcl, dx(1)
+  real(rt)         :: dterm(DIMV(dtbox))
+  real(rt)         :: er(DIMV(ebox))
+  real(rt)         :: bcval(DIMV(bcv))
   integer :: mask(DIMV(msk))
-  real*8 :: d(DIMV(dbox))
-  real*8 :: h
+  real(rt)         :: d(DIMV(dbox))
+  real(rt)         :: h
   integer :: i, bct
   h = dx(1)
   if (cdir == 0) then
@@ -628,9 +639,9 @@ subroutine hdterm3(dterm, &
            bct = bctype
         endif
         if (bct == LO_DIRICHLET) then
-           dterm(i) = d(i)*(er(i) - bcval(i-1))/(0.5d0*h+bcl)
-        else if (bct == LO_NEUMANN .AND. bcval(i-1) == 0.d0) then
-           dterm(i) = 0.d0
+           dterm(i) = d(i)*(er(i) - bcval(i-1))/(0.5e0_rt*h+bcl)
+        else if (bct == LO_NEUMANN .AND. bcval(i-1) == 0.e0_rt) then
+           dterm(i) = 0.e0_rt
         else
            print *, "hdterm3: unsupported boundary type"
            stop
@@ -646,9 +657,9 @@ subroutine hdterm3(dterm, &
            bct = bctype
         endif
         if (bct == LO_DIRICHLET) then
-           dterm(i+1) = d(i+1)*(bcval(i+1)-er(i))/(0.5d0*h+bcl)
-        else if (bct == LO_NEUMANN .AND. bcval(i+1) == 0.d0) then
-           dterm(i+1) = 0.d0
+           dterm(i+1) = d(i+1)*(bcval(i+1)-er(i))/(0.5e0_rt*h+bcl)
+        else if (bct == LO_NEUMANN .AND. bcval(i+1) == 0.e0_rt) then
+           dterm(i+1) = 0.e0_rt
         else
            print *, "hbterm3: unsupported boundary type"
            stop
@@ -664,15 +675,16 @@ subroutine hmac(mat, a, &
                 DIMS(reg), &
                 alpha) bind(C, name="hmac")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(abox)
   integer :: DIMDEC(reg)
-  real*8 :: a(DIMV(abox))
-  real*8 :: mat(0:2, DIMV(reg))
-  real*8 :: alpha
+  real(rt)         :: a(DIMV(abox))
+  real(rt)         :: mat(0:2, DIMV(reg))
+  real(rt)         :: alpha
   integer :: i
-  if (alpha == 0.d0) then
+  if (alpha == 0.e0_rt) then
      do i = reg_l1, reg_h1
-        mat(0,i) = 0.d0
+        mat(0,i) = 0.e0_rt
      enddo
   else
      do i = reg_l1, reg_h1
@@ -686,13 +698,14 @@ subroutine hmbc(mat, b, &
                 DIMS(reg), &
                 beta, dx, n) bind(C, name="hmbc")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(bbox)
   integer :: DIMDEC(reg)
   integer :: n
-  real*8 :: b(DIMV(bbox))
-  real*8 :: mat(0:2, DIMV(reg))
-  real*8 :: beta, dx(1)
-  real*8 :: fac
+  real(rt)         :: b(DIMV(bbox))
+  real(rt)         :: mat(0:2, DIMV(reg))
+  real(rt)         :: beta, dx(1)
+  real(rt)         :: fac
   integer :: i
   fac = beta / (dx(1)**2)
   do i = reg_l1, reg_h1
@@ -707,15 +720,16 @@ subroutine hma2c(mat, a2, &
                  DIMS(reg), &
                  alpha2, n) bind(C, name="hma2c")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(bbox)
   integer :: DIMDEC(reg)
   integer :: n
-  real*8 :: a2(DIMV(bbox))
-  real*8 :: mat(0:2, DIMV(reg))
-  real*8 :: alpha2
-  real*8 :: fac
+  real(rt)         :: a2(DIMV(bbox))
+  real(rt)         :: mat(0:2, DIMV(reg))
+  real(rt)         :: alpha2
+  real(rt)         :: fac
   integer :: i
-  fac = 0.25d0 * alpha2
+  fac = 0.25e0_rt * alpha2
   do i = reg_l1, reg_h1
      mat(0,i) = mat(0,i) + fac * (a2(i) + a2(i+1))
      mat(1,i) = mat(1,i) + fac * a2(i)
@@ -728,14 +742,15 @@ subroutine hmcc(mat, c, &
                 DIMS(reg), &
                 gamma, dx, n) bind(C, name="hmcc")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(cbox)
   integer :: DIMDEC(reg)
   integer :: n
   ! c has two components for upwinding, independent of dimension
-  real*8 :: c(DIMV(cbox), 0:1)
-  real*8 :: mat(0:2, DIMV(reg))
-  real*8 :: gamma, dx(1)
-  real*8 :: fac
+  real(rt)         :: c(DIMV(cbox), 0:1)
+  real(rt)         :: mat(0:2, DIMV(reg))
+  real(rt)         :: gamma, dx(1)
+  real(rt)         :: fac
   integer :: i
   fac = gamma / dx(1)
   do i = reg_l1, reg_h1
@@ -751,18 +766,19 @@ subroutine add_ccoef_flux(dir, &
                           gamma, &
                           dx, &
                           flux, DIMS(fbox))
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer :: DIMDEC(den)
   integer :: DIMDEC(cbox)
   integer :: DIMDEC(fbox)
 
-  real*8 :: den(DIMV(den))
-  real*8 :: c(DIMV(cbox), 0:1)
-  real*8 :: flux(DIMV(fbox))
+  real(rt)         :: den(DIMV(den))
+  real(rt)         :: c(DIMV(cbox), 0:1)
+  real(rt)         :: flux(DIMV(fbox))
 
   integer :: dir
-  real*8 :: gamma, dx(1)
+  real(rt)         :: gamma, dx(1)
   integer :: i
 
   if (dir == 0) then
@@ -782,15 +798,16 @@ subroutine hmd1c(mat, d1, &
                  DIMS(reg), &
                  delta1, dx, n) bind(C, name="hmd1c")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(abox)
   integer :: DIMDEC(reg)
   integer :: n
-  real*8 :: d1(DIMV(abox))
-  real*8 :: mat(0:2, DIMV(reg))
-  real*8 :: delta1, dx(1)
-  real*8 :: fac
+  real(rt)         :: d1(DIMV(abox))
+  real(rt)         :: mat(0:2, DIMV(reg))
+  real(rt)         :: delta1, dx(1)
+  real(rt)         :: fac
   integer :: i
-  fac = 0.5d0 * delta1 / dx(1)
+  fac = 0.5e0_rt * delta1 / dx(1)
   do i = reg_l1, reg_h1
      mat(1,i) = mat(1,i) - fac * d1(i)
      mat(2,i) = mat(2,i) + fac * d1(i)
@@ -802,15 +819,16 @@ subroutine hmd2c(mat, d2, &
                  DIMS(reg), &
                  delta2, dx, n) bind(C, name="hmd2c")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(bbox)
   integer :: DIMDEC(reg)
   integer :: n
-  real*8 :: d2(DIMV(bbox))
-  real*8 :: mat(0:2, DIMV(reg))
-  real*8 :: delta2, dx(1)
-  real*8 :: fac
+  real(rt)         :: d2(DIMV(bbox))
+  real(rt)         :: mat(0:2, DIMV(reg))
+  real(rt)         :: delta2, dx(1)
+  real(rt)         :: fac
   integer :: i
-  fac = 0.5d0 * delta2 / dx(1)
+  fac = 0.5e0_rt * delta2 / dx(1)
   do i = reg_l1, reg_h1
      mat(0,i) = mat(0,i) + fac * (d2(i) - d2(i+1))
      mat(1,i) = mat(1,i) - fac * d2(i)
@@ -824,33 +842,34 @@ subroutine hmmat(mat, &
                  mask, DIMS(msk), &
                  b, DIMS(bbox), &
                  beta, dx) bind(C, name="hmmat")
+  use bl_fort_module, only : rt => c_real
   implicit none
   integer :: DIMDEC(reg)
   integer :: DIMDEC(msk)
   integer :: DIMDEC(bbox)
   integer :: cdir, bct, bho
-  real*8 :: bcl, beta, dx(1)
-  real*8 :: mat(0:2, DIMV(reg))
+  real(rt)         :: bcl, beta, dx(1)
+  real(rt)         :: mat(0:2, DIMV(reg))
   integer :: mask(DIMV(msk))
-  real*8 :: b(DIMV(bbox))
-  real*8 :: h, fac, bfm, bfv
-  real*8 :: bfm2, h2, th2
+  real(rt)         :: b(DIMV(bbox))
+  real(rt)         :: h, fac, bfm, bfv
+  real(rt)         :: bfm2, h2, th2
   integer :: i
   h = dx(1)
   fac = beta / (h**2)
   if (bct == LO_DIRICHLET) then
      if (bho >= 1) then
-        h2 = 0.5d0 * h
-        th2 = 3.d0 * h2
+        h2 = 0.5e0_rt * h
+        th2 = 3.e0_rt * h2
         bfm = fac * (th2 - bcl) / (bcl + h2) - fac
         bfm2 = fac * (bcl - h2) / (bcl + th2)
      else
-        bfv = (beta / h) / (0.5d0 * h + bcl)
+        bfv = (beta / h) / (0.5e0_rt * h + bcl)
         bfm = bfv - fac
      endif
   else if (bct == LO_NEUMANN) then
      bfm = -fac
-     bfm2 = 0.d0
+     bfm2 = 0.e0_rt
   else
      print *, "hmmat: unsupported boundary type"
      stop
@@ -860,7 +879,7 @@ subroutine hmmat(mat, &
      i = reg_l1
      if (mask(i-1) > 0) then
         mat(0,i) = mat(0,i) + bfm * b(i)
-        mat(1,i) = 0.d0
+        mat(1,i) = 0.e0_rt
         if (bho >= 1) then
            mat(2,i) = mat(2,i) + bfm2 * b(i)
         endif
@@ -870,7 +889,7 @@ subroutine hmmat(mat, &
      i = reg_h1
      if (mask(i+1) > 0) then
         mat(0,i) = mat(0,i) + bfm * b(i+1)
-        mat(2,i) = 0.d0
+        mat(2,i) = 0.e0_rt
         if (bho >= 1) then
            mat(1,i) = mat(1,i) + bfm2 * b(i+1)
         endif
@@ -889,20 +908,21 @@ subroutine hmmat3(mat, &
                   beta, dx, c, r, &
                   spa, DIMS(spabox)) bind(C, name="hmmat3")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(reg)
   integer :: DIMDEC(bcv)
   integer :: DIMDEC(msk)
   integer :: DIMDEC(bbox)
   integer :: DIMDEC(spabox)
   integer :: cdir, bctype, tf(DIMV(bcv)), bho
-  real*8 :: bcl, beta, dx(1), c
-  real*8 :: mat(0:2, DIMV(reg))
+  real(rt)         :: bcl, beta, dx(1), c
+  real(rt)         :: mat(0:2, DIMV(reg))
   integer :: mask(DIMV(msk))
-  real*8 :: b(DIMV(bbox))
-  real*8 :: spa(DIMV(spabox))
-  real*8 :: r(1)
-  real*8 :: h, fac, bfm, bfv, r0
-  real*8 :: bfm2, h2, th2
+  real(rt)         :: b(DIMV(bbox))
+  real(rt)         :: spa(DIMV(spabox))
+  real(rt)         :: r(1)
+  real(rt)         :: h, fac, bfm, bfv, r0
+  real(rt)         :: bfm2, h2, th2
   integer :: i, bct
   h = dx(1)
   ! r is passed as an array but actually has only one element, which is
@@ -922,30 +942,30 @@ subroutine hmmat3(mat, &
         endif
         if (bct == LO_DIRICHLET) then
            if (bho >= 1) then
-              h2 = 0.5d0 * h
-              th2 = 3.d0 * h2
+              h2 = 0.5e0_rt * h
+              th2 = 3.e0_rt * h2
               bfm = fac * (th2 - bcl) / (bcl + h2)  * b(i)
               bfm2 = fac * (bcl - h2) / (bcl + th2) * b(i)
            else
-              bfv = (beta / h) / (0.5d0 * h + bcl)
+              bfv = (beta / h) / (0.5e0_rt * h + bcl)
               bfm = bfv * b(i)
            endif
         else if (bct == LO_NEUMANN) then
-           bfm  = 0.d0
-           bfm2 = 0.d0
+           bfm  = 0.e0_rt
+           bfm2 = 0.e0_rt
         else if (bct == LO_MARSHAK) then
-           bfv = 2.d0 * beta * r0 / h
+           bfv = 2.e0_rt * beta * r0 / h
            if (bho >= 1) then
-              bfm  =  0.375d0 * c * bfv
-              bfm2 = -0.125d0 * c * bfv
+              bfm  =  0.375e0_rt * c * bfv
+              bfm2 = -0.125e0_rt * c * bfv
            else
-              bfm = 0.25d0 * c * bfv
+              bfm = 0.25e0_rt * c * bfv
            endif
         else if (bct == LO_SANCHEZ_POMRANING) then
-           bfv = 2.d0 * beta * r0 / h
+           bfv = 2.e0_rt * beta * r0 / h
            if (bho >= 1) then
-              bfm  =  1.5d0 * spa(i) * c * bfv
-              bfm2 = -0.5d0 * spa(i) * c * bfv
+              bfm  =  1.5e0_rt * spa(i) * c * bfv
+              bfm2 = -0.5e0_rt * spa(i) * c * bfv
            else
               bfm = spa(i) * c * bfv
            endif
@@ -954,7 +974,7 @@ subroutine hmmat3(mat, &
            stop
         endif
         mat(0,i) = mat(0,i) + bfm - fac * b(i)
-        mat(1,i) = 0.d0
+        mat(1,i) = 0.e0_rt
         if (bho >= 1) then
            mat(2,i) = mat(2,i) + bfm2
         endif
@@ -970,30 +990,30 @@ subroutine hmmat3(mat, &
         endif
         if (bct == LO_DIRICHLET) then
            if (bho >= 1) then
-              h2 = 0.5d0 * h
-              th2 = 3.d0 * h2
+              h2 = 0.5e0_rt * h
+              th2 = 3.e0_rt * h2
               bfm = fac * (th2 - bcl) / (bcl + h2)  * b(i+1)
               bfm2 = fac * (bcl - h2) / (bcl + th2) * b(i+1)
            else
-              bfv = (beta / h) / (0.5d0 * h + bcl)
+              bfv = (beta / h) / (0.5e0_rt * h + bcl)
               bfm = bfv * b(i+1)
            endif
         else if (bct == LO_NEUMANN) then
-           bfm  = 0.d0
-           bfm2 = 0.d0
+           bfm  = 0.e0_rt
+           bfm2 = 0.e0_rt
         else if (bct == LO_MARSHAK) then
-           bfv = 2.d0 * beta * r0 / h
+           bfv = 2.e0_rt * beta * r0 / h
            if (bho >= 1) then
-              bfm  =  0.375d0 * c * bfv
-              bfm2 = -0.125d0 * c * bfv
+              bfm  =  0.375e0_rt * c * bfv
+              bfm2 = -0.125e0_rt * c * bfv
            else
-              bfm = 0.25d0 * c * bfv
+              bfm = 0.25e0_rt * c * bfv
            endif
         else if (bct == LO_SANCHEZ_POMRANING) then
-           bfv = 2.d0 * beta * r0 / h
+           bfv = 2.e0_rt * beta * r0 / h
            if (bho >= 1) then
-              bfm  =  1.5d0 * spa(i) * c * bfv
-              bfm2 = -0.5d0 * spa(i) * c * bfv
+              bfm  =  1.5e0_rt * spa(i) * c * bfv
+              bfm2 = -0.5e0_rt * spa(i) * c * bfv
            else
               bfm = spa(i) * c * bfv
            endif
@@ -1002,7 +1022,7 @@ subroutine hmmat3(mat, &
            stop
         endif
         mat(0,i) = mat(0,i) + bfm - fac * b(i+1)
-        mat(2,i) = 0.d0
+        mat(2,i) = 0.e0_rt
         if (bho >= 1) then
            mat(1,i) = mat(1,i) + bfm2
         endif
@@ -1020,17 +1040,18 @@ subroutine set_abec_flux( &
                        dx, &
                        flux, DIMS(flux)) bind(C, name="set_abec_flux")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(reg)
   integer :: DIMDEC(density)
   integer :: DIMDEC(dcoef)
   integer :: DIMDEC(flux)
 
-  real*8 :: density(DIMV(density))
-  real*8 :: dcoef(DIMV(dcoef))
-  real*8 :: flux(DIMV(flux))
+  real(rt)         :: density(DIMV(density))
+  real(rt)         :: dcoef(DIMV(dcoef))
+  real(rt)         :: flux(DIMV(flux))
 
   integer :: dir,i
-  real*8 :: beta, dx(BL_SPACEDIM), fac
+  real(rt)         :: beta, dx(BL_SPACEDIM), fac
 
   if( dir == 0 ) then
 

--- a/Source/Radiation/RadSrc_1d/MGFLD_1d.f90
+++ b/Source/Radiation/RadSrc_1d/MGFLD_1d.f90
@@ -9,6 +9,7 @@ subroutine ca_accel_acoe( lo, hi,  &
 
   use rad_params_module, only : ngroups, clight
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: lo(1), hi(1)
@@ -16,16 +17,16 @@ subroutine ca_accel_acoe( lo, hi,  &
   integer, intent(in) ::  spc_l1, spc_h1
   integer, intent(in) ::  kap_l1, kap_h1
   integer, intent(in) ::  aco_l1, aco_h1
-  double precision, intent(in ) :: eta1(eta1_l1:eta1_h1)
-  double precision, intent(in ) :: spc ( spc_l1: spc_h1,0:ngroups-1)
-  double precision, intent(in ) :: kap ( kap_l1: kap_h1,0:ngroups-1)
-  double precision              :: aco ( aco_l1: aco_h1)
-  double precision, intent(in) :: dt, tau
+  real(rt)        , intent(in ) :: eta1(eta1_l1:eta1_h1)
+  real(rt)        , intent(in ) :: spc ( spc_l1: spc_h1,0:ngroups-1)
+  real(rt)        , intent(in ) :: kap ( kap_l1: kap_h1,0:ngroups-1)
+  real(rt)                      :: aco ( aco_l1: aco_h1)
+  real(rt)        , intent(in) :: dt, tau
 
   integer :: i
-  double precision :: kbar, H1, dt1
+  real(rt)         :: kbar, H1, dt1
 
-  dt1 = (1.d0+tau)/dt
+  dt1 = (1.e0_rt+tau)/dt
 
   do i = lo(1), hi(1)
      kbar = sum(spc(i,:) * kap(i,:))
@@ -46,6 +47,7 @@ subroutine ca_accel_rhs( lo, hi, &
 
   use rad_params_module, only : ngroups, clight
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: lo(1), hi(1)
@@ -54,15 +56,15 @@ subroutine ca_accel_rhs( lo, hi, &
   integer, intent(in) :: kap_l1, kap_h1
   integer, intent(in) ::etaT_l1,etaT_h1
   integer, intent(in) :: rhs_l1, rhs_h1
-  double precision, intent(in ) ::Ern ( Ern_l1: Ern_h1,0:ngroups-1)
-  double precision, intent(in ) ::Erl ( Erl_l1: Erl_h1,0:ngroups-1)
-  double precision, intent(in ) :: kap( kap_l1: kap_h1,0:ngroups-1)
-  double precision, intent(in ) ::etaT(etaT_l1:etaT_h1)
-  double precision              :: rhs(rhs_l1:rhs_h1)
-  double precision, intent(in) :: dt
+  real(rt)        , intent(in ) ::Ern ( Ern_l1: Ern_h1,0:ngroups-1)
+  real(rt)        , intent(in ) ::Erl ( Erl_l1: Erl_h1,0:ngroups-1)
+  real(rt)        , intent(in ) :: kap( kap_l1: kap_h1,0:ngroups-1)
+  real(rt)        , intent(in ) ::etaT(etaT_l1:etaT_h1)
+  real(rt)                      :: rhs(rhs_l1:rhs_h1)
+  real(rt)        , intent(in) :: dt
 
   integer :: i 
-  double precision :: rt_term, H
+  real(rt)         :: rt_term, H
 
   do i = lo(1), hi(1)
      rt_term = sum(kap(i,:)*(Ern(i,:)-Erl(i,:)))
@@ -81,29 +83,30 @@ subroutine ca_accel_spec(lo, hi, &
 
   use rad_params_module, only : ngroups, clight
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer,intent(in) :: lo(1), hi(1)
   integer,intent(in):: kap_l1, kap_h1
   integer,intent(in)::mugT_l1,mugT_h1
   integer,intent(in)::spec_l1,spec_h1
-  double precision,intent(in )::kap ( kap_l1: kap_h1,0:ngroups-1)
-  double precision,intent(in )::mugT(mugT_l1:mugT_h1,0:ngroups-1)
-  double precision            ::spec(spec_l1:spec_h1,0:ngroups-1)
-  double precision,intent(in) :: dt, tau
+  real(rt)        ,intent(in )::kap ( kap_l1: kap_h1,0:ngroups-1)
+  real(rt)        ,intent(in )::mugT(mugT_l1:mugT_h1,0:ngroups-1)
+  real(rt)                    ::spec(spec_l1:spec_h1,0:ngroups-1)
+  real(rt)        ,intent(in) :: dt, tau
 
   integer :: i 
-  double precision :: cdt1, sumeps
-  double precision,dimension(0:ngroups-1):: epsilon, kapt
+  real(rt)         :: cdt1, sumeps
+  real(rt)        ,dimension(0:ngroups-1):: epsilon, kapt
 
-  cdt1 = 1.d0/(clight*dt)
+  cdt1 = 1.e0_rt/(clight*dt)
 
   do i = lo(1), hi(1)
-     kapt = kap(i,:) + (1.d0+tau)*cdt1
+     kapt = kap(i,:) + (1.e0_rt+tau)*cdt1
      epsilon = mugT(i,:) / kapt
      sumeps = sum(epsilon)
-     if (sumeps .eq. 0.d0) then
-        spec(i,:) = 0.d0
+     if (sumeps .eq. 0.e0_rt) then
+        spec(i,:) = 0.e0_rt
      else
         spec(i,:) = epsilon / sumeps
      end if
@@ -128,6 +131,7 @@ subroutine ca_check_conv( lo, hi, &
      dt)
   use rad_params_module, only : ngroups, clight
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer,intent(in)::lo(1),hi(1)
@@ -141,33 +145,33 @@ subroutine ca_check_conv( lo, hi, &
   integer,intent(in)::kap_l1, kap_h1
   integer,intent(in):: jg_l1,  jg_h1
   integer,intent(in)::deT_l1, deT_h1
-  double precision,intent(in   )::ren(ren_l1:ren_h1)
-  double precision,intent(in   )::res(res_l1:res_h1)
-  double precision,intent(in   )::re2(re2_l1:re2_h1)
-  double precision,intent(in   )::ern(ern_l1:ern_h1,0:ngroups-1)
-  double precision,intent(in   )::Tmn(Tmn_l1:Tmn_h1)
-  double precision,intent(in   )::Tms(Tms_l1:Tms_h1)
-  double precision,intent(in   )::rho(rho_l1:rho_h1)
-  double precision,intent(in   )::kap(kap_l1:kap_h1,0:ngroups-1)
-  double precision,intent(in   ):: jg( jg_l1: jg_h1,0:ngroups-1)
-  double precision,intent(in   )::deT(deT_l1:deT_h1)
-  double precision,intent(inout)::rel_re, abs_re 
-  double precision,intent(inout)::rel_FT, abs_FT,rel_T, abs_T
-  double precision,intent(in) :: dt
+  real(rt)        ,intent(in   )::ren(ren_l1:ren_h1)
+  real(rt)        ,intent(in   )::res(res_l1:res_h1)
+  real(rt)        ,intent(in   )::re2(re2_l1:re2_h1)
+  real(rt)        ,intent(in   )::ern(ern_l1:ern_h1,0:ngroups-1)
+  real(rt)        ,intent(in   )::Tmn(Tmn_l1:Tmn_h1)
+  real(rt)        ,intent(in   )::Tms(Tms_l1:Tms_h1)
+  real(rt)        ,intent(in   )::rho(rho_l1:rho_h1)
+  real(rt)        ,intent(in   )::kap(kap_l1:kap_h1,0:ngroups-1)
+  real(rt)        ,intent(in   ):: jg( jg_l1: jg_h1,0:ngroups-1)
+  real(rt)        ,intent(in   )::deT(deT_l1:deT_h1)
+  real(rt)        ,intent(inout)::rel_re, abs_re 
+  real(rt)        ,intent(inout)::rel_FT, abs_FT,rel_T, abs_T
+  real(rt)        ,intent(in) :: dt
 
   integer :: i
-  double precision :: chg, relchg, FT, cdt, FTdenom, dTe
+  real(rt)         :: chg, relchg, FT, cdt, FTdenom, dTe
 
   cdt = clight*dt
 
   do i=lo(1),hi(1)
      chg = abs(ren(i) - res(i))
-     relchg = abs(chg/(ren(i)+1.d-50))
+     relchg = abs(chg/(ren(i)+1.e-50_rt))
      rel_re = max(rel_re,relchg)
      abs_re = max(abs_re,chg)
 
      chg = abs(Tmn(i) - Tms(i))
-     relchg = abs(chg/(Tmn(i)+1.d-50))
+     relchg = abs(chg/(Tmn(i)+1.e-50_rt))
      rel_T = max(rel_T,relchg)
      abs_T = max(abs_T,chg)
 
@@ -175,9 +179,9 @@ subroutine ca_check_conv( lo, hi, &
 
      dTe = Tmn(i)
      FTdenom = rho(i)*abs(deT(i)*dTe)
-!     FTdenom = max(abs(ren(i)-re2(i)), abs(ren(i)*1.d-15))
+!     FTdenom = max(abs(ren(i)-re2(i)), abs(ren(i)*1.e-15_rt))
 
-     rel_FT = max(rel_FT, FT/(FTdenom+1.d-50))
+     rel_FT = max(rel_FT, FT/(FTdenom+1.e-50_rt))
      abs_FT = max(abs_FT, FT)
   end do
 
@@ -194,6 +198,7 @@ subroutine ca_check_conv_er( lo, hi, &
 
   use rad_params_module, only : ngroups, clight
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: lo(1), hi(1)
@@ -202,22 +207,22 @@ subroutine ca_check_conv_er( lo, hi, &
   integer, intent(in) :: kap_l1, kap_h1
   integer,intent(in)::temp_l1, temp_h1
   integer,intent(in)::etTz_l1, etTz_h1
-  double precision, intent(in) :: Ern(Ern_l1:Ern_h1,0:ngroups-1)
-  double precision, intent(in) :: Erl(Erl_l1:Erl_h1,0:ngroups-1)
-  double precision, intent(in) :: kap(kap_l1:kap_h1,0:ngroups-1)
-  double precision,intent(in )::etTz(etTz_l1:etTz_h1)
-  double precision,intent(in )::temp(temp_l1:temp_h1)
-  double precision, intent(inout) :: rela, abso, errr
-  double precision, intent(in) :: dt
+  real(rt)        , intent(in) :: Ern(Ern_l1:Ern_h1,0:ngroups-1)
+  real(rt)        , intent(in) :: Erl(Erl_l1:Erl_h1,0:ngroups-1)
+  real(rt)        , intent(in) :: kap(kap_l1:kap_h1,0:ngroups-1)
+  real(rt)        ,intent(in )::etTz(etTz_l1:etTz_h1)
+  real(rt)        ,intent(in )::temp(temp_l1:temp_h1)
+  real(rt)        , intent(inout) :: rela, abso, errr
+  real(rt)        , intent(in) :: dt
 
   integer :: i, g
-  double precision :: chg, tot, cdt, der, kde, err_T, err
+  real(rt)         :: chg, tot, cdt, der, kde, err_T, err
 
   cdt = clight * dt
   do i = lo(1), hi(1)
-     chg = 0.d0
-     tot = 0.d0
-     kde = 0.d0
+     chg = 0.e0_rt
+     tot = 0.e0_rt
+     kde = 0.e0_rt
      do g=0,ngroups-1
         der = Ern(i,g)-Erl(i,g)
         chg = chg + abs(der)
@@ -225,10 +230,10 @@ subroutine ca_check_conv_er( lo, hi, &
         kde = kde + kap(i,g)*der
      end do
      abso = max(abso, chg)
-     rela = max(rela, chg / (tot + 1.d-50))
+     rela = max(rela, chg / (tot + 1.e-50_rt))
 
      err_T =  etTz(i)*kde
-     err = abs(err_T/(temp(i)+1.d-50))
+     err = abs(err_T/(temp(i)+1.e-50_rt))
      errr = max(errr, err)
   end do
 
@@ -243,6 +248,7 @@ subroutine ca_compute_coupt( lo, hi, &
   
   use rad_params_module, only : ngroups
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: lo(1), hi(1)
@@ -250,14 +256,14 @@ subroutine ca_compute_coupt( lo, hi, &
   integer, intent(in) :: kpp_l1, kpp_h1 
   integer, intent(in) ::  eg_l1,  eg_h1
   integer, intent(in) ::  jg_l1,  jg_h1
-  double precision             :: cpt(cpt_l1:cpt_h1)
-  double precision, intent(in) :: kpp(kpp_l1:kpp_h1,0:ngroups-1)
-  double precision, intent(in) ::  eg( eg_l1: eg_h1,0:ngroups-1)
-  double precision, intent(in) ::  jg( jg_l1: jg_h1,0:ngroups-1)
+  real(rt)                     :: cpt(cpt_l1:cpt_h1)
+  real(rt)        , intent(in) :: kpp(kpp_l1:kpp_h1,0:ngroups-1)
+  real(rt)        , intent(in) ::  eg( eg_l1: eg_h1,0:ngroups-1)
+  real(rt)        , intent(in) ::  jg( jg_l1: jg_h1,0:ngroups-1)
 
   integer :: i, g
 
-  cpt(lo(1):hi(1)) = 0.d0
+  cpt(lo(1):hi(1)) = 0.e0_rt
 
   do g=0, ngroups-1
      do i=lo(1),hi(1)
@@ -281,6 +287,7 @@ subroutine ca_compute_etat( lo, hi, &
 
   use rad_params_module, only : ngroups, clight
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: lo(1), hi(1)
@@ -292,28 +299,28 @@ subroutine ca_compute_etat( lo, hi, &
   integer, intent(in) :: dedT_l1, dedT_h1
   integer, intent(in) ::  Ers_l1,  Ers_h1
   integer, intent(in) ::  rho_l1,  rho_h1
-  double precision               :: etaT(etaT_l1:etaT_h1)
-  double precision               :: etTz(etTz_l1:etTz_h1)
-  double precision               :: eta1(eta1_l1:eta1_h1)
-  double precision               :: djdT(djdT_l1:djdT_h1,0:ngroups-1)
-  double precision, intent(in )  :: dkdT(dkdT_l1:dkdT_h1,0:ngroups-1)
-  double precision, intent(in )  :: dedT(dedT_l1:dedT_h1)
-  double precision, intent(in )  :: Ers ( Ers_l1: Ers_h1,0:ngroups-1)
-  double precision, intent(in )  :: rho ( rho_l1: rho_h1)
-  double precision, intent(in) :: dt, tau
+  real(rt)                       :: etaT(etaT_l1:etaT_h1)
+  real(rt)                       :: etTz(etTz_l1:etTz_h1)
+  real(rt)                       :: eta1(eta1_l1:eta1_h1)
+  real(rt)                       :: djdT(djdT_l1:djdT_h1,0:ngroups-1)
+  real(rt)        , intent(in )  :: dkdT(dkdT_l1:dkdT_h1,0:ngroups-1)
+  real(rt)        , intent(in )  :: dedT(dedT_l1:dedT_h1)
+  real(rt)        , intent(in )  :: Ers ( Ers_l1: Ers_h1,0:ngroups-1)
+  real(rt)        , intent(in )  :: rho ( rho_l1: rho_h1)
+  real(rt)        , intent(in) :: dt, tau
 
   integer :: i
-  double precision :: cdt, sigma
-  double precision :: dZdT(0:ngroups-1), sumdZdT, foo, bar
+  real(rt)         :: cdt, sigma
+  real(rt)         :: dZdT(0:ngroups-1), sumdZdT, foo, bar
 
-  sigma = 1.d0 + tau
+  sigma = 1.e0_rt + tau
   cdt = clight * dt
 
   do i = lo(1), hi(1)
      dZdT = djdT(i,:) - dkdT(i,:)*Ers(i,:)
      sumdZdT = sum(dZdT)
-     if (sumdZdT .eq. 0.d0) then
-        sumdZdT = 1.d-50
+     if (sumdZdT .eq. 0.e0_rt) then
+        sumdZdT = 1.e-50_rt
      end if
      foo = cdt * sumdZdT
      bar = sigma*rho(i)*dedT(i)
@@ -338,6 +345,7 @@ subroutine ca_compute_emissivity( lo, hi, &
        pi, clight, hplanck, kboltz, arad
   use blackbody_module, only : BdBdTIndefInteg
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in)  :: lo(1), hi(1) 
@@ -346,37 +354,37 @@ subroutine ca_compute_emissivity( lo, hi, &
   integer, intent(in) ::    T_l1,    T_h1
   integer, intent(in) ::  kap_l1,  kap_h1
   integer, intent(in) :: dkdT_l1, dkdT_h1
-  double precision              :: jg  (  jg_l1:  jg_h1,0:ngroups-1)
-  double precision              :: djdT(djdT_l1:djdT_h1,0:ngroups-1)
-  double precision, intent(in ) ::    T(   T_l1:   T_h1)
-  double precision, intent(in ) ::  kap( kap_l1: kap_h1,0:ngroups-1)
-  double precision, intent(in ) :: dkdT(dkdT_l1:dkdT_h1,0:ngroups-1)
-  double precision, intent(in) :: pfc(0:ngroups-1)
+  real(rt)                      :: jg  (  jg_l1:  jg_h1,0:ngroups-1)
+  real(rt)                      :: djdT(djdT_l1:djdT_h1,0:ngroups-1)
+  real(rt)        , intent(in ) ::    T(   T_l1:   T_h1)
+  real(rt)        , intent(in ) ::  kap( kap_l1: kap_h1,0:ngroups-1)
+  real(rt)        , intent(in ) :: dkdT(dkdT_l1:dkdT_h1,0:ngroups-1)
+  real(rt)        , intent(in) :: pfc(0:ngroups-1)
   integer, intent(in) :: use_WiensLaw, integrate_Planck
-  double precision, intent(in) :: Tf
+  real(rt)        , intent(in) :: Tf
 
   integer :: i, g
-  double precision :: dBdT, Bg
-  double precision :: Teff, nu, num, nup, hoverk
-  double precision :: cB, Tfix
-  double precision :: B0, B1, dBdT0, dBdT1
-  double precision :: dnu, nubar, expnubar, cdBdT
-  double precision :: xnu_full(0:ngroups)
+  real(rt)         :: dBdT, Bg
+  real(rt)         :: Teff, nu, num, nup, hoverk
+  real(rt)         :: cB, Tfix
+  real(rt)         :: B0, B1, dBdT0, dBdT1
+  real(rt)         :: dnu, nubar, expnubar, cdBdT
+  real(rt)         :: xnu_full(0:ngroups)
 
   if (ngroups .eq. 1) then
 
      do i = lo(1), hi(1)
         Bg = arad*T(i)**4
-        dBdT = 4.d0*arad*T(i)**3
+        dBdT = 4.e0_rt*arad*T(i)**3
         g = 0
         jg(i,g) = Bg*kap(i,g)
         djdT(i,g) = dkdT(i,g)*Bg + dBdT*kap(i,g)
      end do     
 
-  else if (pfc(0) > 0.d0) then  ! a special case for picket-fence model in Su-Olson test
+  else if (pfc(0) > 0.e0_rt) then  ! a special case for picket-fence model in Su-Olson test
      do i = lo(1), hi(1)
         Bg = arad*T(i)**4
-        dBdT = 4.d0*arad*T(i)**3
+        dBdT = 4.e0_rt*arad*T(i)**3
         do g=0, ngroups-1
            jg(i,g) = pfc(g) * Bg*kap(i,g)
            djdT(i,g) = pfc(g) * (dkdT(i,g)*Bg + dBdT*kap(i,g))
@@ -392,7 +400,7 @@ subroutine ca_compute_emissivity( lo, hi, &
         num = xnu(g)
         nup = xnu(g+1)
         do i = lo(1), hi(1)
-           if (Tf < 0.d0) then
+           if (Tf < 0.e0_rt) then
               Tfix = T(i)
            else
               Tfix = Tf
@@ -407,11 +415,11 @@ subroutine ca_compute_emissivity( lo, hi, &
   else if (integrate_Planck > 0) then
 
      xnu_full = xnu(0:ngroups)
-     xnu_full(0) = 0.d0
-     xnu_full(ngroups) = max(xnu(ngroups), 1.d25)
+     xnu_full(0) = 0.e0_rt
+     xnu_full(ngroups) = max(xnu(ngroups), 1.e25_rt)
 
      do i=lo(1), hi(1)
-        Teff = max(T(i), 1.d-50)
+        Teff = max(T(i), 1.e-50_rt)
         call BdBdTIndefInteg(Teff, xnu_full(0), B1, dBdT1)
         do g=0, ngroups-1
            B0 = B1
@@ -427,25 +435,25 @@ subroutine ca_compute_emissivity( lo, hi, &
 
   else
 
-     cB = 8.d0*pi*hplanck / clight**3
-     cdBdT = 8.d0*pi*hplanck**2 / (kboltz*clight**3)
+     cB = 8.e0_rt*pi*hplanck / clight**3
+     cdBdT = 8.e0_rt*pi*hplanck**2 / (kboltz*clight**3)
 
      do g=0, ngroups-1
         nu = nugroup(g)
         dnu = dnugroup(g)
         do i=lo(1), hi(1)
-           Teff = max(T(i), 1.d-50)
+           Teff = max(T(i), 1.e-50_rt)
            nubar = hplanck * nu / (kboltz * Teff)
-           if (nubar > 100.d0) then
-              Bg = 0.d0
-              dBdT = 0.d0
-           else if (nubar < 1.d-15) then
-              Bg = 0.d0
-              dBdT = 0.d0           
+           if (nubar > 100.e0_rt) then
+              Bg = 0.e0_rt
+              dBdT = 0.e0_rt
+           else if (nubar < 1.e-15_rt) then
+              Bg = 0.e0_rt
+              dBdT = 0.e0_rt           
            else
               expnubar = exp(nubar)
-              Bg = cB * nu**3 / (expnubar - 1.d0) * dnu
-              dBdT = cdBdT * nu**4 / Teff**2 * expnubar / (expnubar-1.d0)**2 * dnu
+              Bg = cB * nu**3 / (expnubar - 1.e0_rt) * dnu
+              dBdT = cdBdT * nu**4 / Teff**2 * expnubar / (expnubar-1.e0_rt)**2 * dnu
            end if
 
            jg(i,g) = Bg*kap(i,g)
@@ -474,6 +482,7 @@ subroutine ca_compute_kappas(lo, hi, &
   use fundamental_constants_module, only : hplanck, k_B
   use meth_params_module, only : NVAR, URHO
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in)  :: lo(1), hi(1) 
@@ -483,19 +492,19 @@ subroutine ca_compute_kappas(lo, hi, &
   integer, intent(in) :: kpr_l1, kpr_h1
   integer, intent(in) :: kpT_l1, kpT_h1
   integer, intent(in) :: do_stme, use_dkdT
-  double precision, intent(in)   :: stt(stt_l1:stt_h1,NVAR)
-  double precision, intent(in)   ::   T(  T_l1:  T_h1)
-  double precision               :: kpp(kpp_l1:kpp_h1, 0:ngroups-1)
-  double precision               :: kpr(kpr_l1:kpr_h1, 0:ngroups-1)
-  double precision               :: kpT(kpT_l1:kpT_h1, 0:ngroups-1)
-  double precision, intent(in)   :: c_kpp, kpp_m, kpp_n, kpp_p 
-  double precision, intent(in)   :: c_kpr, kpr_m, kpr_n, kpr_p 
-  double precision, intent(in)   :: c_sct, sct_m, sct_n, sct_p 
-  double precision, intent(in)   :: Tfloor
+  real(rt)        , intent(in)   :: stt(stt_l1:stt_h1,NVAR)
+  real(rt)        , intent(in)   ::   T(  T_l1:  T_h1)
+  real(rt)                       :: kpp(kpp_l1:kpp_h1, 0:ngroups-1)
+  real(rt)                       :: kpr(kpr_l1:kpr_h1, 0:ngroups-1)
+  real(rt)                       :: kpT(kpT_l1:kpT_h1, 0:ngroups-1)
+  real(rt)        , intent(in)   :: c_kpp, kpp_m, kpp_n, kpp_p 
+  real(rt)        , intent(in)   :: c_kpr, kpr_m, kpr_n, kpr_p 
+  real(rt)        , intent(in)   :: c_sct, sct_m, sct_n, sct_p 
+  real(rt)        , intent(in)   :: Tfloor
 
   integer :: i, g
-  double precision, parameter :: tiny = 1.0d-50
-  double precision :: Teff, nup_kpp, nup_kpr, nup_sct, sct, foo, hnuoverkt, exptmp
+  real(rt)        , parameter :: tiny = 1.0e-50_rt
+  real(rt)         :: Teff, nup_kpp, nup_kpr, nup_sct, sct, foo, hnuoverkt, exptmp
 
   do g=0, ngroups-1
      nup_kpp = nugroup(g)**kpp_p
@@ -509,17 +518,17 @@ subroutine ca_compute_kappas(lo, hi, &
            foo = kpp(i,g)
            hnuoverkt = hplanck*nugroup(g)/(k_B*Teff)
            exptmp = exp(-hnuoverkt)
-           kpp(i,g) = foo * (1.d0 - exptmp)
-           kpT(i,g) = foo*(-kpp_n/Teff)*(1.d0-exptmp) - foo*exptmp*(hnuoverkt/Teff)
+           kpp(i,g) = foo * (1.e0_rt - exptmp)
+           kpT(i,g) = foo*(-kpp_n/Teff)*(1.e0_rt-exptmp) - foo*exptmp*(hnuoverkt/Teff)
         else
            kpT(i,g) = kpp(i,g) * (-kpp_n/Teff)           
         end if
 
         if (use_dkdT.eq.0) then
-           kpT(i,g) = 0.d0
+           kpT(i,g) = 0.e0_rt
         end if
 
-        if (c_kpr < 0.0d0) then
+        if (c_kpr < 0.0e0_rt) then
            sct       = c_sct * (stt(i,URHO) ** sct_m) * (Teff ** (-sct_n)) * nup_sct
            kpr(i,g) = kpp(i,g) + sct
         else
@@ -545,6 +554,7 @@ subroutine ca_compute_rhs( lo, hi, &
 
   use rad_params_module, only : ngroups, clight
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer,intent(in):: lo(1), hi(1) 
@@ -557,23 +567,23 @@ subroutine ca_compute_rhs( lo, hi, &
   integer,intent(in):: re2_l1, re2_h1
   integer,intent(in):: Ers_l1, Ers_h1
   integer,intent(in):: res_l1, res_h1
-  double precision            ::rhs ( rhs_l1: rhs_h1)
-  double precision,intent(in )::jg  (  jg_l1:  jg_h1,0:ngroups-1)
-  double precision,intent(in )::mugT(mugT_l1:mugT_h1,0:ngroups-1)
-  double precision,intent(in )::cpT ( cpT_l1: cpT_h1)
-  double precision,intent(in )::etaT(etaT_l1:etaT_h1)
-  double precision,intent(in )::Er2 ( Er2_l1: Er2_h1,0:ngroups-1)
-  double precision,intent(in )::re2 ( re2_l1: re2_h1)
-  double precision,intent(in )::Ers ( Ers_l1: Ers_h1,0:ngroups-1)
-  double precision,intent(in )::res ( res_l1: res_h1)
-  double precision,intent(in) ::   r(lo(1):hi(1))
-  double precision,intent(in) :: dt, tau
+  real(rt)                    ::rhs ( rhs_l1: rhs_h1)
+  real(rt)        ,intent(in )::jg  (  jg_l1:  jg_h1,0:ngroups-1)
+  real(rt)        ,intent(in )::mugT(mugT_l1:mugT_h1,0:ngroups-1)
+  real(rt)        ,intent(in )::cpT ( cpT_l1: cpT_h1)
+  real(rt)        ,intent(in )::etaT(etaT_l1:etaT_h1)
+  real(rt)        ,intent(in )::Er2 ( Er2_l1: Er2_h1,0:ngroups-1)
+  real(rt)        ,intent(in )::re2 ( re2_l1: re2_h1)
+  real(rt)        ,intent(in )::Ers ( Ers_l1: Ers_h1,0:ngroups-1)
+  real(rt)        ,intent(in )::res ( res_l1: res_h1)
+  real(rt)        ,intent(in) ::   r(lo(1):hi(1))
+  real(rt)        ,intent(in) :: dt, tau
   integer, intent(in) :: igroup
 
   integer :: i
-  double precision :: Hg, dt1
+  real(rt)         :: Hg, dt1
 
-  dt1 = 1.d0/dt
+  dt1 = 1.e0_rt/dt
   do i=lo(1),hi(1)
      Hg = mugT(i,igroup) * etaT(i)
 
@@ -600,6 +610,7 @@ subroutine ca_compute_rhs_so( lo, hi, & ! MG Su-Olson
 
   use rad_params_module, only : ngroups, clight
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer,intent(in):: lo(1), hi(1) 
@@ -611,24 +622,24 @@ subroutine ca_compute_rhs_so( lo, hi, & ! MG Su-Olson
   integer,intent(in):: Er2_l1, Er2_h1
   integer,intent(in):: re2_l1, re2_h1
   integer,intent(in):: res_l1, res_h1
-  double precision            ::rhs ( rhs_l1: rhs_h1)
-  double precision,intent(in )::jg  (  jg_l1:  jg_h1,0:ngroups-1)
-  double precision,intent(in )::mugT(mugT_l1:mugT_h1,0:ngroups-1)
-  double precision,intent(in )::cpT ( cpT_l1: cpT_h1)
-  double precision,intent(in )::etaT(etaT_l1:etaT_h1)
-  double precision,intent(in )::Er2 ( Er2_l1: Er2_h1,0:ngroups-1)
-  double precision,intent(in )::re2 ( re2_l1: re2_h1)
-  double precision,intent(in )::res ( res_l1: res_h1)
-  double precision,intent(in) :: x(lo(1):hi(1))
-  double precision,intent(in) :: t, dt
+  real(rt)                    ::rhs ( rhs_l1: rhs_h1)
+  real(rt)        ,intent(in )::jg  (  jg_l1:  jg_h1,0:ngroups-1)
+  real(rt)        ,intent(in )::mugT(mugT_l1:mugT_h1,0:ngroups-1)
+  real(rt)        ,intent(in )::cpT ( cpT_l1: cpT_h1)
+  real(rt)        ,intent(in )::etaT(etaT_l1:etaT_h1)
+  real(rt)        ,intent(in )::Er2 ( Er2_l1: Er2_h1,0:ngroups-1)
+  real(rt)        ,intent(in )::re2 ( re2_l1: re2_h1)
+  real(rt)        ,intent(in )::res ( res_l1: res_h1)
+  real(rt)        ,intent(in) :: x(lo(1):hi(1))
+  real(rt)        ,intent(in) :: t, dt
   integer, intent(in) :: igroup
 
-  double precision, parameter :: x0 = 0.5d0
-  double precision, parameter :: t0 = 3.3356409519815202d-10 
-  double precision, parameter :: qn = 1.134074546528399d20 
+  real(rt)        , parameter :: x0 = 0.5e0_rt
+  real(rt)        , parameter :: t0 = 3.3356409519815202e-10_rt 
+  real(rt)        , parameter :: qn = 1.134074546528399e20_rt 
 
   integer :: i
-  double precision :: Hg
+  real(rt)         :: Hg
 
   do i=lo(1),hi(1)
      Hg = mugT(i,igroup)*etaT(i)
@@ -652,6 +663,7 @@ subroutine ca_local_accel( lo, hi,  &
 
   use rad_params_module, only : ngroups, clight
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer,intent(in):: lo(1), hi(1)
@@ -660,29 +672,29 @@ subroutine ca_local_accel( lo, hi,  &
   integer,intent(in):: kap_l1, kap_h1
   integer,intent(in)::etaT_l1,etaT_h1
   integer,intent(in)::mugT_l1,mugT_h1
-  double precision              ::Ern ( Ern_l1: Ern_h1,0:ngroups-1)
-  double precision,intent(in   )::Erl ( Erl_l1: Erl_h1,0:ngroups-1)
-  double precision,intent(in   )::kap ( kap_l1: kap_h1,0:ngroups-1)
-  double precision,intent(in   )::etaT(etaT_l1:etaT_h1)
-  double precision,intent(in   )::mugT(mugT_l1:mugT_h1,0:ngroups-1)
-  double precision,intent(in) :: dt, tau
+  real(rt)                      ::Ern ( Ern_l1: Ern_h1,0:ngroups-1)
+  real(rt)        ,intent(in   )::Erl ( Erl_l1: Erl_h1,0:ngroups-1)
+  real(rt)        ,intent(in   )::kap ( kap_l1: kap_h1,0:ngroups-1)
+  real(rt)        ,intent(in   )::etaT(etaT_l1:etaT_h1)
+  real(rt)        ,intent(in   )::mugT(mugT_l1:mugT_h1,0:ngroups-1)
+  real(rt)        ,intent(in) :: dt, tau
 
   integer :: i 
-  double precision :: cdt1, rt_term, p
-  double precision,dimension(0:ngroups-1)::Hg, epsilon, kapt, kk
+  real(rt)         :: cdt1, rt_term, p
+  real(rt)        ,dimension(0:ngroups-1)::Hg, epsilon, kapt, kk
 
-  cdt1 = 1.d0/(clight*dt)
+  cdt1 = 1.e0_rt/(clight*dt)
 
   do i = lo(1), hi(1)
      rt_term = sum(kap(i,:)*(Ern(i,:)-Erl(i,:)))
 
      Hg = mugT(i,:)*etaT(i)
 
-     kapt = kap(i,:) + (1.d0+tau)*cdt1
+     kapt = kap(i,:) + (1.e0_rt+tau)*cdt1
      kk = kap(i,:) / kapt
 
-     p = 1.d0-sum(Hg*kk)
-     epsilon = (Hg * rt_term) / (kapt*p + 1.d-50)
+     p = 1.e0_rt-sum(Hg*kk)
+     epsilon = (Hg * rt_term) / (kapt*p + 1.e-50_rt)
 
      Ern(i,:) = Ern(i,:) + epsilon
   end do
@@ -699,6 +711,7 @@ subroutine ca_state_update( lo, hi, &
 
   use meth_params_module, only : NVAR, UEDEN, UEINT, UTEMP
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: lo(1), hi(1) 
@@ -706,24 +719,24 @@ subroutine ca_state_update( lo, hi, &
   integer, intent(in) ::  rhoe_l1,  rhoe_h1
   integer, intent(in) ::  temp_l1,  temp_h1
   integer, intent(in) ::   msk_l1,   msk_h1
-  double precision, intent(in)   :: rhoe( rhoe_l1: rhoe_h1)
-  double precision, intent(in)   :: temp( temp_l1: temp_h1)
-  double precision, intent(in)   ::  msk(  msk_l1:  msk_h1)
-  double precision               ::state(state_l1:state_h1, NVAR)
-  double precision, intent(inout) :: derat, dTrat
+  real(rt)        , intent(in)   :: rhoe( rhoe_l1: rhoe_h1)
+  real(rt)        , intent(in)   :: temp( temp_l1: temp_h1)
+  real(rt)        , intent(in)   ::  msk(  msk_l1:  msk_h1)
+  real(rt)                       ::state(state_l1:state_h1, NVAR)
+  real(rt)        , intent(inout) :: derat, dTrat
 
   integer :: i
-  double precision :: ei, ek, Told
+  real(rt)         :: ei, ek, Told
 
   do i=lo(1), hi(1)
      ei = state(i,UEINT)
-     derat = max(derat, abs((rhoe(i) - ei)*msk(i)/ (ei + 1.d-50)))
+     derat = max(derat, abs((rhoe(i) - ei)*msk(i)/ (ei + 1.e-50_rt)))
      ek = state(i,UEDEN) - state(i,UEINT)
      state(i,UEINT) = rhoe(i)
      state(i,UEDEN) = rhoe(i) + ek
 
      Told = state(i,UTEMP)
-     dTrat = max(dTrat, abs((temp(i)-Told)*msk(i)/ (Told + 1.d-50)))
+     dTrat = max(dTrat, abs((temp(i)-Told)*msk(i)/ (Told + 1.e-50_rt)))
      state(i,UTEMP) = temp(i)
   end do
 
@@ -746,6 +759,7 @@ subroutine ca_update_matter( lo, hi,  &
   use rad_params_module, only : ngroups, clight
   use meth_params_module, only : NVAR
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer,intent(in)::lo(1),hi(1)
@@ -759,20 +773,20 @@ subroutine ca_update_matter( lo, hi,  &
   integer,intent(in):: kpp_l1,  kpp_h1
   integer,intent(in)::mugT_l1, mugT_h1
   integer,intent(in)::Snew_l1, Snew_h1
-  double precision            ::re_n(re_n_l1:re_n_h1)
-  double precision,intent(in )::Er_n(Er_n_l1:Er_n_h1,0:ngroups-1)
-  double precision,intent(in )::Er_l(Er_l_l1:Er_l_h1,0:ngroups-1)
-  double precision,intent(in )::re_s(re_s_l1:re_s_h1)
-  double precision,intent(in )::re_2(re_2_l1:re_2_h1)
-  double precision,intent(in )::eta1(eta1_l1:eta1_h1)
-  double precision,intent(in ):: cpt( cpt_l1: cpt_h1)
-  double precision,intent(in ):: kpp( kpp_l1: kpp_h1,0:ngroups-1)
-  double precision,intent(in )::mugT(mugT_l1:mugT_h1,0:ngroups-1)
-  double precision,intent(in )::Snew(Snew_l1:Snew_h1,NVAR)
-  double precision,intent(in) :: dt, tau
+  real(rt)                    ::re_n(re_n_l1:re_n_h1)
+  real(rt)        ,intent(in )::Er_n(Er_n_l1:Er_n_h1,0:ngroups-1)
+  real(rt)        ,intent(in )::Er_l(Er_l_l1:Er_l_h1,0:ngroups-1)
+  real(rt)        ,intent(in )::re_s(re_s_l1:re_s_h1)
+  real(rt)        ,intent(in )::re_2(re_2_l1:re_2_h1)
+  real(rt)        ,intent(in )::eta1(eta1_l1:eta1_h1)
+  real(rt)        ,intent(in ):: cpt( cpt_l1: cpt_h1)
+  real(rt)        ,intent(in ):: kpp( kpp_l1: kpp_h1,0:ngroups-1)
+  real(rt)        ,intent(in )::mugT(mugT_l1:mugT_h1,0:ngroups-1)
+  real(rt)        ,intent(in )::Snew(Snew_l1:Snew_h1,NVAR)
+  real(rt)        ,intent(in) :: dt, tau
 
   integer :: i
-  double precision :: cdt, H1, dkEE, chg
+  real(rt)         :: cdt, H1, dkEE, chg
 
   cdt = clight * dt
   do i = lo(1), hi(1)
@@ -784,7 +798,7 @@ subroutine ca_update_matter( lo, hi,  &
 
      re_n(i) = re_s(i) + chg
 
-     re_n(i) = (re_n(i) + tau*re_s(i)) / (1.d0+tau)
+     re_n(i) = (re_n(i) + tau*re_s(i)) / (1.e0_rt+tau)
 
      ! temperature will be updated after exiting this subroutine
   end do
@@ -804,6 +818,7 @@ subroutine ca_ncupdate_matter( lo, hi,  &
 
   use rad_params_module, only : ngroups, clight
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer,intent(in)::lo(1),hi(1)
@@ -814,24 +829,24 @@ subroutine ca_ncupdate_matter( lo, hi,  &
   integer,intent(in)::etTz_l1, etTz_h1
   integer,intent(in):: kpp_l1,  kpp_h1
   integer,intent(in)::  jg_l1,   jg_h1
-  double precision           ::Tp_n(Tp_n_l1:Tp_n_h1)
-  double precision,intent(in)::Er_n(Er_n_l1:Er_n_h1,0:ngroups-1)
-  double precision,intent(in)::re_s(re_s_l1:re_s_h1)
-  double precision,intent(in)::re_2(re_2_l1:re_2_h1)
-  double precision,intent(in)::etTz(etTz_l1:etTz_h1)
-  double precision,intent(in):: kpp( kpp_l1: kpp_h1,0:ngroups-1)
-  double precision,intent(in)::  jg(  jg_l1:  jg_h1,0:ngroups-1)
-  double precision,intent(in) :: dt
+  real(rt)                   ::Tp_n(Tp_n_l1:Tp_n_h1)
+  real(rt)        ,intent(in)::Er_n(Er_n_l1:Er_n_h1,0:ngroups-1)
+  real(rt)        ,intent(in)::re_s(re_s_l1:re_s_h1)
+  real(rt)        ,intent(in)::re_2(re_2_l1:re_2_h1)
+  real(rt)        ,intent(in)::etTz(etTz_l1:etTz_h1)
+  real(rt)        ,intent(in):: kpp( kpp_l1: kpp_h1,0:ngroups-1)
+  real(rt)        ,intent(in)::  jg(  jg_l1:  jg_h1,0:ngroups-1)
+  real(rt)        ,intent(in) :: dt
 
    integer :: i,g
-   double precision :: cdt1, cpT, scrch_re
-   double precision :: dTemp
-   double precision, parameter :: fac = 0.01d0
+   real(rt)         :: cdt1, cpT, scrch_re
+   real(rt)         :: dTemp
+   real(rt)        , parameter :: fac = 0.01e0_rt
 
-   cdt1 = 1.d0 / (clight * dt)
+   cdt1 = 1.e0_rt / (clight * dt)
    do i = lo(1), hi(1)
 
-      cpT = 0.d0
+      cpT = 0.e0_rt
       do g = 0, ngroups-1
          cpT = cpT + kpp(i,g)*Er_n(i,g) - jg(i,g)
       end do
@@ -840,7 +855,7 @@ subroutine ca_ncupdate_matter( lo, hi,  &
 
       dTemp = etTz(i)*scrch_re
 
-      if (abs(dTemp/(Tp_n(i)+1.d-50)) > fac) then
+      if (abs(dTemp/(Tp_n(i)+1.e-50_rt)) > fac) then
          dTemp = sign(fac*Tp_n(i), dTemp)
       end if
 
@@ -865,6 +880,7 @@ subroutine ca_opacs( lo, hi,  &
   use network, only : naux
   use meth_params_module, only : NVAR, URHO, UFX
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: lo(1), hi(1)
@@ -874,24 +890,24 @@ subroutine ca_opacs( lo, hi,  &
   integer, intent(in) ::  kpp_l1,  kpp_h1 
   integer, intent(in) ::  kpr_l1,  kpr_h1
   integer, intent(in) :: dkdT_l1, dkdT_h1
-  double precision, intent(in ) :: Snew(Snew_l1:Snew_h1,NVAR)
-  double precision, intent(in ) :: T   (   T_l1:   T_h1)
-  double precision, intent(in ) :: Ts  (  Ts_l1:  Ts_h1)
-  double precision :: kpp ( kpp_l1: kpp_h1,0:ngroups-1)
-  double precision :: kpr ( kpr_l1: kpr_h1,0:ngroups-1)
-  double precision :: dkdT(dkdT_l1:dkdT_h1,0:ngroups-1)
+  real(rt)        , intent(in ) :: Snew(Snew_l1:Snew_h1,NVAR)
+  real(rt)        , intent(in ) :: T   (   T_l1:   T_h1)
+  real(rt)        , intent(in ) :: Ts  (  Ts_l1:  Ts_h1)
+  real(rt)         :: kpp ( kpp_l1: kpp_h1,0:ngroups-1)
+  real(rt)         :: kpr ( kpr_l1: kpr_h1,0:ngroups-1)
+  real(rt)         :: dkdT(dkdT_l1:dkdT_h1,0:ngroups-1)
   integer, intent(in) :: use_dkdT, validStar, lag_opac
 
   integer :: i, g
-  double precision :: kp, kr, nu, rho, temp, Ye
-  double precision :: kp1, kr1
-  double precision :: kp2, kr2
-  double precision :: dT
+  real(rt)         :: kp, kr, nu, rho, temp, Ye
+  real(rt)         :: kp1, kr1
+  real(rt)         :: kp2, kr2
+  real(rt)         :: dT
   logical :: comp_kp, comp_kr
-  double precision, parameter :: fac = 0.5d0, minfrac = 1.d-8
+  real(rt)        , parameter :: fac = 0.5e0_rt, minfrac = 1.e-8_rt
 
   if (lag_opac .eq. 1) then
-     dkdT(lo(1):hi(1),:) = 0.d0
+     dkdT(lo(1):hi(1),:) = 0.e0_rt
      return
   end if
 
@@ -902,14 +918,14 @@ subroutine ca_opacs( lo, hi,  &
      if (naux > 0) then
         Ye = Snew(i,UFX)
      else
-        Ye = 0.d0
+        Ye = 0.e0_rt
      end if
 
      if (validStar > 0) then
         dT = fac*abs(Ts(i) - T(i))
         dT = max(dT, minfrac*T(i))
      else
-        dT = T(i) * 1.d-3 + 1.d-50
+        dT = T(i) * 1.e-3_rt + 1.e-50_rt
      end if
 
      do g=0, ngroups-1
@@ -924,7 +940,7 @@ subroutine ca_opacs( lo, hi,  &
         kpr(i,g) = kr 
 
         if (use_dkdT .eq. 0) then        
-           dkdT(i,g) = 0.d0
+           dkdT(i,g) = 0.e0_rt
         else
 
            comp_kp = .true.
@@ -933,7 +949,7 @@ subroutine ca_opacs( lo, hi,  &
            call get_opacities(kp1, kr1, rho, temp-dT, Ye, nu, comp_kp, comp_kr)
            call get_opacities(kp2, kr2, rho, temp+dT, Ye, nu, comp_kp, comp_kr)
 
-           dkdT(i,g) = (kp2-kp1)/(2.d0*dT)
+           dkdT(i,g) = (kp2-kp1)/(2.e0_rt*dT)
 
         end if
 
@@ -952,16 +968,17 @@ subroutine ca_compute_rosseland( lo, hi, &
   use network, only : naux
   use meth_params_module, only : NVAR, URHO, UTEMP, UFX
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: lo(1), hi(1)
   integer, intent(in) ::  kpr_l1,  kpr_h1
   integer, intent(in) :: stat_l1, stat_h1 
-  double precision             :: kpr ( kpr_l1: kpr_h1,0:ngroups-1)
-  double precision, intent(in) :: stat(stat_l1:stat_h1,NVAR)
+  real(rt)                     :: kpr ( kpr_l1: kpr_h1,0:ngroups-1)
+  real(rt)        , intent(in) :: stat(stat_l1:stat_h1,NVAR)
 
   integer :: i, g
-  double precision :: kp, kr, nu, rho, temp, Ye
+  real(rt)         :: kp, kr, nu, rho, temp, Ye
   logical, parameter :: comp_kp = .false. 
   logical, parameter :: comp_kr = .true.
 
@@ -976,7 +993,7 @@ subroutine ca_compute_rosseland( lo, hi, &
         if (naux > 0) then
            Ye = stat(i,UFX)
         else
-           Ye = 0.d0
+           Ye = 0.e0_rt
         end if
 
         call get_opacities(kp, kr, rho, temp, Ye, nu, comp_kp, comp_kr)
@@ -998,16 +1015,17 @@ subroutine ca_compute_planck( lo, hi,  &
   use network, only : naux
   use meth_params_module, only : NVAR, URHO, UTEMP, UFX
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: lo(1), hi(1)
   integer, intent(in) ::  kpp_l1,  kpp_h1
   integer, intent(in) :: stat_l1, stat_h1 
-  double precision             :: kpp ( kpp_l1: kpp_h1,0:ngroups-1)
-  double precision, intent(in) :: stat(stat_l1:stat_h1,NVAR)
+  real(rt)                     :: kpp ( kpp_l1: kpp_h1,0:ngroups-1)
+  real(rt)        , intent(in) :: stat(stat_l1:stat_h1,NVAR)
 
   integer :: i, g
-  double precision :: kp, kr, nu, rho, temp, Ye
+  real(rt)         :: kp, kr, nu, rho, temp, Ye
   logical, parameter :: comp_kp = .true. 
   logical, parameter :: comp_kr = .false.
 
@@ -1022,7 +1040,7 @@ subroutine ca_compute_planck( lo, hi,  &
         if (naux > 0) then
            Ye = stat(i,UFX)
         else
-           Ye = 0.d0
+           Ye = 0.e0_rt
         end if
 
         call get_opacities(kp, kr, rho, temp, Ye, nu, comp_kp, comp_kr)
@@ -1049,24 +1067,25 @@ subroutine ca_accel_ccoe( lo, hi, &
 
   use rad_params_module, only : ngroups
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: lo(1), hi(1)
   integer, intent(in) :: bcgr_l1, bcgr_h1
   integer, intent(in) :: spec_l1, spec_h1
   integer, intent(in) :: ccoe_l1, ccoe_h1
-  double precision, intent(in) :: bcgr(bcgr_l1:bcgr_h1)
-  double precision, intent(in) :: spec(spec_l1:spec_h1, 0:ngroups-1)
-  double precision             :: ccoe(ccoe_l1:ccoe_h1, 0:1)
-  double precision, intent(in) :: dx(1)
+  real(rt)        , intent(in) :: bcgr(bcgr_l1:bcgr_h1)
+  real(rt)        , intent(in) :: spec(spec_l1:spec_h1, 0:ngroups-1)
+  real(rt)                     :: ccoe(ccoe_l1:ccoe_h1, 0:1)
+  real(rt)        , intent(in) :: dx(1)
   integer, intent(in) :: idim, igroup
 
   integer :: i
-  double precision :: grad_spec, foo
+  real(rt)         :: grad_spec, foo
 
   do i = lo(1), hi(1)
      grad_spec = (spec(i,igroup) - spec(i-1,igroup)) / dx(1)
-     foo = - 0.5d0 * bcgr(i) * grad_spec
+     foo = - 0.5e0_rt * bcgr(i) * grad_spec
      ccoe(i,0) = ccoe(i,0) + foo
      ccoe(i,1) = ccoe(i,1) + foo
   end do
@@ -1079,6 +1098,7 @@ subroutine ca_flux_face2center( lo, hi, &
      f, f_l1, f_h1, &
      x, x_l1, x_h1, &
      nt, idim, it)
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer,intent(in):: lo(1), hi(1)
@@ -1086,24 +1106,25 @@ subroutine ca_flux_face2center( lo, hi, &
   integer,intent(in)::f_l1,f_h1
   integer,intent(in)::x_l1,x_h1
   integer,intent(in) :: nt, idim, it
-  double precision           ::t(t_l1:t_h1,0:nt-1)
-  double precision,intent(in)::f(f_l1:f_h1)
-  double precision,intent(in)::x(x_l1:x_h1)
+  real(rt)                   ::t(t_l1:t_h1,0:nt-1)
+  real(rt)        ,intent(in)::f(f_l1:f_h1)
+  real(rt)        ,intent(in)::x(x_l1:x_h1)
 
   integer i
 
   do i=lo(1),hi(1)
-     t(i,it) = (f(i)/(x(i)+1.d-50) + f(i+1)/x(i+1)) * 0.5d0
+     t(i,it) = (f(i)/(x(i)+1.e-50_rt) + f(i+1)/x(i+1)) * 0.5e0_rt
   end do
 
 end subroutine ca_flux_face2center
 
 subroutine ca_rhstoer(lo, hi, rhs, rhs_l1, rhs_h1, r, dt)
+  use bl_fort_module, only : rt => c_real
   implicit none
   integer,intent(in):: lo(1), hi(1), rhs_l1, rhs_h1
-  double precision           ::rhs ( rhs_l1: rhs_h1)
-  double precision,intent(in)::   r(lo(1):hi(1))
-  double precision,intent(in):: dt
+  real(rt)                   ::rhs ( rhs_l1: rhs_h1)
+  real(rt)        ,intent(in)::   r(lo(1):hi(1))
+  real(rt)        ,intent(in):: dt
   integer :: i
   do i=lo(1),hi(1)
      rhs(i) = rhs(i)*dt/r(i)
@@ -1123,22 +1144,23 @@ subroutine ca_compute_powerlaw_kappa_s( lo, hi, &
   use rad_params_module, only : ngroups, nugroup
   use meth_params_module, only : NVAR, URHO, UTEMP
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: lo(1), hi(1)
   integer, intent(in) :: k_l1, k_h1, &
                          u_l1, u_h1
-  double precision             :: kappa(k_l1:k_h1, 0:ngroups-1) 
-  double precision, intent(in) ::     u(u_l1:u_h1, NVAR)
-  double precision, intent(in) :: kappa0, m, n, p, Tfloor, kfloor
-  double precision, intent(in) :: s0, sm, sn, sp
+  real(rt)                     :: kappa(k_l1:k_h1, 0:ngroups-1) 
+  real(rt)        , intent(in) ::     u(u_l1:u_h1, NVAR)
+  real(rt)        , intent(in) :: kappa0, m, n, p, Tfloor, kfloor
+  real(rt)        , intent(in) :: s0, sm, sn, sp
 
   integer :: i, g
-  double precision, parameter :: tiny = 1.0d-50
-  double precision :: Teff, kf, sct, nup, nusp
+  real(rt)        , parameter :: tiny = 1.0e-50_rt
+  real(rt)         :: Teff, kf, sct, nup, nusp
 
-  if (  m.eq.0.d0 .and.  n.eq.0.d0 .and.  p.eq.0.d0 .and. &
-       sm.eq.0.d0 .and. sn.eq.0.d0 .and. sp.eq.0.d0 ) then
+  if (  m.eq.0.e0_rt .and.  n.eq.0.e0_rt .and.  p.eq.0.e0_rt .and. &
+       sm.eq.0.e0_rt .and. sn.eq.0.e0_rt .and. sp.eq.0.e0_rt ) then
      kappa(lo(1):hi(1),:) = kappa0 + s0
   else
      do g = 0, ngroups-1
@@ -1165,20 +1187,21 @@ subroutine ca_compute_powerlaw_kappa( lo, hi,  &
   use rad_params_module, only : ngroups, nugroup
   use meth_params_module, only : NVAR, URHO, UTEMP
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: lo(1), hi(1)
   integer, intent(in) :: k_l1, k_h1, &
                          u_l1, u_h1
-  double precision             :: kappa(k_l1:k_h1, 0:ngroups-1) 
-  double precision, intent(in) ::     u(u_l1:u_h1, NVAR)
-  double precision, intent(in) :: kappa0, m, n, p, Tfloor, kfloor
+  real(rt)                     :: kappa(k_l1:k_h1, 0:ngroups-1) 
+  real(rt)        , intent(in) ::     u(u_l1:u_h1, NVAR)
+  real(rt)        , intent(in) :: kappa0, m, n, p, Tfloor, kfloor
 
   integer :: i, g
-  double precision, parameter :: tiny = 1.0d-50
-  double precision :: Teff, kf, nup
+  real(rt)        , parameter :: tiny = 1.0e-50_rt
+  real(rt)         :: Teff, kf, nup
 
-  if (  m.eq.0.d0 .and.  n.eq.0.d0 .and.  p.eq.0.d0 ) then
+  if (  m.eq.0.e0_rt .and.  n.eq.0.e0_rt .and.  p.eq.0.e0_rt ) then
      kappa(lo(1):hi(1),:) = kappa0
   else
      do g = 0, ngroups-1
@@ -1202,13 +1225,14 @@ subroutine ca_spalpha( lo, hi, &
 
   use rad_params_module, only : ngroups
   use fluxlimiter_module, only : FLDalpha
+  use bl_fort_module, only : rt => c_real
   implicit none
   integer, intent(in) :: lo(1), hi(1)
   integer, intent(in) :: spa_l1, spa_h1
   integer, intent(in) :: lam_l1, lam_h1
   integer, intent(in) :: igroup
-  double precision             :: spa(spa_l1:spa_h1)
-  double precision, intent(in) :: lam(lam_l1:lam_h1, 0:ngroups-1)
+  real(rt)                     :: spa(spa_l1:spa_h1)
+  real(rt)        , intent(in) :: lam(lam_l1:lam_h1, 0:ngroups-1)
   integer :: i
 
   i = spa_l1

--- a/Source/Radiation/RadSrc_1d/MGFLDneut_1d.f90
+++ b/Source/Radiation/RadSrc_1d/MGFLDneut_1d.f90
@@ -9,6 +9,7 @@ subroutine ca_accel_acoe_neut( lo, hi,  &
 
   use rad_params_module, only : ngroups, clight, erg2rhoYe
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: lo(1), hi(1)
@@ -18,22 +19,22 @@ subroutine ca_accel_acoe_neut( lo, hi,  &
   integer, intent(in) ::  spc_l1, spc_h1
   integer, intent(in) ::  kap_l1, kap_h1
   integer, intent(in) ::  aco_l1, aco_h1
-  double precision, intent(in) :: eta1(eta1_l1:eta1_h1)
-  double precision, intent(in) :: theT(theT_l1:theT_h1)
-  double precision, intent(in) :: theY(theY_l1:theY_h1)
-  double precision, intent(in) :: spc ( spc_l1: spc_h1,0:ngroups-1)
-  double precision, intent(in) :: kap ( kap_l1: kap_h1,0:ngroups-1)
-  double precision             :: aco ( aco_l1: aco_h1)
-  double precision, intent(in) :: dt, tau
+  real(rt)        , intent(in) :: eta1(eta1_l1:eta1_h1)
+  real(rt)        , intent(in) :: theT(theT_l1:theT_h1)
+  real(rt)        , intent(in) :: theY(theY_l1:theY_h1)
+  real(rt)        , intent(in) :: spc ( spc_l1: spc_h1,0:ngroups-1)
+  real(rt)        , intent(in) :: kap ( kap_l1: kap_h1,0:ngroups-1)
+  real(rt)                     :: aco ( aco_l1: aco_h1)
+  real(rt)        , intent(in) :: dt, tau
 
   integer :: i, g
-  double precision :: kbar, kybar, H1, Theta, dt1, foo
+  real(rt)         :: kbar, kybar, H1, Theta, dt1, foo
 
-  dt1 = (1.d0+tau)/dt
+  dt1 = (1.e0_rt+tau)/dt
 
   do i = lo(1), hi(1)
-     kbar = 0.d0
-     kybar = 0.d0
+     kbar = 0.e0_rt
+     kybar = 0.e0_rt
      do g=0, ngroups-1
         foo = spc(i,g) * kap(i,g)
         kbar = kbar + foo
@@ -62,6 +63,7 @@ subroutine ca_accel_rhs_neut( lo, hi, &
 
   use rad_params_module, only : ngroups, clight, erg2rhoYe
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: lo(1), hi(1)
@@ -73,22 +75,22 @@ subroutine ca_accel_rhs_neut( lo, hi, &
   integer, intent(in) ::theT_l1,theT_h1
   integer, intent(in) ::theY_l1,theY_h1
   integer, intent(in) :: rhs_l1, rhs_h1
-  double precision, intent(in) ::Ern ( Ern_l1: Ern_h1,0:ngroups-1)
-  double precision, intent(in) ::Erl ( Erl_l1: Erl_h1,0:ngroups-1)
-  double precision, intent(in) :: kap( kap_l1: kap_h1,0:ngroups-1)
-  double precision, intent(in) ::etaT(etaT_l1:etaT_h1)
-  double precision, intent(in) ::etaY(etaY_l1:etaY_h1)
-  double precision, intent(in) ::theT(theT_l1:theT_h1)
-  double precision, intent(in) ::theY(theY_l1:theY_h1)
-  double precision             :: rhs(rhs_l1:rhs_h1)
-  double precision, intent(in) :: dt
+  real(rt)        , intent(in) ::Ern ( Ern_l1: Ern_h1,0:ngroups-1)
+  real(rt)        , intent(in) ::Erl ( Erl_l1: Erl_h1,0:ngroups-1)
+  real(rt)        , intent(in) :: kap( kap_l1: kap_h1,0:ngroups-1)
+  real(rt)        , intent(in) ::etaT(etaT_l1:etaT_h1)
+  real(rt)        , intent(in) ::etaY(etaY_l1:etaY_h1)
+  real(rt)        , intent(in) ::theT(theT_l1:theT_h1)
+  real(rt)        , intent(in) ::theY(theY_l1:theY_h1)
+  real(rt)                     :: rhs(rhs_l1:rhs_h1)
+  real(rt)        , intent(in) :: dt
 
   integer :: i, g
-  double precision :: rt, ry, H, Theta, foo
+  real(rt)         :: rt, ry, H, Theta, foo
 
   do i = lo(1), hi(1)
-     rt = 0.d0
-     ry = 0.d0
+     rt = 0.e0_rt
+     ry = 0.e0_rt
      do g=0,ngroups-1
         foo = kap(i,g)*(Ern(i,g)-Erl(i,g))
         rt = rt + foo
@@ -119,6 +121,7 @@ subroutine ca_accel_spec_neut( lo, hi, &
 
   use rad_params_module, only : ngroups, clight, erg2rhoYe
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer,intent(in) :: lo(1), hi(1)
@@ -132,28 +135,28 @@ subroutine ca_accel_spec_neut( lo, hi, &
   integer,intent(in)::mugT_l1,mugT_h1
   integer,intent(in)::mugY_l1,mugY_h1
   integer,intent(in)::spec_l1,spec_h1
-  double precision,intent(in)::Ern ( Ern_l1: Ern_h1,0:ngroups-1)
-  double precision,intent(in)::Erl ( Erl_l1: Erl_h1,0:ngroups-1)
-  double precision,intent(in)::kap ( kap_l1: kap_h1,0:ngroups-1)
-  double precision,intent(in)::etaT(etaT_l1:etaT_h1)
-  double precision,intent(in)::etaY(etaY_l1:etaY_h1)
-  double precision,intent(in)::theT(theT_l1:theT_h1)
-  double precision,intent(in)::theY(theY_l1:theY_h1)
-  double precision,intent(in)::mugT(mugT_l1:mugT_h1,0:ngroups-1)
-  double precision,intent(in)::mugY(mugY_l1:mugY_h1,0:ngroups-1)
-  double precision           ::spec(spec_l1:spec_h1,0:ngroups-1)
-  double precision,intent(in) :: dt, tau
+  real(rt)        ,intent(in)::Ern ( Ern_l1: Ern_h1,0:ngroups-1)
+  real(rt)        ,intent(in)::Erl ( Erl_l1: Erl_h1,0:ngroups-1)
+  real(rt)        ,intent(in)::kap ( kap_l1: kap_h1,0:ngroups-1)
+  real(rt)        ,intent(in)::etaT(etaT_l1:etaT_h1)
+  real(rt)        ,intent(in)::etaY(etaY_l1:etaY_h1)
+  real(rt)        ,intent(in)::theT(theT_l1:theT_h1)
+  real(rt)        ,intent(in)::theY(theY_l1:theY_h1)
+  real(rt)        ,intent(in)::mugT(mugT_l1:mugT_h1,0:ngroups-1)
+  real(rt)        ,intent(in)::mugY(mugY_l1:mugY_h1,0:ngroups-1)
+  real(rt)                   ::spec(spec_l1:spec_h1,0:ngroups-1)
+  real(rt)        ,intent(in) :: dt, tau
 
   integer :: i , g
-  double precision :: cdt1, rt, ry, p, q, r, s, foo, sumeps
-  double precision,dimension(0:ngroups-1)::Hg, Tg, epsilon, kapt, kk
+  real(rt)         :: cdt1, rt, ry, p, q, r, s, foo, sumeps
+  real(rt)        ,dimension(0:ngroups-1)::Hg, Tg, epsilon, kapt, kk
 
-  cdt1 = 1.d0/(clight*dt)
+  cdt1 = 1.e0_rt/(clight*dt)
 
   do i = lo(1), hi(1)
 
-     rt = 0.d0
-     ry = 0.d0
+     rt = 0.e0_rt
+     ry = 0.e0_rt
      do g=0,ngroups-1
         foo = kap(i,g)*(Ern(i,g)-Erl(i,g))
         rt = rt + foo
@@ -163,19 +166,19 @@ subroutine ca_accel_spec_neut( lo, hi, &
      Hg = mugT(i,:)*etaT(i) - mugY(i,:)*etaY(i)
      Tg = -mugT(i,:)*theT(i) + mugY(i,:)*theY(i)
 
-     kapt = kap(i,:) + (1.d0+tau)*cdt1
+     kapt = kap(i,:) + (1.e0_rt+tau)*cdt1
      kk = kap(i,:) / kapt
 
-     p = 1.d0 - sum(Hg*kk)
-     q = 1.d0 - sum(Tg*erg2rhoYe*kk)
+     p = 1.e0_rt - sum(Hg*kk)
+     q = 1.e0_rt - sum(Tg*erg2rhoYe*kk)
      r = sum(Hg*erg2rhoYe*kk)
      s = sum(Tg*kk)
 
      epsilon = ((r*Tg + q*Hg) * rt + (s*Hg + p*Tg) * ry) / kapt
      
      sumeps = sum(epsilon)
-     if (sumeps .eq. 0.d0) then
-        sumeps = 1.d-50
+     if (sumeps .eq. 0.e0_rt) then
+        sumeps = 1.e-50_rt
      end if
 
      spec(i,:) = epsilon / sumeps
@@ -205,6 +208,7 @@ subroutine ca_check_conv_neut( lo, hi, &
      dt)
   use rad_params_module, only : ngroups, clight, erg2rhoYe
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer,intent(in)::lo(1),hi(1)
@@ -222,43 +226,43 @@ subroutine ca_check_conv_neut( lo, hi, &
   integer,intent(in):: jg_l1,  jg_h1
   integer,intent(in)::deT_l1, deT_h1
   integer,intent(in)::deY_l1, deY_h1
-  double precision,intent(in   )::ren(ren_l1:ren_h1)
-  double precision,intent(in   )::res(res_l1:res_h1)
-  double precision,intent(in   )::re2(re2_l1:re2_h1)
-  double precision,intent(in   )::ern(ern_l1:ern_h1,0:ngroups-1)
-  double precision,intent(in   )::Tmn(Tmn_l1:Tmn_h1)
-  double precision,intent(in   )::Tms(Tms_l1:Tms_h1)
-  double precision,intent(in   )::rYn(rYn_l1:rYn_h1)
-  double precision,intent(in   )::rYs(rYs_l1:rYs_h1)
-  double precision,intent(in   )::rY2(rY2_l1:rY2_h1)
-  double precision,intent(in   )::rho(rho_l1:rho_h1)
-  double precision,intent(in   )::kap(kap_l1:kap_h1,0:ngroups-1)
-  double precision,intent(in   ):: jg( jg_l1: jg_h1,0:ngroups-1)
-  double precision,intent(in   )::deT(deT_l1:deT_h1)
-  double precision,intent(in   )::deY(deY_l1:deY_h1)
-  double precision,intent(inout)::rel_re, abs_re
-  double precision,intent(inout)::rel_FT, abs_FT,rel_T, abs_T
-  double precision,intent(inout)::rel_FY, abs_FY,rel_Y, abs_Y
-  double precision,intent(in) :: dt
+  real(rt)        ,intent(in   )::ren(ren_l1:ren_h1)
+  real(rt)        ,intent(in   )::res(res_l1:res_h1)
+  real(rt)        ,intent(in   )::re2(re2_l1:re2_h1)
+  real(rt)        ,intent(in   )::ern(ern_l1:ern_h1,0:ngroups-1)
+  real(rt)        ,intent(in   )::Tmn(Tmn_l1:Tmn_h1)
+  real(rt)        ,intent(in   )::Tms(Tms_l1:Tms_h1)
+  real(rt)        ,intent(in   )::rYn(rYn_l1:rYn_h1)
+  real(rt)        ,intent(in   )::rYs(rYs_l1:rYs_h1)
+  real(rt)        ,intent(in   )::rY2(rY2_l1:rY2_h1)
+  real(rt)        ,intent(in   )::rho(rho_l1:rho_h1)
+  real(rt)        ,intent(in   )::kap(kap_l1:kap_h1,0:ngroups-1)
+  real(rt)        ,intent(in   ):: jg( jg_l1: jg_h1,0:ngroups-1)
+  real(rt)        ,intent(in   )::deT(deT_l1:deT_h1)
+  real(rt)        ,intent(in   )::deY(deY_l1:deY_h1)
+  real(rt)        ,intent(inout)::rel_re, abs_re
+  real(rt)        ,intent(inout)::rel_FT, abs_FT,rel_T, abs_T
+  real(rt)        ,intent(inout)::rel_FY, abs_FY,rel_Y, abs_Y
+  real(rt)        ,intent(in) :: dt
 
   integer :: i
-  double precision :: chg, relchg, FT, FY, cdt, FTdenom, FYdenom, dTe, dYe
+  real(rt)         :: chg, relchg, FT, FY, cdt, FTdenom, FYdenom, dTe, dYe
 
   cdt = clight*dt
 
   do i=lo(1),hi(1)
      chg = abs(ren(i) - res(i))
-     relchg = abs(chg/(ren(i)+1.d-50))
+     relchg = abs(chg/(ren(i)+1.e-50_rt))
      rel_re = max(rel_re,relchg)
      abs_re = max(abs_re,chg)
 
      chg = abs(Tmn(i) - Tms(i))
-     relchg = abs(chg/(Tmn(i)+1.d-50))
+     relchg = abs(chg/(Tmn(i)+1.e-50_rt))
      rel_T = max(rel_T,relchg)
      abs_T = max(abs_T,chg)
 
      chg = abs(rYn(i) - rYs(i))
-     relchg = abs(chg/(rYn(i)+1.d-50))
+     relchg = abs(chg/(rYn(i)+1.e-50_rt))
      rel_Y = max(rel_Y,relchg)
      abs_Y = max(abs_Y,chg/rho(i))
 
@@ -270,10 +274,10 @@ subroutine ca_check_conv_neut( lo, hi, &
      FTdenom = rho(i)*(abs(deT(i)*dTe)+abs(deY(i)*dYe))
      FYdenom = rYn(i)
 
-     rel_FT = max(rel_FT, FT/(FTdenom+1.d-50))
+     rel_FT = max(rel_FT, FT/(FTdenom+1.e-50_rt))
      abs_FT = max(abs_FT, FT)
 
-     rel_FY = max(rel_FY, FY/(FYdenom+1.d-50))
+     rel_FY = max(rel_FY, FY/(FYdenom+1.e-50_rt))
      abs_FY = max(abs_FY, FY)
   end do
 
@@ -294,6 +298,7 @@ subroutine ca_check_conv_er_neut( lo, hi, &
 
   use rad_params_module, only : ngroups, clight, erg2rhoYe
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: lo(1), hi(1)
@@ -306,27 +311,27 @@ subroutine ca_check_conv_er_neut( lo, hi, &
   integer,intent(in)::etYz_l1, etYz_h1
   integer,intent(in)::thTz_l1, thTz_h1
   integer,intent(in)::thYz_l1, thYz_h1
-  double precision, intent(in) :: Ern(Ern_l1:Ern_h1,0:ngroups-1)
-  double precision, intent(in) :: Erl(Erl_l1:Erl_h1,0:ngroups-1)
-  double precision, intent(in) :: kap(kap_l1:kap_h1,0:ngroups-1)
-  double precision,intent(in )::etTz(etTz_l1:etTz_h1)
-  double precision,intent(in )::etYz(etYz_l1:etYz_h1)
-  double precision,intent(in )::thTz(thTz_l1:thTz_h1)
-  double precision,intent(in )::thYz(thYz_l1:thYz_h1)
-  double precision,intent(in )::temp(temp_l1:temp_h1)
-  double precision,intent(in )::Ye  (  Ye_l1:  Ye_h1)
-  double precision, intent(inout) :: rela, abso, errr
-  double precision, intent(in) :: dt
+  real(rt)        , intent(in) :: Ern(Ern_l1:Ern_h1,0:ngroups-1)
+  real(rt)        , intent(in) :: Erl(Erl_l1:Erl_h1,0:ngroups-1)
+  real(rt)        , intent(in) :: kap(kap_l1:kap_h1,0:ngroups-1)
+  real(rt)        ,intent(in )::etTz(etTz_l1:etTz_h1)
+  real(rt)        ,intent(in )::etYz(etYz_l1:etYz_h1)
+  real(rt)        ,intent(in )::thTz(thTz_l1:thTz_h1)
+  real(rt)        ,intent(in )::thYz(thYz_l1:thYz_h1)
+  real(rt)        ,intent(in )::temp(temp_l1:temp_h1)
+  real(rt)        ,intent(in )::Ye  (  Ye_l1:  Ye_h1)
+  real(rt)        , intent(inout) :: rela, abso, errr
+  real(rt)        , intent(in) :: dt
 
   integer :: i, g
-  double precision :: chg, tot, cdt, der, kdeT, kdeY, err_T, err_Y, err
+  real(rt)         :: chg, tot, cdt, der, kdeT, kdeY, err_T, err_Y, err
 
   cdt = clight * dt
   do i = lo(1), hi(1)
-     chg = 0.d0
-     tot = 0.d0
-     kdeT = 0.d0
-     kdeY = 0.d0
+     chg = 0.e0_rt
+     tot = 0.e0_rt
+     kdeT = 0.e0_rt
+     kdeY = 0.e0_rt
      do g=0,ngroups-1
         der = Ern(i,g)-Erl(i,g)
         chg = chg + abs(der)
@@ -335,11 +340,11 @@ subroutine ca_check_conv_er_neut( lo, hi, &
         kdeY = kdeY + erg2rhoYe(g)*kap(i,g)*der
      end do
      abso = max(abso, chg)
-     rela = max(rela, chg / (tot + 1.d-50))
+     rela = max(rela, chg / (tot + 1.e-50_rt))
 
      err_T =  etTz(i)*kdeT - thTz(i)*kdeY 
      err_Y = -etYz(i)*kdeT + thYz(i)*kdeY 
-     err = max(abs(err_T/(temp(i)+1.d-50)), abs(err_Y/(Ye(i)+1.d-50)))
+     err = max(abs(err_T/(temp(i)+1.e-50_rt)), abs(err_Y/(Ye(i)+1.e-50_rt)))
      errr = max(errr, err)
   end do
 
@@ -355,6 +360,7 @@ subroutine ca_compute_coupty( lo, hi, &
   
   use rad_params_module, only : ngroups, erg2rhoYe
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: lo(1), hi(1)
@@ -363,17 +369,17 @@ subroutine ca_compute_coupty( lo, hi, &
   integer, intent(in) :: kpp_l1, kpp_h1 
   integer, intent(in) ::  eg_l1,  eg_h1
   integer, intent(in) ::  jg_l1,  jg_h1
-  double precision             :: cpt(cpt_l1:cpt_h1)
-  double precision             :: cpy(cpy_l1:cpy_h1)
-  double precision, intent(in) :: kpp(kpp_l1:kpp_h1,0:ngroups-1)
-  double precision, intent(in) ::  eg( eg_l1: eg_h1,0:ngroups-1)
-  double precision, intent(in) ::  jg( jg_l1: jg_h1,0:ngroups-1)
+  real(rt)                     :: cpt(cpt_l1:cpt_h1)
+  real(rt)                     :: cpy(cpy_l1:cpy_h1)
+  real(rt)        , intent(in) :: kpp(kpp_l1:kpp_h1,0:ngroups-1)
+  real(rt)        , intent(in) ::  eg( eg_l1: eg_h1,0:ngroups-1)
+  real(rt)        , intent(in) ::  jg( jg_l1: jg_h1,0:ngroups-1)
 
   integer :: i, g
-  double precision :: foo
+  real(rt)         :: foo
 
-  cpt(lo(1):hi(1)) = 0.d0
-  cpy(lo(1):hi(1)) = 0.d0
+  cpt(lo(1):hi(1)) = 0.e0_rt
+  cpy(lo(1):hi(1)) = 0.e0_rt
 
   do g=0, ngroups-1
      do i=lo(1),hi(1)
@@ -400,6 +406,7 @@ subroutine ca_compute_dedx( lo, hi,  &
   use network, only : nspec, naux
   use meth_params_module, only : NVAR, URHO, UFS
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: lo(1), hi(1)
@@ -410,24 +417,24 @@ subroutine ca_compute_dedx( lo, hi,  &
   integer, intent(in) ::  Yes_l1,  Yes_h1
   integer, intent(in) :: dedT_l1, dedT_h1
   integer, intent(in) :: dedY_l1, dedY_h1
-  double precision, intent(in) :: S   (   S_l1:   S_h1,NVAR)
-  double precision, intent(in) :: T   (   T_l1:   T_h1)
-  double precision, intent(in) :: Ye  (  Ye_l1:  Ye_h1)
-  double precision, intent(in) :: Ts  (  Ts_l1:  Ts_h1)
-  double precision, intent(in) :: Yes ( Yes_l1: Yes_h1)
-  double precision             :: dedT(dedT_l1:dedT_h1)
-  double precision             :: dedY(dedY_l1:dedY_h1)
+  real(rt)        , intent(in) :: S   (   S_l1:   S_h1,NVAR)
+  real(rt)        , intent(in) :: T   (   T_l1:   T_h1)
+  real(rt)        , intent(in) :: Ye  (  Ye_l1:  Ye_h1)
+  real(rt)        , intent(in) :: Ts  (  Ts_l1:  Ts_h1)
+  real(rt)        , intent(in) :: Yes ( Yes_l1: Yes_h1)
+  real(rt)                     :: dedT(dedT_l1:dedT_h1)
+  real(rt)                     :: dedY(dedY_l1:dedY_h1)
   integer, intent(in) :: validStar
 
   integer :: i
-  double precision :: rhoinv, e1, e2
+  real(rt)         :: rhoinv, e1, e2
   type(eos_t) :: eos_state
-  double precision :: dT, dYe, T1, T2, Ye1, Ye2
-  double precision, parameter :: fac = 0.5d0, minfrac = 1.d-8
+  real(rt)         :: dT, dYe, T1, T2, Ye1, Ye2
+  real(rt)        , parameter :: fac = 0.5e0_rt, minfrac = 1.e-8_rt
 
   do i=lo(1),hi(1)
 
-     rhoinv = 1.d0/S(i,URHO)
+     rhoinv = 1.e0_rt/S(i,URHO)
      eos_state % rho = S(i,URHO)
      eos_state % xn  = S(i,UFS:UFS+nspec-1) * rhoinv
      eos_state % aux = ye(i)
@@ -438,18 +445,18 @@ subroutine ca_compute_dedx( lo, hi,  &
         dYe = fac*abs(Yes(i) - Ye(i))
         dYe = max(dYe, minfrac*Ye(i))
      else
-        dT = T(i) * 1.d-3 + 1.d-50
-        dYe = 1.d-4
+        dT = T(i) * 1.e-3_rt + 1.e-50_rt
+        dYe = 1.e-4_rt
      end if
 
      T1 = T(i) - dT
-     if (T1 < Tmin*(1.d0+1.d-6)) then
+     if (T1 < Tmin*(1.e0_rt+1.e-6_rt)) then
         T1 = T(i)
      end if
      T2 = T(i) + dT
 
      Ye1 = Ye(i) - dYe
-     if (Ye1 < Ymin*(1.d0+1.d-6)) then
+     if (Ye1 < Ymin*(1.e0_rt+1.e-6_rt)) then
         Ye1 = Ye(i)
      end if
      Ye2 = Ye(i) + dYe
@@ -504,6 +511,7 @@ subroutine ca_compute_eta_the( lo, hi, &
 
   use rad_params_module, only : ngroups, clight, erg2rhoYe
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: lo(1), hi(1)
@@ -525,32 +533,32 @@ subroutine ca_compute_eta_the( lo, hi, &
   integer, intent(in) :: dedY_l1, dedY_h1
   integer, intent(in) ::  Ers_l1,  Ers_h1
   integer, intent(in) ::  rho_l1,  rho_h1
-  double precision             :: etaT(etaT_l1:etaT_h1)
-  double precision             :: etTz(etTz_l1:etTz_h1)
-  double precision             :: etaY(etaY_l1:etaY_h1)
-  double precision             :: etYz(etYz_l1:etYz_h1)
-  double precision             :: eta1(eta1_l1:eta1_h1)
-  double precision             :: theT(theT_l1:theT_h1)
-  double precision             :: thTz(thTz_l1:thTz_h1)
-  double precision             :: theY(theY_l1:theY_h1)
-  double precision             :: thYz(thYz_l1:thYz_h1)
-  double precision             :: the1(the1_l1:the1_h1)
-  double precision             :: djdT(djdT_l1:djdT_h1,0:ngroups-1)
-  double precision             :: djdY(djdY_l1:djdY_h1,0:ngroups-1)
-  double precision, intent(in) :: dkdT(dkdT_l1:dkdT_h1,0:ngroups-1)
-  double precision, intent(in) :: dkdY(dkdY_l1:dkdY_h1,0:ngroups-1)
-  double precision, intent(in) :: dedT(dedT_l1:dedT_h1)
-  double precision, intent(in) :: dedY(dedY_l1:dedY_h1)
-  double precision, intent(in) :: Ers ( Ers_l1: Ers_h1,0:ngroups-1)
-  double precision, intent(in) :: rho ( rho_l1: rho_h1)
-  double precision, intent(in) :: dt, tau
+  real(rt)                     :: etaT(etaT_l1:etaT_h1)
+  real(rt)                     :: etTz(etTz_l1:etTz_h1)
+  real(rt)                     :: etaY(etaY_l1:etaY_h1)
+  real(rt)                     :: etYz(etYz_l1:etYz_h1)
+  real(rt)                     :: eta1(eta1_l1:eta1_h1)
+  real(rt)                     :: theT(theT_l1:theT_h1)
+  real(rt)                     :: thTz(thTz_l1:thTz_h1)
+  real(rt)                     :: theY(theY_l1:theY_h1)
+  real(rt)                     :: thYz(thYz_l1:thYz_h1)
+  real(rt)                     :: the1(the1_l1:the1_h1)
+  real(rt)                     :: djdT(djdT_l1:djdT_h1,0:ngroups-1)
+  real(rt)                     :: djdY(djdY_l1:djdY_h1,0:ngroups-1)
+  real(rt)        , intent(in) :: dkdT(dkdT_l1:dkdT_h1,0:ngroups-1)
+  real(rt)        , intent(in) :: dkdY(dkdY_l1:dkdY_h1,0:ngroups-1)
+  real(rt)        , intent(in) :: dedT(dedT_l1:dedT_h1)
+  real(rt)        , intent(in) :: dedY(dedY_l1:dedY_h1)
+  real(rt)        , intent(in) :: Ers ( Ers_l1: Ers_h1,0:ngroups-1)
+  real(rt)        , intent(in) :: rho ( rho_l1: rho_h1)
+  real(rt)        , intent(in) :: dt, tau
 
   integer :: i
-  double precision :: cdt, det, et, ey, tt, ty, sigma
-  double precision :: dZdT(0:ngroups-1), dZdY(0:ngroups-1)
-  double precision :: sumdZdT, sumdZdY, fooT, fooY, barT, barY
+  real(rt)         :: cdt, det, et, ey, tt, ty, sigma
+  real(rt)         :: dZdT(0:ngroups-1), dZdY(0:ngroups-1)
+  real(rt)         :: sumdZdT, sumdZdY, fooT, fooY, barT, barY
 
-  sigma = 1.d0 + tau
+  sigma = 1.e0_rt + tau
   cdt = clight * dt
 
   do i = lo(1), hi(1)
@@ -560,12 +568,12 @@ subroutine ca_compute_eta_the( lo, hi, &
      sumdZdT = sum(dZdT)
      sumdZdY = sum(dZdY)
 
-     if (sumdZdT .eq. 0.d0) then
-        sumdZdT = 1.d-50
+     if (sumdZdT .eq. 0.e0_rt) then
+        sumdZdT = 1.e-50_rt
      end if
 
-     if (sumdZdY .eq. 0.d0) then
-        sumdZdY = 1.d-50
+     if (sumdZdY .eq. 0.e0_rt) then
+        sumdZdY = 1.e-50_rt
      end if
 
      fooT = cdt * sumdZdT
@@ -619,6 +627,7 @@ subroutine ca_compute_rhs_neut( lo, hi, &
 
   use rad_params_module, only : ngroups, clight
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer,intent(in):: lo(1), hi(1)
@@ -638,30 +647,30 @@ subroutine ca_compute_rhs_neut( lo, hi, &
   integer,intent(in):: Ers_l1, Ers_h1
   integer,intent(in):: res_l1, res_h1
   integer,intent(in):: rYs_l1, rYs_h1
-  double precision           ::rhs ( rhs_l1: rhs_h1)
-  double precision,intent(in)::jg  (  jg_l1:  jg_h1,0:ngroups-1)
-  double precision,intent(in)::mugT(mugT_l1:mugT_h1,0:ngroups-1)
-  double precision,intent(in)::mugY(mugY_l1:mugY_h1,0:ngroups-1)
-  double precision,intent(in)::cpT ( cpT_l1: cpT_h1)
-  double precision,intent(in)::cpY ( cpY_l1: cpY_h1)
-  double precision,intent(in)::etaT(etaT_l1:etaT_h1)
-  double precision,intent(in)::etaY(etaY_l1:etaY_h1)
-  double precision,intent(in)::theT(theT_l1:theT_h1)
-  double precision,intent(in)::theY(theY_l1:theY_h1)
-  double precision,intent(in)::Er2 ( Er2_l1: Er2_h1,0:ngroups-1)
-  double precision,intent(in)::re2 ( re2_l1: re2_h1)
-  double precision,intent(in)::rY2 ( rY2_l1: rY2_h1)
-  double precision,intent(in)::Ers ( Ers_l1: Ers_h1,0:ngroups-1)
-  double precision,intent(in)::res ( res_l1: res_h1)
-  double precision,intent(in)::rYs ( rYs_l1: rYs_h1)
-  double precision,intent(in) ::   r(lo(1):hi(1))
-  double precision,intent(in) :: dt, tau
+  real(rt)                   ::rhs ( rhs_l1: rhs_h1)
+  real(rt)        ,intent(in)::jg  (  jg_l1:  jg_h1,0:ngroups-1)
+  real(rt)        ,intent(in)::mugT(mugT_l1:mugT_h1,0:ngroups-1)
+  real(rt)        ,intent(in)::mugY(mugY_l1:mugY_h1,0:ngroups-1)
+  real(rt)        ,intent(in)::cpT ( cpT_l1: cpT_h1)
+  real(rt)        ,intent(in)::cpY ( cpY_l1: cpY_h1)
+  real(rt)        ,intent(in)::etaT(etaT_l1:etaT_h1)
+  real(rt)        ,intent(in)::etaY(etaY_l1:etaY_h1)
+  real(rt)        ,intent(in)::theT(theT_l1:theT_h1)
+  real(rt)        ,intent(in)::theY(theY_l1:theY_h1)
+  real(rt)        ,intent(in)::Er2 ( Er2_l1: Er2_h1,0:ngroups-1)
+  real(rt)        ,intent(in)::re2 ( re2_l1: re2_h1)
+  real(rt)        ,intent(in)::rY2 ( rY2_l1: rY2_h1)
+  real(rt)        ,intent(in)::Ers ( Ers_l1: Ers_h1,0:ngroups-1)
+  real(rt)        ,intent(in)::res ( res_l1: res_h1)
+  real(rt)        ,intent(in)::rYs ( rYs_l1: rYs_h1)
+  real(rt)        ,intent(in) ::   r(lo(1):hi(1))
+  real(rt)        ,intent(in) :: dt, tau
   integer, intent(in) :: igroup
 
   integer :: i
-  double precision :: Hg, thetag, dt1
+  real(rt)         :: Hg, thetag, dt1
 
-  dt1 = 1.d0/dt
+  dt1 = 1.e0_rt/dt
   do i=lo(1),hi(1)
      Hg = mugT(i,igroup)*etaT(i) - mugY(i,igroup)*etaY(i)
      thetag = mugY(i,igroup)*theY(i) - mugT(i,igroup)*theT(i)
@@ -691,6 +700,7 @@ subroutine ca_local_accel_neut( lo, hi,  &
 
   use rad_params_module, only : ngroups, clight, erg2rhoYe
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer,intent(in):: lo(1), hi(1)
@@ -703,22 +713,22 @@ subroutine ca_local_accel_neut( lo, hi,  &
   integer,intent(in)::theY_l1,theY_h1
   integer,intent(in)::mugT_l1,mugT_h1
   integer,intent(in)::mugY_l1,mugY_h1
-  double precision           ::Ern ( Ern_l1: Ern_h1,0:ngroups-1)
-  double precision,intent(in)::Erl ( Erl_l1: Erl_h1,0:ngroups-1)
-  double precision,intent(in)::kap ( kap_l1: kap_h1,0:ngroups-1)
-  double precision,intent(in)::etaT(etaT_l1:etaT_h1)
-  double precision,intent(in)::etaY(etaY_l1:etaY_h1)
-  double precision,intent(in)::theT(theT_l1:theT_h1)
-  double precision,intent(in)::theY(theY_l1:theY_h1)
-  double precision,intent(in)::mugT(mugT_l1:mugT_h1,0:ngroups-1)
-  double precision,intent(in)::mugY(mugY_l1:mugY_h1,0:ngroups-1)
-  double precision,intent(in) :: dt, tau
+  real(rt)                   ::Ern ( Ern_l1: Ern_h1,0:ngroups-1)
+  real(rt)        ,intent(in)::Erl ( Erl_l1: Erl_h1,0:ngroups-1)
+  real(rt)        ,intent(in)::kap ( kap_l1: kap_h1,0:ngroups-1)
+  real(rt)        ,intent(in)::etaT(etaT_l1:etaT_h1)
+  real(rt)        ,intent(in)::etaY(etaY_l1:etaY_h1)
+  real(rt)        ,intent(in)::theT(theT_l1:theT_h1)
+  real(rt)        ,intent(in)::theY(theY_l1:theY_h1)
+  real(rt)        ,intent(in)::mugT(mugT_l1:mugT_h1,0:ngroups-1)
+  real(rt)        ,intent(in)::mugY(mugY_l1:mugY_h1,0:ngroups-1)
+  real(rt)        ,intent(in) :: dt, tau
 
   integer :: i 
-  double precision :: cdt1, rt, ry, p, q, r, s 
-  double precision,dimension(0:ngroups-1)::Hg, Tg, epsilon, kapt, kk
+  real(rt)         :: cdt1, rt, ry, p, q, r, s 
+  real(rt)        ,dimension(0:ngroups-1)::Hg, Tg, epsilon, kapt, kk
 
-  cdt1 = 1.d0/(clight*dt)
+  cdt1 = 1.e0_rt/(clight*dt)
 
   do i = lo(1), hi(1)
      rt = sum(kap(i,:)*(Ern(i,:)-Erl(i,:)))
@@ -727,16 +737,16 @@ subroutine ca_local_accel_neut( lo, hi,  &
      Hg = mugT(i,:)*etaT(i) - mugY(i,:)*etaY(i)
      Tg = -mugT(i,:)*theT(i) + mugY(i,:)*theY(i)
 
-     kapt = kap(i,:) + (1.d0+tau)*cdt1
+     kapt = kap(i,:) + (1.e0_rt+tau)*cdt1
      kk = kap(i,:) / kapt
 
-     p = 1.d0-sum(Hg*kk)
-     q = 1.d0-sum(Tg*erg2rhoYe*kk)
+     p = 1.e0_rt-sum(Hg*kk)
+     q = 1.e0_rt-sum(Tg*erg2rhoYe*kk)
      r = sum(Hg*erg2rhoYe*kk)
      s = sum(Tg*kk)
 
      epsilon = ((r*Tg + q*Hg) * rt + (s*Hg + p*Tg) * ry)  &
-          / (kapt*(p*q-r*s) + 1.d-50)
+          / (kapt*(p*q-r*s) + 1.e-50_rt)
 
      Ern(i,:) = Ern(i,:) + epsilon
   end do
@@ -763,6 +773,7 @@ subroutine ca_opac_emis_neut( lo, hi,  &
   use opacity_table_module, only : prep_opacity, get_opacity_emissivity
   use meth_params_module, only : NVAR, URHO
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: lo(1), hi(1)
@@ -778,28 +789,28 @@ subroutine ca_opac_emis_neut( lo, hi,  &
   integer, intent(in) :: djdY_l1, djdY_h1
   integer, intent(in) :: dkdT_l1, dkdT_h1
   integer, intent(in) :: dkdY_l1, dkdY_h1
-  double precision, intent(in) :: Snew(Snew_l1:Snew_h1,NVAR)
-  double precision, intent(in) :: T   (   T_l1:   T_h1)
-  double precision, intent(in) :: Ye  (  Ye_l1:  Ye_h1)
-  double precision, intent(in) :: Ts  (  Ts_l1:  Ts_h1)
-  double precision, intent(in) :: Yes ( Yes_l1: Yes_h1)
-  double precision             :: kpp ( kpp_l1: kpp_h1,0:ngroups-1)
-  double precision             :: kpr ( kpr_l1: kpr_h1,0:ngroups-1)
-  double precision             :: jg  (   j_l1:   j_h1,0:ngroups-1)
-  double precision             :: djdT(djdT_l1:djdT_h1,0:ngroups-1)
-  double precision             :: djdY(djdY_l1:djdY_h1,0:ngroups-1)
-  double precision             :: dkdT(dkdT_l1:dkdT_h1,0:ngroups-1)
-  double precision             :: dkdY(dkdY_l1:dkdY_h1,0:ngroups-1)
+  real(rt)        , intent(in) :: Snew(Snew_l1:Snew_h1,NVAR)
+  real(rt)        , intent(in) :: T   (   T_l1:   T_h1)
+  real(rt)        , intent(in) :: Ye  (  Ye_l1:  Ye_h1)
+  real(rt)        , intent(in) :: Ts  (  Ts_l1:  Ts_h1)
+  real(rt)        , intent(in) :: Yes ( Yes_l1: Yes_h1)
+  real(rt)                     :: kpp ( kpp_l1: kpp_h1,0:ngroups-1)
+  real(rt)                     :: kpr ( kpr_l1: kpr_h1,0:ngroups-1)
+  real(rt)                     :: jg  (   j_l1:   j_h1,0:ngroups-1)
+  real(rt)                     :: djdT(djdT_l1:djdT_h1,0:ngroups-1)
+  real(rt)                     :: djdY(djdY_l1:djdY_h1,0:ngroups-1)
+  real(rt)                     :: dkdT(dkdT_l1:dkdT_h1,0:ngroups-1)
+  real(rt)                     :: dkdY(dkdY_l1:dkdY_h1,0:ngroups-1)
   integer, intent(in) :: use_dkdT, validStar, lag_opac
 
   integer :: i, g, inu
-  double precision :: ab, sc, delta, eta, er, der, rho, temp
-  double precision :: ab1, sc1, delta1, eta1
-  double precision :: ab2, sc2, delta2, eta2 
-  double precision :: dT, dYe
-  double precision :: Bg, Bg1, Bg2
+  real(rt)         :: ab, sc, delta, eta, er, der, rho, temp
+  real(rt)         :: ab1, sc1, delta1, eta1
+  real(rt)         :: ab2, sc2, delta2, eta2 
+  real(rt)         :: dT, dYe
+  real(rt)         :: Bg, Bg1, Bg2
   logical :: comp_ab, comp_sc, comp_eta
-  double precision, parameter :: fac = 0.5d0, minfrac = 1.d-8
+  real(rt)        , parameter :: fac = 0.5e0_rt, minfrac = 1.e-8_rt
 
   do i=lo(1), hi(1)
      
@@ -812,8 +823,8 @@ subroutine ca_opac_emis_neut( lo, hi,  &
         dYe = fac*abs(Yes(i) - Ye(i))
         dYe = max(dYe, minfrac*Ye(i))
      else
-        dT = T(i) * 1.d-3 + 1.d-50
-        dYe = 1.d-4
+        dT = T(i) * 1.e-3_rt + 1.e-50_rt
+        dYe = 1.e-4_rt
      end if
 
      do g=0, ngroups-1
@@ -822,8 +833,8 @@ subroutine ca_opac_emis_neut( lo, hi,  &
 
         if (lag_opac .eq. 1) then
 
-           dkdT(i,g) = 0.d0
-           dkdY(i,g) = 0.d0              
+           dkdT(i,g) = 0.e0_rt
+           dkdY(i,g) = 0.e0_rt              
 
            comp_ab = .true.
            comp_sc = .false.
@@ -842,7 +853,7 @@ subroutine ca_opac_emis_neut( lo, hi,  &
                 rho, Ye(i)+dye, temp, er, inu, comp_ab, comp_sc, comp_eta)
            Bg2 = eta2 * der / ab2
 
-           djdY(i,g) = (Bg2-Bg1)*kpp(i,g)/(2.d0*dye)
+           djdY(i,g) = (Bg2-Bg1)*kpp(i,g)/(2.e0_rt*dye)
 
            call get_opacity_emissivity(ab1, sc1, delta1, eta1, &
                 rho, Ye(i), temp-dT, er, inu, comp_ab, comp_sc, comp_eta)
@@ -852,7 +863,7 @@ subroutine ca_opac_emis_neut( lo, hi,  &
                 rho, Ye(i), temp+dT, er, inu, comp_ab, comp_sc, comp_eta)
            Bg2 = eta2 * der / ab2
 
-           djdT(i,g) = (Bg2-Bg1)*kpp(i,g)/(2.d0*dT)
+           djdT(i,g) = (Bg2-Bg1)*kpp(i,g)/(2.e0_rt*dT)
            
         else
 
@@ -863,7 +874,7 @@ subroutine ca_opac_emis_neut( lo, hi,  &
            call get_opacity_emissivity(ab, sc, delta, eta, &
                 rho, Ye(i), temp, er, inu, comp_ab, comp_sc, comp_eta)
            kpp(i,g) = ab
-           kpr(i,g) = ab + sc * (1.d0 - delta/3.d0)
+           kpr(i,g) = ab + sc * (1.e0_rt - delta/3.e0_rt)
            jg(i,g) = eta * der 
            
            comp_ab = .true.
@@ -874,22 +885,22 @@ subroutine ca_opac_emis_neut( lo, hi,  &
                 rho, Ye(i)-dye, temp, er, inu, comp_ab, comp_sc, comp_eta)
            call get_opacity_emissivity(ab2, sc2, delta2, eta2, &
                 rho, Ye(i)+dye, temp, er, inu, comp_ab, comp_sc, comp_eta)
-           djdY(i,g) = (eta2-eta1)*der/(2.d0*dye)
-           dkdY(i,g) = (ab2-ab1)/(2.d0*dye)
+           djdY(i,g) = (eta2-eta1)*der/(2.e0_rt*dye)
+           dkdY(i,g) = (ab2-ab1)/(2.e0_rt*dye)
            if (use_dkdT .eq. 0) then
-              djdY(i,g) = (eta2/ab2 - eta1/ab1)*der/(2.d0*dye) * ab
-              dkdY(i,g) = 0.d0
+              djdY(i,g) = (eta2/ab2 - eta1/ab1)*der/(2.e0_rt*dye) * ab
+              dkdY(i,g) = 0.e0_rt
            end if
            
            call get_opacity_emissivity(ab1, sc1, delta1, eta1, &
                 rho, Ye(i), temp-dT, er, inu, comp_ab, comp_sc, comp_eta)
            call get_opacity_emissivity(ab2, sc2, delta2, eta2, &
                 rho, Ye(i), temp+dT, er, inu, comp_ab, comp_sc, comp_eta)
-           djdT(i,g) = (eta2-eta1)*der/(2.d0*dT)
-           dkdT(i,g) = (ab2-ab1)/(2.d0*dT)
+           djdT(i,g) = (eta2-eta1)*der/(2.e0_rt*dT)
+           dkdT(i,g) = (ab2-ab1)/(2.e0_rt*dT)
            if (use_dkdT .eq. 0) then        
-              djdT(i,g) = (eta2/ab2 - eta1/ab1)*der/(2.d0*dT) * ab
-              dkdT(i,g) = 0.d0
+              djdT(i,g) = (eta2/ab2 - eta1/ab1)*der/(2.e0_rt*dT) * ab
+              dkdT(i,g) = 0.e0_rt
            end if
 
         end if
@@ -910,6 +921,7 @@ subroutine ca_state_update_neut( lo, hi, &
 
   use meth_params_module, only : NVAR, URHO, UEDEN, UEINT, UTEMP, UFX
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: lo(1), hi(1) 
@@ -918,25 +930,25 @@ subroutine ca_state_update_neut( lo, hi, &
   integer, intent(in) ::    Ye_l1,    Ye_h1
   integer, intent(in) ::  temp_l1,  temp_h1
   integer, intent(in) ::   msk_l1,   msk_h1
-  double precision, intent(in) :: rhoe( rhoe_l1: rhoe_h1)
-  double precision, intent(in) ::   Ye(   Ye_l1:   Ye_h1)
-  double precision, intent(in) :: temp( temp_l1: temp_h1)
-  double precision, intent(in) ::  msk(  msk_l1:  msk_h1)
-  double precision             ::state(state_l1:state_h1, NVAR)
-  double precision, intent(inout) :: derat, dTrat, dye
+  real(rt)        , intent(in) :: rhoe( rhoe_l1: rhoe_h1)
+  real(rt)        , intent(in) ::   Ye(   Ye_l1:   Ye_h1)
+  real(rt)        , intent(in) :: temp( temp_l1: temp_h1)
+  real(rt)        , intent(in) ::  msk(  msk_l1:  msk_h1)
+  real(rt)                     ::state(state_l1:state_h1, NVAR)
+  real(rt)        , intent(inout) :: derat, dTrat, dye
 
   integer :: i
-  double precision :: ei, ek, Told, Yeold
+  real(rt)         :: ei, ek, Told, Yeold
 
   do i=lo(1), hi(1)
      ei = state(i,UEINT)
-     derat = max(derat, abs((rhoe(i) - ei)*msk(i)/ (ei + 1.d-50)))
+     derat = max(derat, abs((rhoe(i) - ei)*msk(i)/ (ei + 1.e-50_rt)))
      ek = state(i,UEDEN) - state(i,UEINT)
      state(i,UEINT) = rhoe(i)
      state(i,UEDEN) = rhoe(i) + ek
 
      Told = state(i,UTEMP);
-     dTrat = max(dTrat, abs((temp(i)-Told)*msk(i)/ (Told + 1.d-50)))
+     dTrat = max(dTrat, abs((temp(i)-Told)*msk(i)/ (Told + 1.e-50_rt)))
      state(i,UTEMP) = temp(i)
 
      Yeold = state(i,UFX) / state(i,URHO)
@@ -974,6 +986,7 @@ subroutine ca_update_matter_neut( lo, hi,  &
   use rad_params_module, only : ngroups, erg2rhoYe, clight
   use meth_params_module, only : NVAR, URHO
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer,intent(in)::lo(1),hi(1)
@@ -998,32 +1011,32 @@ subroutine ca_update_matter_neut( lo, hi,  &
   integer,intent(in)::mugT_l1, mugT_h1
   integer,intent(in)::mugY_l1, mugY_h1
   integer,intent(in)::Snew_l1, Snew_h1
-  double precision           ::re_n(re_n_l1:re_n_h1)
-  double precision           ::rY_n(rY_n_l1:rY_n_h1)
-  double precision           ::Ye_n(Ye_n_l1:Ye_n_h1)
-  double precision,intent(in)::Er_n(Er_n_l1:Er_n_h1,0:ngroups-1)
-  double precision,intent(in)::Er_l(Er_l_l1:Er_l_h1,0:ngroups-1)
-  double precision,intent(in)::re_s(re_s_l1:re_s_h1)
-  double precision,intent(in)::rY_s(rY_s_l1:rY_s_h1)
-  double precision,intent(in)::re_2(re_2_l1:re_2_h1)
-  double precision,intent(in)::rY_2(rY_2_l1:rY_2_h1)
-  double precision,intent(in)::etaT(etaT_l1:etaT_h1)
-  double precision,intent(in)::etaY(etaY_l1:etaY_h1)
-  double precision,intent(in)::eta1(eta1_l1:eta1_h1)
-  double precision,intent(in)::theT(theT_l1:theT_h1)
-  double precision,intent(in)::theY(theY_l1:theY_h1)
-  double precision,intent(in)::the1(the1_l1:the1_h1)
-  double precision,intent(in):: cpt( cpt_l1: cpt_h1)
-  double precision,intent(in):: cpy( cpy_l1: cpy_h1)
-  double precision,intent(in):: kpp( kpp_l1: kpp_h1,0:ngroups-1)
-  double precision,intent(in)::mugT(mugT_l1:mugT_h1,0:ngroups-1)
-  double precision,intent(in)::mugY(mugY_l1:mugY_h1,0:ngroups-1)
-  double precision,intent(in)::Snew(Snew_l1:Snew_h1,NVAR)
-  double precision,intent(in) :: dt, tau
+  real(rt)                   ::re_n(re_n_l1:re_n_h1)
+  real(rt)                   ::rY_n(rY_n_l1:rY_n_h1)
+  real(rt)                   ::Ye_n(Ye_n_l1:Ye_n_h1)
+  real(rt)        ,intent(in)::Er_n(Er_n_l1:Er_n_h1,0:ngroups-1)
+  real(rt)        ,intent(in)::Er_l(Er_l_l1:Er_l_h1,0:ngroups-1)
+  real(rt)        ,intent(in)::re_s(re_s_l1:re_s_h1)
+  real(rt)        ,intent(in)::rY_s(rY_s_l1:rY_s_h1)
+  real(rt)        ,intent(in)::re_2(re_2_l1:re_2_h1)
+  real(rt)        ,intent(in)::rY_2(rY_2_l1:rY_2_h1)
+  real(rt)        ,intent(in)::etaT(etaT_l1:etaT_h1)
+  real(rt)        ,intent(in)::etaY(etaY_l1:etaY_h1)
+  real(rt)        ,intent(in)::eta1(eta1_l1:eta1_h1)
+  real(rt)        ,intent(in)::theT(theT_l1:theT_h1)
+  real(rt)        ,intent(in)::theY(theY_l1:theY_h1)
+  real(rt)        ,intent(in)::the1(the1_l1:the1_h1)
+  real(rt)        ,intent(in):: cpt( cpt_l1: cpt_h1)
+  real(rt)        ,intent(in):: cpy( cpy_l1: cpy_h1)
+  real(rt)        ,intent(in):: kpp( kpp_l1: kpp_h1,0:ngroups-1)
+  real(rt)        ,intent(in)::mugT(mugT_l1:mugT_h1,0:ngroups-1)
+  real(rt)        ,intent(in)::mugY(mugY_l1:mugY_h1,0:ngroups-1)
+  real(rt)        ,intent(in)::Snew(Snew_l1:Snew_h1,NVAR)
+  real(rt)        ,intent(in) :: dt, tau
 
   integer :: i,g
-  double precision :: cdt, H1, Theta, Thbar1, Hbar 
-  double precision :: dkEE, dkEEY, foo, chg, chgY
+  real(rt)         :: cdt, H1, Theta, Thbar1, Hbar 
+  real(rt)         :: dkEE, dkEEY, foo, chg, chgY
 
   cdt = clight * dt
   do i = lo(1), hi(1)
@@ -1034,8 +1047,8 @@ subroutine ca_update_matter_neut( lo, hi,  &
      Theta = theY(i) - theT(i)
      Hbar = sum(erg2rhoYe*(mugT(i,:)*etaT(i) - mugY(i,:)*etaY(i)))
 
-     dkEE = 0.d0
-     dkEEY = 0.d0
+     dkEE = 0.e0_rt
+     dkEEY = 0.e0_rt
      do g=0, ngroups-1
         foo = kpp(i,g)*(Er_n(i,g)-Er_l(i,g))
         dkEE = dkEE + foo
@@ -1051,8 +1064,8 @@ subroutine ca_update_matter_neut( lo, hi,  &
      re_n(i) = re_s(i) + chg
      rY_n(i) = rY_s(i) + chgY
 
-     re_n(i) = (re_n(i) + tau*re_s(i)) / (1.d0+tau)
-     rY_n(i) = (rY_n(i) + tau*rY_s(i)) / (1.d0+tau)
+     re_n(i) = (re_n(i) + tau*re_s(i)) / (1.e0_rt+tau)
+     rY_n(i) = (rY_n(i) + tau*rY_s(i)) / (1.e0_rt+tau)
 
      Ye_n(i) = rY_n(i) / Snew(i,URHO)
 
@@ -1080,6 +1093,7 @@ subroutine ca_ncupdate_matter_neut( lo, hi,  &
 
   use rad_params_module, only : ngroups, erg2rhoYe, clight
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer,intent(in)::lo(1),hi(1)
@@ -1096,31 +1110,31 @@ subroutine ca_ncupdate_matter_neut( lo, hi,  &
   integer,intent(in)::thYz_l1, thYz_h1
   integer,intent(in):: kpp_l1,  kpp_h1
   integer,intent(in)::  jg_l1,   jg_h1
-  double precision           ::Tp_n(Tp_n_l1:Tp_n_h1)
-  double precision           ::Ye_n(Ye_n_l1:Ye_n_h1)
-  double precision,intent(in)::Er_n(Er_n_l1:Er_n_h1,0:ngroups-1)
-  double precision,intent(in)::re_s(re_s_l1:re_s_h1)
-  double precision,intent(in)::rY_s(rY_s_l1:rY_s_h1)
-  double precision,intent(in)::re_2(re_2_l1:re_2_h1)
-  double precision,intent(in)::rY_2(rY_2_l1:rY_2_h1)
-  double precision,intent(in)::etTz(etTz_l1:etTz_h1)
-  double precision,intent(in)::etYz(etYz_l1:etYz_h1)
-  double precision,intent(in)::thTz(thTz_l1:thTz_h1)
-  double precision,intent(in)::thYz(thYz_l1:thYz_h1)
-  double precision,intent(in):: kpp( kpp_l1: kpp_h1,0:ngroups-1)
-  double precision,intent(in)::  jg(  jg_l1:  jg_h1,0:ngroups-1)
-  double precision,intent(in) :: dt
+  real(rt)                   ::Tp_n(Tp_n_l1:Tp_n_h1)
+  real(rt)                   ::Ye_n(Ye_n_l1:Ye_n_h1)
+  real(rt)        ,intent(in)::Er_n(Er_n_l1:Er_n_h1,0:ngroups-1)
+  real(rt)        ,intent(in)::re_s(re_s_l1:re_s_h1)
+  real(rt)        ,intent(in)::rY_s(rY_s_l1:rY_s_h1)
+  real(rt)        ,intent(in)::re_2(re_2_l1:re_2_h1)
+  real(rt)        ,intent(in)::rY_2(rY_2_l1:rY_2_h1)
+  real(rt)        ,intent(in)::etTz(etTz_l1:etTz_h1)
+  real(rt)        ,intent(in)::etYz(etYz_l1:etYz_h1)
+  real(rt)        ,intent(in)::thTz(thTz_l1:thTz_h1)
+  real(rt)        ,intent(in)::thYz(thYz_l1:thYz_h1)
+  real(rt)        ,intent(in):: kpp( kpp_l1: kpp_h1,0:ngroups-1)
+  real(rt)        ,intent(in)::  jg(  jg_l1:  jg_h1,0:ngroups-1)
+  real(rt)        ,intent(in) :: dt
 
    integer :: i,g
-   double precision :: cdt1, cpT, cpY, foo, scrch_re, scrch_rY
-   double precision :: dTemp, dYe
-   double precision, parameter :: fac = 0.01d0
+   real(rt)         :: cdt1, cpT, cpY, foo, scrch_re, scrch_rY
+   real(rt)         :: dTemp, dYe
+   real(rt)        , parameter :: fac = 0.01e0_rt
 
-   cdt1 = 1.d0 / (clight * dt)
+   cdt1 = 1.e0_rt / (clight * dt)
    do i = lo(1), hi(1)
 
-      cpT = 0.d0
-      cpY = 0.d0
+      cpT = 0.e0_rt
+      cpY = 0.e0_rt
       do g = 0, ngroups-1
          foo = kpp(i,g)*Er_n(i,g) - jg(i,g)
          cpT = cpT + foo
@@ -1133,11 +1147,11 @@ subroutine ca_ncupdate_matter_neut( lo, hi,  &
       dTemp = etTz(i)*scrch_re - thTz(i)*scrch_rY
       dYe   = -etYz(i)*scrch_re + thYz(i)*scrch_rY
 
-      if (abs(dTemp/(Tp_n(i)+1.d-50)) > fac) then
+      if (abs(dTemp/(Tp_n(i)+1.e-50_rt)) > fac) then
          dTemp = sign(fac*Tp_n(i), dTemp)
       end if
 
-      if (abs(dYe/(Ye_n(i)+1.d-50)) > fac) then
+      if (abs(dYe/(Ye_n(i)+1.e-50_rt)) > fac) then
          dYe = sign(fac*Ye_n(i), dYe)
       end if
 
@@ -1156,16 +1170,17 @@ subroutine ca_compute_rosseland_neut( lo, hi,  &
   use opacity_table_module, only : prep_opacity, get_opacity_emissivity
   use meth_params_module, only : NVAR, URHO, UTEMP, UFX
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: lo(1), hi(1)
   integer, intent(in) ::  kpr_l1,  kpr_h1
   integer, intent(in) :: stat_l1, stat_h1 
-  double precision             :: kpr ( kpr_l1: kpr_h1,0:ngroups-1)
-  double precision, intent(in) :: stat(stat_l1:stat_h1,NVAR)
+  real(rt)                     :: kpr ( kpr_l1: kpr_h1,0:ngroups-1)
+  real(rt)        , intent(in) :: stat(stat_l1:stat_h1,NVAR)
 
   integer :: i, g, inu
-  double precision :: ab, sc, delta, eta, er, der, rho, temp, Ye
+  real(rt)         :: ab, sc, delta, eta, er, der, rho, temp, Ye
   logical :: comp_ab, comp_sc, comp_eta
 
   comp_ab = .true.
@@ -1185,7 +1200,7 @@ subroutine ca_compute_rosseland_neut( lo, hi,  &
         call get_opacity_emissivity(ab, sc, delta, eta, &
              rho, Ye, temp, er, inu, comp_ab, comp_sc, comp_eta)
 
-        kpr(i,g) = ab + sc * (1.d0 - delta/3.d0)
+        kpr(i,g) = ab + sc * (1.e0_rt - delta/3.e0_rt)
 
      end do
   end do
@@ -1201,16 +1216,17 @@ subroutine ca_compute_planck_neut( lo, hi,  &
   use opacity_table_module, only : prep_opacity, get_opacity_emissivity
   use meth_params_module, only : NVAR, URHO, UTEMP, UFX
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: lo(1), hi(1)
   integer, intent(in) ::  kpp_l1,  kpp_h1
   integer, intent(in) :: stat_l1, stat_h1 
-  double precision             :: kpp ( kpp_l1: kpp_h1,0:ngroups-1)
-  double precision, intent(in) :: stat(stat_l1:stat_h1,NVAR)
+  real(rt)                     :: kpp ( kpp_l1: kpp_h1,0:ngroups-1)
+  real(rt)        , intent(in) :: stat(stat_l1:stat_h1,NVAR)
 
   integer :: i, g, inu
-  double precision :: ab, sc, delta, eta, er, der, rho, temp, Ye
+  real(rt)         :: ab, sc, delta, eta, er, der, rho, temp, Ye
   logical :: comp_ab, comp_sc, comp_eta
 
   comp_ab = .true.

--- a/Source/Radiation/RadSrc_1d/RAD_1D.F90
+++ b/Source/Radiation/RadSrc_1d/RAD_1D.F90
@@ -9,10 +9,11 @@ module rad_module
 
   use rad_util_module, only : FLDlambda
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
-  double precision, parameter :: tiny = 1.d-50
-  double precision, parameter :: BIGKR = 1.e25_dp_t
+  real(rt)        , parameter :: tiny = 1.e-50_rt
+  real(rt)        , parameter :: BIGKR = 1.e25_rt
 
 contains
 
@@ -21,11 +22,12 @@ subroutine multrs(d, &
                   DIMS(reg), &
                   r, s) bind(C, name="multrs")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(dbox)
   integer :: DIMDEC(reg)
-  real*8 :: d(DIMV(dbox))
-  real*8 :: r(reg_l1:reg_h1)
-  real*8 :: s(1)
+  real(rt)         :: d(DIMV(dbox))
+  real(rt)         :: r(reg_l1:reg_h1)
+  real(rt)         :: s(1)
   integer :: i
   do i = reg_l1, reg_h1
      d(i) = d(i) * r(i)
@@ -34,15 +36,16 @@ end subroutine multrs
 
 subroutine sphc(r, s, &
                 DIMS(reg), dx) bind(C, name="sphc")
+  use bl_fort_module, only : rt => c_real
   implicit none
   integer :: DIMDEC(reg)
-  real*8 :: r(reg_l1:reg_h1)
-  real*8 :: s(1)
-  real*8 :: dx(1)
-  real*8 :: h1, d1
+  real(rt)         :: r(reg_l1:reg_h1)
+  real(rt)         :: s(1)
+  real(rt)         :: dx(1)
+  real(rt)         :: h1, d1
   integer :: i
-  h1 = 0.5d0 * dx(1)
-  d1 = 1.d0 / (3.d0 * dx(1))
+  h1 = 0.5e0_rt * dx(1)
+  d1 = 1.e0_rt / (3.e0_rt * dx(1))
   do i = reg_l1, reg_h1
      r(i) = d1 * ((r(i) + h1)**3 - (r(i) - h1)**3)
   enddo
@@ -50,12 +53,13 @@ end subroutine sphc
 
 subroutine sphe(r, s, n, &
                 DIMS(reg), dx) bind(C, name="sphe")
+  use bl_fort_module, only : rt => c_real
   implicit none
   integer :: DIMDEC(reg)
-  real*8 :: r(reg_l1:reg_h1)
-  real*8 :: s(1)
+  real(rt)         :: r(reg_l1:reg_h1)
+  real(rt)         :: s(1)
   integer :: n
-  real*8 :: dx(1)
+  real(rt)         :: dx(1)
   integer :: i
   do i = reg_l1, reg_h1
      r(i) = r(i)**2
@@ -66,23 +70,24 @@ subroutine lacoef(a, &
                   DIMS(abox), &
                   DIMS(reg), &
                   fkp, eta, etainv, r, s, c, dt, theta) bind(C, name="lacoef")
+  use bl_fort_module, only : rt => c_real
   implicit none
   integer :: DIMDEC(abox)
   integer :: DIMDEC(reg)
-  real*8 :: a(DIMV(abox))
-  real*8 :: fkp(DIMV(abox))
-  real*8 :: eta(DIMV(abox))
-  real*8 :: etainv(DIMV(abox))
-  real*8 :: r(reg_l1:reg_h1)
-  real*8 :: s(1)
-  real*8 :: c, dt, theta
+  real(rt)         :: a(DIMV(abox))
+  real(rt)         :: fkp(DIMV(abox))
+  real(rt)         :: eta(DIMV(abox))
+  real(rt)         :: etainv(DIMV(abox))
+  real(rt)         :: r(reg_l1:reg_h1)
+  real(rt)         :: s(1)
+  real(rt)         :: c, dt, theta
   integer :: i
-  real*8 :: dtm
-  dtm = 1.d0 / dt
+  real(rt)         :: dtm
+  dtm = 1.e0_rt / dt
   do i = reg_l1, reg_h1
      a(i) = r(i) * &
           (fkp(i) * etainv(i) * c + dtm) / &
-          (1.d0 - (1.d0 - theta) * eta(i))
+          (1.e0_rt - (1.e0_rt - theta) * eta(i))
   enddo
 end subroutine lacoef
 
@@ -91,20 +96,21 @@ subroutine bclim(b, &
                  DIMS(reg), &
                  n, kappar, DIMS(kbox), &
                  r, s, c, dx) bind(C, name="bclim")
+  use bl_fort_module, only : rt => c_real
   implicit none
   integer :: DIMDEC(bbox)
   integer :: DIMDEC(reg)
   integer :: DIMDEC(kbox)
   integer :: n
-  real*8 :: b(DIMV(bbox))
-  real*8 :: lambda(DIMV(bbox))
-  real*8 :: kappar(DIMV(kbox))
-  real*8 :: r(reg_l1:reg_h1+1)
-  real*8 :: s(1)
-  real*8 :: c, dx(1)
-  real*8 :: kavg
+  real(rt)         :: b(DIMV(bbox))
+  real(rt)         :: lambda(DIMV(bbox))
+  real(rt)         :: kappar(DIMV(kbox))
+  real(rt)         :: r(reg_l1:reg_h1+1)
+  real(rt)         :: s(1)
+  real(rt)         :: c, dx(1)
+  real(rt)         :: kavg
   integer :: i
-  real*8 :: kap
+  real(rt)         :: kap
   do i = reg_l1, reg_h1 + 1
      kap = kavg(kappar(i-1), kappar(i), dx(1),-1)
      b(i) = r(i) * c * lambda(i) / kap
@@ -114,11 +120,12 @@ end subroutine bclim
 subroutine flxlim(lambda, &
                   DIMS(rbox), &
                   DIMS(reg), limiter) bind(C, name="flxlim")
+  use bl_fort_module, only : rt => c_real
   implicit none
   integer :: DIMDEC(rbox)
   integer :: DIMDEC(reg)
   integer :: limiter
-  real*8 :: lambda(DIMV(rbox))
+  real(rt)         :: lambda(DIMV(rbox))
   integer :: i
   do i = reg_l1, reg_h1
      lambda(i) = FLDlambda(lambda(i),limiter)
@@ -128,13 +135,14 @@ end subroutine flxlim
 subroutine eddfac(efact, &
                   DIMS(rbox), &
                   DIMS(reg), limiter, n)
+  use bl_fort_module, only : rt => c_real
   implicit none
   integer :: DIMDEC(rbox)
   integer :: DIMDEC(reg)
   integer :: n, limiter
-  real*8 :: efact(DIMV(rbox))
+  real(rt)         :: efact(DIMV(rbox))
   integer :: i
-  real*8 :: r, lambda
+  real(rt)         :: r, lambda
   do i = reg_l1, reg_h1 + 1
      r = efact(i)
      lambda = FLDlambda(r,limiter)
@@ -147,28 +155,29 @@ subroutine scgrd1(r, &
                   DIMS(reg), &
                   n, kappar, DIMS(kbox), &
                   er, dx) bind(C, name="scgrd1")
+  use bl_fort_module, only : rt => c_real
   implicit none
   integer :: DIMDEC(rbox)
   integer :: DIMDEC(reg)
   integer :: DIMDEC(kbox)
   integer :: n
-  real*8 :: r(DIMV(rbox))
-  real*8 :: kappar(DIMV(kbox))
-  real*8 :: er(DIMV(kbox))
-  real*8 :: dx(1)
-  real*8 :: kavg
+  real(rt)         :: r(DIMV(rbox))
+  real(rt)         :: kappar(DIMV(kbox))
+  real(rt)         :: er(DIMV(kbox))
+  real(rt)         :: dx(1)
+  real(rt)         :: kavg
   integer :: i
-  real*8 :: kap
+  real(rt)         :: kap
   ! gradient assembly:
   do i = reg_l1, reg_h1 + 1
      r(i) = abs(er(i) - er(i-1)) / dx(1)
   enddo
   i = reg_l1
-  if (er(i-1) == -1.d0) then
+  if (er(i-1) == -1.e0_rt) then
      r(i) = abs(er(i+1) - er(i)) / dx(1)
   endif
   i = reg_h1 + 1
-  if (er(i) == -1.d0) then
+  if (er(i) == -1.e0_rt) then
      r(i) = abs(er(i-1) - er(i-2)) / dx(1)
   endif
   ! construct scaled gradient:
@@ -184,28 +193,29 @@ subroutine scgrd2(r, &
                   DIMS(reg), &
                   n, kappar, DIMS(kbox), &
                   er, dx) bind(C, name="scgrd2")
+  use bl_fort_module, only : rt => c_real
   implicit none
   integer :: DIMDEC(rbox)
   integer :: DIMDEC(reg)
   integer :: DIMDEC(kbox)
   integer :: n
-  real*8 :: r(DIMV(rbox))
-  real*8 :: kappar(DIMV(kbox))
-  real*8 :: er(DIMV(kbox))
-  real*8 :: dx(1)
-  real*8 :: kavg
+  real(rt)         :: r(DIMV(rbox))
+  real(rt)         :: kappar(DIMV(kbox))
+  real(rt)         :: er(DIMV(kbox))
+  real(rt)         :: dx(1)
+  real(rt)         :: kavg
   integer :: i
-  real*8 :: kap
+  real(rt)         :: kap
   ! gradient assembly:
   do i = reg_l1, reg_h1 + 1
      r(i) = abs(er(i) - er(i-1)) / dx(1)
   enddo
   i = reg_l1
-  if (er(i-1) == -1.d0) then
+  if (er(i-1) == -1.e0_rt) then
      r(i) = abs(er(i+1) - er(i)) / dx(1)
   endif
   i = reg_h1 + 1
-  if (er(i) == -1.d0) then
+  if (er(i) == -1.e0_rt) then
      r(i) = abs(er(i-1) - er(i-2)) / dx(1)
   endif
   ! construct scaled gradient:
@@ -221,28 +231,29 @@ subroutine scgrd3(r, &
                   DIMS(reg), &
                   n, kappar, DIMS(kbox), &
                   er, dx) bind(C, name="scgrd3")
+  use bl_fort_module, only : rt => c_real
   implicit none
   integer :: DIMDEC(rbox)
   integer :: DIMDEC(reg)
   integer :: DIMDEC(kbox)
   integer :: n
-  real*8 :: r(DIMV(rbox))
-  real*8 :: kappar(DIMV(kbox))
-  real*8 :: er(DIMV(kbox))
-  real*8 :: dx(1)
-  real*8 :: kavg
+  real(rt)         :: r(DIMV(rbox))
+  real(rt)         :: kappar(DIMV(kbox))
+  real(rt)         :: er(DIMV(kbox))
+  real(rt)         :: dx(1)
+  real(rt)         :: kavg
   integer :: i
-  real*8 :: kap
+  real(rt)         :: kap
   ! gradient assembly:
   do i = reg_l1, reg_h1 + 1
      r(i) = abs(er(i) - er(i-1)) / dx(1)
   enddo
   i = reg_l1
-  if (er(i-1) == -1.d0) then
+  if (er(i-1) == -1.e0_rt) then
      r(i) = abs(er(i+1) - er(i)) / dx(1)
   endif
   i = reg_h1 + 1
-  if (er(i) == -1.d0) then
+  if (er(i) == -1.e0_rt) then
      r(i) = abs(er(i-1) - er(i-2)) / dx(1)
   endif
   ! construct scaled gradient:
@@ -259,55 +270,57 @@ subroutine lrhs(rhs, &
                 temp, fkp, eta, etainv, frhoem, frhoes, dfo, &
                 ero, DIMS(ebox), edot, &
                 r, s, dt, sigma, c, theta) bind(C, name="lrhs")
+  use bl_fort_module, only : rt => c_real
   implicit none
   integer :: DIMDEC(rbox)
   integer :: DIMDEC(ebox)
   integer :: DIMDEC(reg)
-  real*8 :: rhs(DIMV(rbox))
-  real*8 :: temp(DIMV(rbox))
-  real*8 :: fkp(DIMV(rbox))
-  real*8 :: eta(DIMV(rbox))
-  real*8 :: etainv(DIMV(rbox))
-  real*8 :: frhoem(DIMV(rbox))
-  real*8 :: frhoes(DIMV(rbox))
-  real*8 :: dfo(DIMV(rbox))
-  real*8 :: ero(DIMV(ebox))
-  real*8 :: edot(DIMV(rbox))
-  real*8 :: r(reg_l1:reg_h1)
-  real*8 :: s(1)
-  real*8 :: dt, sigma, c, theta
+  real(rt)         :: rhs(DIMV(rbox))
+  real(rt)         :: temp(DIMV(rbox))
+  real(rt)         :: fkp(DIMV(rbox))
+  real(rt)         :: eta(DIMV(rbox))
+  real(rt)         :: etainv(DIMV(rbox))
+  real(rt)         :: frhoem(DIMV(rbox))
+  real(rt)         :: frhoes(DIMV(rbox))
+  real(rt)         :: dfo(DIMV(rbox))
+  real(rt)         :: ero(DIMV(ebox))
+  real(rt)         :: edot(DIMV(rbox))
+  real(rt)         :: r(reg_l1:reg_h1)
+  real(rt)         :: s(1)
+  real(rt)         :: dt, sigma, c, theta
   integer :: i
-  real*8 :: dtm, ek, bs, es, ekt
-  dtm = 1.d0 / dt
+  real(rt)         :: dtm, ek, bs, es, ekt
+  dtm = 1.e0_rt / dt
   do i = reg_l1, reg_h1
      ek = fkp(i) * eta(i)
      bs = etainv(i) * &
-          &         4.d0 * sigma * fkp(i) * temp(i)**4
+          &         4.e0_rt * sigma * fkp(i) * temp(i)**4
      es = eta(i) * (frhoem(i) - frhoes(i))
-     ekt = (1.d0 - theta) * eta(i)
+     ekt = (1.e0_rt - theta) * eta(i)
      rhs(i) = (rhs(i) + r(i) * &
           (bs + dtm * (ero(i) + es) + &
           ek * c * edot(i) - &
           ekt * dfo(i))) / &
-          (1.d0 - ekt)
+          (1.e0_rt - ekt)
   enddo
 end subroutine lrhs
 
 subroutine anatw2(test, &
                   DIMS(reg), &
                   temp, p, xf, Tc, dx, xlo, lo) bind(C, name="anatw2")
+  use bl_fort_module, only : rt => c_real
   implicit none
   integer :: DIMDEC(reg)
-  real*8 :: test(DIMV(reg), 0:1)
-  real*8 :: temp(DIMV(reg))
-  real*8 :: p, xf, Tc, dx(1), xlo(1)
+  real(rt)         :: test(DIMV(reg), 0:1)
+  real(rt)         :: temp(DIMV(reg))
+  real(rt)         :: p, xf, Tc, dx(1), xlo(1)
   integer :: lo(1)
   integer :: i
-  real*8 :: x, r2
+  real(rt)         :: x, r2
   do i = reg_l1, reg_h1
-     x  = xlo(1) + dx(1) * ((i-lo(1)) + 0.5d0)
+     x  = xlo(1) + dx(1) * ((i-lo(1)) + 0.5e0_rt)
      r2 = x*x
-     test(i,0) = Tc * max((1.d0-r2/xf**2), 0.d0)**(1.d0/p)
+     test(i,0) = Tc * max((1.e0_rt-r2/xf**2), 0.e0_rt)**(1.e0_rt/p)
      test(i,1) = temp(i) - test(i,0)
   enddo
 end subroutine anatw2
@@ -318,15 +331,16 @@ subroutine cfrhoe(DIMS(reg), &
                   state, &
                   DIMS(sb)) bind(C, name="cfrhoe")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(reg)
   integer :: DIMDEC(fb)
   integer :: DIMDEC(sb)
-  real*8 :: frhoe(DIMV(fb))
-  real*8 :: state(DIMV(sb), NVAR)
-  !      real*8 kin
+  real(rt)         :: frhoe(DIMV(fb))
+  real(rt)         :: state(DIMV(sb), NVAR)
+  !      real(rt)         kin
   integer :: i
   do i = reg_l1, reg_h1
-     !         kin = 0.5d0 * (state(i,XMOM) ** 2) /
+     !         kin = 0.5e0_rt * (state(i,XMOM) ** 2) /
      !     @                 state(i,DEN)
      !         frhoe(i) = state(i,EDEN) - kin
      frhoe(i) = state(i,UEINT)
@@ -340,31 +354,32 @@ subroutine gtemp(DIMS(reg), &
                  const, em, en, &
                  state, DIMS(sb)) bind(C, name="gtemp")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(reg)
   integer :: DIMDEC(tb)
   integer :: DIMDEC(sb)
-  real*8 :: temp(DIMV(tb))
-  real*8 :: const(0:1), em(0:1), en(0:1)
-  real*8 :: state(DIMV(sb), NVAR)
-  real*8 :: alpha, teff, ex, frhoal
+  real(rt)         :: temp(DIMV(tb))
+  real(rt)         :: const(0:1), em(0:1), en(0:1)
+  real(rt)         :: state(DIMV(sb), NVAR)
+  real(rt)         :: alpha, teff, ex, frhoal
   integer :: i
-  if (en(0) >= 1.d0) then
+  if (en(0) >= 1.e0_rt) then
      print *, "Bad exponent for cv calculation"
      stop
   endif
-  ex = 1.d0 / (1.d0 - en(0))
+  ex = 1.e0_rt / (1.e0_rt - en(0))
   do i = reg_l1, reg_h1
-     if (em(0) == 0.d0) then
+     if (em(0) == 0.e0_rt) then
         alpha = const(0)
      else
         alpha = const(0) * state(i,URHO) ** em(0)
      endif
      frhoal = state(i, URHO) * alpha + tiny
-     if (en(0) == 0.d0) then
+     if (en(0) == 0.e0_rt) then
         temp(i) = temp(i) / frhoal
      else
         teff = max(temp(i), tiny)
-        temp(i) = ((1.d0 - en(0)) * teff / frhoal) ** ex
+        temp(i) = ((1.e0_rt - en(0)) * teff / frhoal) ** ex
      endif
   enddo
 end subroutine gtemp
@@ -377,24 +392,25 @@ subroutine gcv(DIMS(reg), &
                const, em, en, tf, &
                state, DIMS(sbox)) bind(C, name="gcv")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(reg)
   integer :: DIMDEC(cbox)
   integer :: DIMDEC(tbox)
   integer :: DIMDEC(sbox)
-  real*8 :: cv(DIMV(cbox))
-  real*8 :: temp(DIMV(tbox))
-  real*8 :: const(0:1), em(0:1), en(0:1), tf(0:1)
-  real*8 :: state(DIMV(sbox),  NVAR)
-  real*8 :: alpha, teff, frhoal
+  real(rt)         :: cv(DIMV(cbox))
+  real(rt)         :: temp(DIMV(tbox))
+  real(rt)         :: const(0:1), em(0:1), en(0:1), tf(0:1)
+  real(rt)         :: state(DIMV(sbox),  NVAR)
+  real(rt)         :: alpha, teff, frhoal
   integer :: i
   do i = reg_l1, reg_h1
-     if (em(0) == 0.d0) then
+     if (em(0) == 0.e0_rt) then
         alpha = const(0)
      else
         alpha = const(0) * state(i, URHO) ** em(0)
      endif
      frhoal = state(i, URHO) * alpha + tiny
-     if (en(0) == 0.d0) then
+     if (en(0) == 0.e0_rt) then
         cv(i) = alpha
      else
         teff = max(temp(i), tiny)
@@ -411,19 +427,20 @@ subroutine cexch(DIMS(reg), &
                  er  , DIMS(ebox), &
                  fkp , DIMS(kbox), &
                  sigma, c) bind(C, name="cexch")
+  use bl_fort_module, only : rt => c_real
   implicit none
   integer :: DIMDEC(reg)
   integer :: DIMDEC(xbox)
   integer :: DIMDEC(ebox)
   integer :: DIMDEC(kbox)
-  real*8 :: exch(DIMV(xbox))
-  real*8 :: er  (DIMV(ebox))
-  real*8 :: fkp (DIMV(kbox))
-  real*8 :: sigma, c
+  real(rt)         :: exch(DIMV(xbox))
+  real(rt)         :: er  (DIMV(ebox))
+  real(rt)         :: fkp (DIMV(kbox))
+  real(rt)         :: sigma, c
   integer :: i
   do i = reg_l1, reg_h1
      exch(i) = fkp(i) * &
-          (4.d0 * sigma * exch(i)**4 &
+          (4.e0_rt * sigma * exch(i)**4 &
           - c * er(i))
   enddo
 end subroutine cexch
@@ -436,6 +453,7 @@ subroutine ceta2(DIMS(reg), &
                  fkp, DIMS(fb), &
                  er, DIMS(ebox), &
                  dtemp, dtime, sigma, c, underr, lagpla) bind(C, name="ceta2")
+  use bl_fort_module, only : rt => c_real
   implicit none
   integer :: DIMDEC(reg)
   integer :: DIMDEC(etab)
@@ -444,20 +462,20 @@ subroutine ceta2(DIMS(reg), &
   integer :: DIMDEC(cb)
   integer :: DIMDEC(fb)
   integer :: DIMDEC(ebox)
-  real*8 :: eta(DIMV(etab))
-  real*8 :: etainv(DIMV(etab))
-  real*8 :: frho(DIMV(sb))
-  real*8 :: temp(DIMV(tb))
-  real*8 :: cv(DIMV(cb))
-  real*8 :: fkp(DIMV(fb))
-  real*8 :: er(DIMV(ebox))
-  real*8 :: dtemp, dtime, sigma, c, underr
+  real(rt)         :: eta(DIMV(etab))
+  real(rt)         :: etainv(DIMV(etab))
+  real(rt)         :: frho(DIMV(sb))
+  real(rt)         :: temp(DIMV(tb))
+  real(rt)         :: cv(DIMV(cb))
+  real(rt)         :: fkp(DIMV(fb))
+  real(rt)         :: er(DIMV(ebox))
+  real(rt)         :: dtemp, dtime, sigma, c, underr
   integer :: lagpla
-  real*8 :: d, frc, fac0, fac1, fac2
+  real(rt)         :: d, frc, fac0, fac1, fac2
   integer :: i
-  fac1 = 16.d0 * sigma * dtime
+  fac1 = 16.e0_rt * sigma * dtime
   if (lagpla == 0) then
-     fac0 = 0.25d0 * fac1 / dtemp
+     fac0 = 0.25e0_rt * fac1 / dtemp
      fac2 = dtime * c / dtemp
   endif
   do i = reg_l1, reg_h1
@@ -473,8 +491,8 @@ subroutine ceta2(DIMS(reg), &
         !     @          fac0 * (eta(i) - fkp(i)) * temp(i) ** 4 -
         !     @          fac2 * (eta(i) - fkp(i)) * er(i)
         ! analytic derivatives for specific test problem:
-        !            d = (1.2d+6 * sigma * temp(i) ** 2 +
-        !     @           1.d+5 * c * er(i) * (temp(i) + tiny) ** (-2)) * dtime
+        !            d = (1.2e+6_rt * sigma * temp(i) ** 2 +
+        !     @           1.e+5_rt * c * er(i) * (temp(i) + tiny) ** (-2)) * dtime
         ! another alternate form (much worse):
         !            d = fac1 * fkp(i) * (temp(i) + dtemp) ** 3 +
         !     @          fac0 * (eta(i) - fkp(i)) * (temp(i) + dtemp) ** 4 -
@@ -483,8 +501,8 @@ subroutine ceta2(DIMS(reg), &
      frc = frho(i) * cv(i) + tiny
      eta(i) = d / (d + frc)
      etainv(i) = underr * frc / (d + frc)
-     eta(i) = 1.d0 - etainv(i)
-     !         eta(i) = 1.d0 - underr * (1.d0 - eta(i))
+     eta(i) = 1.e0_rt - etainv(i)
+     !         eta(i) = 1.e0_rt - underr * (1.e0_rt - eta(i))
   enddo
 end subroutine ceta2
 
@@ -492,26 +510,27 @@ subroutine ceup(DIMS(reg), relres, absres, &
                 frhoes, DIMS(grd), &
                 frhoem, eta, etainv, dfo, dfn, exch, &
                 dt, theta) bind(C, name="ceup")
+  use bl_fort_module, only : rt => c_real
   implicit none
   integer :: DIMDEC(reg)
   integer :: DIMDEC(grd)
-  real*8 :: frhoes(DIMV(grd))
-  real*8 :: frhoem(DIMV(grd))
-  real*8 :: eta(DIMV(grd))
-  real*8 :: etainv(DIMV(grd))
-  real*8 :: dfo(DIMV(grd))
-  real*8 :: dfn(DIMV(grd))
-  real*8 :: exch(DIMV(grd))
-  real*8 :: dt, theta, relres, absres
-  real*8 :: tmp, chg, tot
+  real(rt)         :: frhoes(DIMV(grd))
+  real(rt)         :: frhoem(DIMV(grd))
+  real(rt)         :: eta(DIMV(grd))
+  real(rt)         :: etainv(DIMV(grd))
+  real(rt)         :: dfo(DIMV(grd))
+  real(rt)         :: dfn(DIMV(grd))
+  real(rt)         :: exch(DIMV(grd))
+  real(rt)         :: dt, theta, relres, absres
+  real(rt)         :: tmp, chg, tot
   integer :: i
   do i = reg_l1, reg_h1
-     chg = 0.d0
-     tot = 0.d0
+     chg = 0.e0_rt
+     tot = 0.e0_rt
      tmp = eta(i) * frhoes(i) + &
           etainv(i) * &
           (frhoem(i) - &
-          dt * ((1.d0 - theta) * &
+          dt * ((1.e0_rt - theta) * &
           (dfo(i) - dfn(i)) + &
           exch(i)))
      chg = abs(tmp - frhoes(i))
@@ -526,27 +545,28 @@ subroutine ceupdterm(DIMS(reg), relres, absres, &
                      frhoes, DIMS(grd), &
                      frhoem, eta, etainv, dfo, dfn, exch, dterm, &
                      dt, theta) bind(C, name="ceupdterm")
+  use bl_fort_module, only : rt => c_real
   implicit none
   integer :: DIMDEC(reg)
   integer :: DIMDEC(grd)
-  real*8 :: frhoes(DIMV(grd))
-  real*8 :: frhoem(DIMV(grd))
-  real*8 :: eta(DIMV(grd))
-  real*8 :: etainv(DIMV(grd))
-  real*8 :: dfo(DIMV(grd))
-  real*8 :: dfn(DIMV(grd))
-  real*8 :: exch(DIMV(grd))
-  real*8 :: dterm(DIMV(grd))
-  real*8 :: dt, theta, relres, absres
-  real*8 :: tmp, chg, tot
+  real(rt)         :: frhoes(DIMV(grd))
+  real(rt)         :: frhoem(DIMV(grd))
+  real(rt)         :: eta(DIMV(grd))
+  real(rt)         :: etainv(DIMV(grd))
+  real(rt)         :: dfo(DIMV(grd))
+  real(rt)         :: dfn(DIMV(grd))
+  real(rt)         :: exch(DIMV(grd))
+  real(rt)         :: dterm(DIMV(grd))
+  real(rt)         :: dt, theta, relres, absres
+  real(rt)         :: tmp, chg, tot
   integer :: i
   do i = reg_l1, reg_h1
-     chg = 0.d0
-     tot = 0.d0
+     chg = 0.e0_rt
+     tot = 0.e0_rt
      tmp = eta(i) * frhoes(i) + &
           etainv(i) * &
           (frhoem(i) - &
-          dt * ((1.d0 - theta) * &
+          dt * ((1.e0_rt - theta) * &
           (dfo(i) - dfn(i)) + &
           exch(i))) &
           + dt * dterm(i)
@@ -567,43 +587,44 @@ subroutine nceup(DIMS(reg), relres, absres, &
      state, DIMS(sb), &
      sigma, c, dt, theta) bind(C, name="nceup")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(reg)
   integer :: DIMDEC(grd)
   integer :: DIMDEC(sb)
   integer :: DIMDEC(ebox)
-  real*8 :: frhoes(DIMV(grd))
-  real*8 :: frhoem(DIMV(grd))
-  real*8 :: eta(DIMV(grd))
-  real*8 :: etainv(DIMV(grd))
-  real*8 :: er(DIMV(ebox))
-  real*8 :: dfo(DIMV(grd))
-  real*8 :: dfn(DIMV(grd))
-  real*8 :: temp(DIMV(grd))
-  real*8 :: fkp(DIMV(grd))
-  real*8 :: cv(DIMV(reg))
-  real*8 :: state(DIMV(sb),  NVAR)
-  real*8 :: sigma, c, dt, theta, relres, absres
-  real*8 :: tmp, chg, tot, exch, b, db, dbdt, frhocv
+  real(rt)         :: frhoes(DIMV(grd))
+  real(rt)         :: frhoem(DIMV(grd))
+  real(rt)         :: eta(DIMV(grd))
+  real(rt)         :: etainv(DIMV(grd))
+  real(rt)         :: er(DIMV(ebox))
+  real(rt)         :: dfo(DIMV(grd))
+  real(rt)         :: dfn(DIMV(grd))
+  real(rt)         :: temp(DIMV(grd))
+  real(rt)         :: fkp(DIMV(grd))
+  real(rt)         :: cv(DIMV(reg))
+  real(rt)         :: state(DIMV(sb),  NVAR)
+  real(rt)         :: sigma, c, dt, theta, relres, absres
+  real(rt)         :: tmp, chg, tot, exch, b, db, dbdt, frhocv
   integer :: i
   do i = reg_l1, reg_h1
-     chg = 0.d0
-     tot = 0.d0
+     chg = 0.e0_rt
+     tot = 0.e0_rt
      frhocv = state(i, URHO) * cv(i)
-     dbdt = 16.d0 * sigma * temp(i)**3
-     b = 4.d0 * sigma * temp(i)**4
+     dbdt = 16.e0_rt * sigma * temp(i)**3
+     b = 4.e0_rt * sigma * temp(i)**4
      exch = fkp(i) * (b - c * er(i))
      tmp = eta(i) * frhoes(i) + etainv(i) * &
           (frhoem(i) - &
-          dt * ((1.d0 - theta) * &
+          dt * ((1.e0_rt - theta) * &
           (dfo(i) - dfn(i)) + &
           exch))
 #if 1
      if (frhocv > tiny .AND. tmp > frhoes(i)) then
         db = (tmp - frhoes(i)) * dbdt / frhocv
-        if (b + db <= 0.d0) then
+        if (b + db <= 0.e0_rt) then
            print *, i, b, db, b+db
         endif
-        tmp = ((b + db) / (4.d0 * sigma))**0.25d0
+        tmp = ((b + db) / (4.e0_rt * sigma))**0.25e0_rt
         tmp = frhoes(i) + frhocv * (tmp - temp(i))
      endif
 #endif
@@ -619,15 +640,16 @@ subroutine cetot(DIMS(reg), &
                  state, DIMS(sb), &
                  frhoe, DIMS(fb)) bind(C, name="cetot")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(reg)
   integer :: DIMDEC(sb)
   integer :: DIMDEC(fb)
-  real*8 :: state(DIMV(sb), NVAR)
-  real*8 :: frhoe(DIMV(fb))
-  real*8 :: kin
+  real(rt)         :: state(DIMV(sb), NVAR)
+  real(rt)         :: frhoe(DIMV(fb))
+  real(rt)         :: kin
   integer :: i
   do i = reg_l1, reg_h1
-     !         kin = 0.5d0 * (state(i,XMOM) ** 2) /
+     !         kin = 0.5e0_rt * (state(i,XMOM) ** 2) /
      !     @                 state(i,DEN)
      kin = state(i, UEDEN) - state(i, UEINT)
      state(i, UEINT) = frhoe(i)
@@ -642,16 +664,17 @@ subroutine fkpn(DIMS(reg), &
                 temp, DIMS(tb), &
                 state, DIMS(sb)) bind(C, name="fkpn")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(reg)
   integer :: DIMDEC(fb)
   integer :: DIMDEC(tb)
   integer :: DIMDEC(sb)
-  real*8 :: fkp(DIMV(fb))
-  real*8 :: const(0:1), em(0:1), en(0:1), tf(0:1)
-  real*8 :: ep(0:1), nu
-  real*8 :: temp(DIMV(tb))
-  real*8 :: state(DIMV(sb),  NVAR)
-  real*8 :: teff
+  real(rt)         :: fkp(DIMV(fb))
+  real(rt)         :: const(0:1), em(0:1), en(0:1), tf(0:1)
+  real(rt)         :: ep(0:1), nu
+  real(rt)         :: temp(DIMV(tb))
+  real(rt)         :: state(DIMV(sb),  NVAR)
+  real(rt)         :: teff
   integer :: i
   do i = reg_l1, reg_h1
      teff = max(temp(i), tiny)
@@ -671,17 +694,18 @@ subroutine rosse1( DIMS(reg), &
      temp, DIMS(tb), &
      state, DIMS(sb)) bind(C, name="rosse1")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(reg)
   integer :: DIMDEC(kbox)
   integer :: DIMDEC(tb)
   integer :: DIMDEC(sb)
-  real*8 :: kappar(DIMV(kbox))
-  real*8 :: const(0:1), em(0:1), en(0:1), tf(0:1)
-  real*8 :: ep(0:1), nu
-  real*8 :: temp(DIMV(tb))
-  real*8 :: state(DIMV(sb),  NVAR)
-  real*8 :: kfloor
-  real*8 :: kf, teff
+  real(rt)         :: kappar(DIMV(kbox))
+  real(rt)         :: const(0:1), em(0:1), en(0:1), tf(0:1)
+  real(rt)         :: ep(0:1), nu
+  real(rt)         :: temp(DIMV(tb))
+  real(rt)         :: state(DIMV(sb),  NVAR)
+  real(rt)         :: kfloor
+  real(rt)         :: kf, teff
   integer :: i
   do i = reg_l1, reg_h1
      teff = max(temp(i), tiny)
@@ -705,18 +729,19 @@ subroutine rosse1s(DIMS(reg), &
                    temp, DIMS(tb), &
                    state, DIMS(sb)) bind(C, name="rosse1s")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(reg)
   integer :: DIMDEC(kbox)
   integer :: DIMDEC(tb)
   integer :: DIMDEC(sb)
-  real*8 :: kappar(DIMV(kbox))
-  real*8 :: const(0:1), em(0:1), en(0:1), tf(0:1)
-  real*8 :: ep(0:1), nu
-  real*8 :: sconst(0:1), sem(0:1), sen(0:1), sep(0:1)
-  real*8 :: temp(DIMV(tb))
-  real*8 :: state(DIMV(sb),  NVAR)
-  real*8 :: kfloor
-  real*8 :: kf, teff, sct
+  real(rt)         :: kappar(DIMV(kbox))
+  real(rt)         :: const(0:1), em(0:1), en(0:1), tf(0:1)
+  real(rt)         :: ep(0:1), nu
+  real(rt)         :: sconst(0:1), sem(0:1), sen(0:1), sep(0:1)
+  real(rt)         :: temp(DIMV(tb))
+  real(rt)         :: state(DIMV(sb),  NVAR)
+  real(rt)         :: kfloor
+  real(rt)         :: kf, teff, sct
   integer :: i
   do i = reg_l1, reg_h1
      teff = max(temp(i), tiny)
@@ -737,12 +762,13 @@ subroutine nfloor(dest, &
                   DIMS(dbox), &
                   DIMS(reg), &
                   nflr, flr, nvar) bind(C, name="nfloor")
+  use bl_fort_module, only : rt => c_real
   implicit none
   integer :: DIMDEC(dbox)
   integer :: DIMDEC(reg)
   integer :: nvar, nflr
-  real*8 :: dest(DIMV(dbox), 0:nvar-1)
-  real*8 :: flr
+  real(rt)         :: dest(DIMV(dbox), 0:nvar-1)
+  real(rt)         :: flr
   integer :: i, n
   nflr = 0
   do n = 0, nvar-1
@@ -766,18 +792,19 @@ subroutine lacoefmgfld(a, &
                        DIMS(kbox), &
                        r, s, &
                        dt, c) bind(C, name="lacoefmgfld")
+  use bl_fort_module, only : rt => c_real
   implicit none
   integer :: DIMDEC(abox)
   integer :: DIMDEC(reg)
   integer :: DIMDEC(kbox)
-  real*8 :: a(DIMV(abox))
-  real*8 :: kappa(DIMV(kbox))
-  real*8 :: r(reg_l1:reg_h1)
-  real*8 :: s(1)
-  real*8 :: dt, c
+  real(rt)         :: a(DIMV(abox))
+  real(rt)         :: kappa(DIMV(kbox))
+  real(rt)         :: r(reg_l1:reg_h1)
+  real(rt)         :: s(1)
+  real(rt)         :: dt, c
   integer :: i
   do i = reg_l1, reg_h1
-     a(i) = c*kappa(i) + 1.d0/dt
+     a(i) = c*kappa(i) + 1.e0_rt/dt
      a(i) = r(i) * a(i)
   enddo
 end subroutine lacoefmgfld
@@ -791,27 +818,29 @@ subroutine rfface(fine, &
                   crse, &
                   DIMS(cbox), &
                   idim, irat) bind(C, name="rfface")
+  use bl_fort_module, only : rt => c_real
   implicit none
   integer :: DIMDEC(fbox)
   integer :: DIMDEC(cbox)
-  real*8 :: fine(DIMV(fbox))
-  real*8 :: crse(DIMV(cbox))
+  real(rt)         :: fine(DIMV(fbox))
+  real(rt)         :: crse(DIMV(cbox))
   integer :: idim, irat(0:0)
   fine(fbox_l1) = crse(cbox_l1)
 end subroutine rfface
 
 subroutine bextrp(f, fbox_l1, fbox_h1, reg_l1, reg_h1) bind(C, name="bextrp")
+  use bl_fort_module, only : rt => c_real
   implicit none
   integer :: fbox_l1, fbox_h1
   integer ::  reg_l1,  reg_h1
-  real*8 :: f(fbox_l1:fbox_h1)
+  real(rt)         :: f(fbox_l1:fbox_h1)
   integer :: i
 
   !     i direction first:
   i = reg_l1
-  f(i-1) = 2.d0 * f(i) - f(i+1)
+  f(i-1) = 2.e0_rt * f(i) - f(i+1)
   i = reg_h1
-  f(i+1) = 2.d0 * f(i) - f(i-1)
+  f(i+1) = 2.e0_rt * f(i) - f(i-1)
 end subroutine bextrp
 
 
@@ -820,19 +849,20 @@ subroutine lbcoefna(bcoef, &
                     reg_l1, reg_h1, &
                     spec, sbox_l1, sbox_h1, &
                     idim) bind(C, name="lbcoefna")
+  use bl_fort_module, only : rt => c_real
   implicit none
   integer :: idim
   integer ::  reg_l1,  reg_h1
   integer :: bbox_l1, bbox_h1
   integer :: sbox_l1, sbox_h1
-  real*8 :: bcoef(bbox_l1:bbox_h1)
-  real*8 :: bcgrp(bbox_l1:bbox_h1)
-  real*8 :: spec(sbox_l1:sbox_h1)
+  real(rt)         :: bcoef(bbox_l1:bbox_h1)
+  real(rt)         :: bcgrp(bbox_l1:bbox_h1)
+  real(rt)         :: spec(sbox_l1:sbox_h1)
   integer :: i
   if (idim == 0) then
      do i = reg_l1, reg_h1
         bcoef(i) = bcoef(i) &
-             + 0.5d0 * (spec(i-1) + spec(i)) * bcgrp(i)
+             + 0.5e0_rt * (spec(i-1) + spec(i)) * bcgrp(i)
      enddo
   endif
 end subroutine lbcoefna
@@ -843,15 +873,16 @@ subroutine ljupna(jnew, jbox_l1, jbox_h1, &
                   spec, sbox_l1, sbox_h1, &
                   accel, abox_l1, abox_h1, &
                   nTotal) bind(C, name="ljupna")
+  use bl_fort_module, only : rt => c_real
   implicit none
   integer :: nTotal
   integer ::  reg_l1,  reg_h1
   integer :: jbox_l1, jbox_h1
   integer :: sbox_l1, sbox_h1
   integer :: abox_l1, abox_h1
-  real*8 :: jnew(jbox_l1:jbox_h1, 0:nTotal-1)
-  real*8 :: spec(sbox_l1:sbox_h1, 0:nTotal-1)
-  real*8 :: accel(abox_l1:abox_h1)
+  real(rt)         :: jnew(jbox_l1:jbox_h1, 0:nTotal-1)
+  real(rt)         :: spec(sbox_l1:sbox_h1, 0:nTotal-1)
+  real(rt)         :: accel(abox_l1:abox_h1)
   integer :: i, n
   do n = 0, nTotal - 1
      do i = reg_l1, reg_h1

--- a/Source/Radiation/RadSrc_1d/RadBndry_1d.f90
+++ b/Source/Radiation/RadSrc_1d/RadBndry_1d.f90
@@ -14,15 +14,16 @@ subroutine rbndry(  &
 
   use rad_params_module, only : ngroups
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: b_l1, b_h1
   integer, intent(in) :: d_l1, d_h1  ! computational domain index
   integer, intent(in) :: dir         ! always 0 (i.e., x-direction) in 1D
   integer, intent(in) :: face        ! 0: low     1: high
-  double precision, intent(out) :: bf(b_l1:b_h1,0:ngroups-1)
-  double precision, intent(in) :: dx(1), xlo(1), t
+  real(rt)        , intent(out) :: bf(b_l1:b_h1,0:ngroups-1)
+  real(rt)        , intent(in) :: dx(1), xlo(1), t
 
-  bf = 0.5d0
+  bf = 0.5e0_rt
 
 end subroutine rbndry

--- a/Source/Radiation/RadSrc_1d/RadEOS_1d.f90
+++ b/Source/Radiation/RadSrc_1d/RadEOS_1d.f90
@@ -8,22 +8,23 @@ subroutine ca_compute_c_v(lo, hi, &
   use network, only : nspec, naux
   use meth_params_module, only : NVAR, URHO, UFS, UFX
   
+  use bl_fort_module, only : rt => c_real
   implicit none
   integer, intent(in)           :: lo(1), hi(1)
   integer, intent(in)           :: cv_l1, cv_h1
   integer, intent(in)           :: temp_l1, temp_h1
   integer, intent(in)           :: state_l1, state_h1
-  double precision              :: cv(cv_l1:cv_h1)
-  double precision, intent(in)  :: temp(temp_l1:temp_h1)
-  double precision, intent(in)  :: state(state_l1:state_h1,NVAR)
+  real(rt)                      :: cv(cv_l1:cv_h1)
+  real(rt)        , intent(in)  :: temp(temp_l1:temp_h1)
+  real(rt)        , intent(in)  :: state(state_l1:state_h1,NVAR)
   
   integer           :: i
-  double precision :: rhoInv
+  real(rt)         :: rhoInv
   type(eos_t) :: eos_state
   
   do i = lo(1), hi(1)
      
-     rhoInv = 1.d0 / state(i,URHO)
+     rhoInv = 1.e0_rt / state(i,URHO)
      eos_state % rho = state(i,URHO)
      eos_state % T = temp(i)
      eos_state % xn  = state(i,UFS:UFS+nspec-1) * rhoInv
@@ -47,22 +48,23 @@ subroutine ca_get_rhoe(lo, hi, &
   use network, only : nspec, naux
   use meth_params_module, only : NVAR, URHO, UFS, UFX
   
+  use bl_fort_module, only : rt => c_real
   implicit none
   integer         , intent(in) :: lo(1), hi(1)
   integer         , intent(in) :: rhoe_l1, rhoe_h1
   integer         , intent(in) :: temp_l1, temp_h1
   integer         , intent(in) :: state_l1, state_h1
-  double precision, intent(in) :: temp(temp_l1:temp_h1)
-  double precision, intent(in) :: state(state_l1:state_h1,NVAR)
-  double precision             :: rhoe(rhoe_l1:rhoe_h1)
+  real(rt)        , intent(in) :: temp(temp_l1:temp_h1)
+  real(rt)        , intent(in) :: state(state_l1:state_h1,NVAR)
+  real(rt)                     :: rhoe(rhoe_l1:rhoe_h1)
   
   integer          :: i
-  double precision :: rhoInv
+  real(rt)         :: rhoInv
   type(eos_t) :: eos_state  
 
   do i = lo(1), hi(1)
 
-     rhoInv = 1.d0 / state(i,URHO)
+     rhoInv = 1.e0_rt / state(i,URHO)
      eos_state % rho = state(i,URHO)
      eos_state % T   = temp(i)
      eos_state % xn  = state(i,UFS:UFS+nspec-1) * rhoInv
@@ -84,21 +86,22 @@ subroutine ca_compute_temp_given_rhoe(lo,hi,  &
   use eos_module
   use meth_params_module, only : NVAR, URHO, UFS, UFX, UTEMP, small_temp, allow_negative_energy
 
+  use bl_fort_module, only : rt => c_real
   implicit none
   integer         , intent(in) :: lo(1),hi(1)
   integer         , intent(in) :: temp_l1,temp_h1, state_l1,state_h1
-  double precision, intent(in) :: state(state_l1:state_h1,NVAR)
-  double precision             :: temp(temp_l1:temp_h1) ! temp contains rhoe as input
+  real(rt)        , intent(in) :: state(state_l1:state_h1,NVAR)
+  real(rt)                     :: temp(temp_l1:temp_h1) ! temp contains rhoe as input
 
   integer :: i
-  double precision :: rhoInv
+  real(rt)         :: rhoInv
   type (eos_t) :: eos_state
 
   do i = lo(1),hi(1)
-     if (allow_negative_energy.eq.0 .and. temp(i).le.0.d0) then
+     if (allow_negative_energy.eq.0 .and. temp(i).le.0.e0_rt) then
         temp(i) = small_temp
      else
-        rhoInv = 1.d0 / state(i,URHO)
+        rhoInv = 1.e0_rt / state(i,URHO)
         eos_state % rho = state(i,URHO)
         eos_state % T   = state(i,UTEMP)
         eos_state % e   = temp(i)*rhoInv 
@@ -120,30 +123,31 @@ subroutine ca_compute_temp_given_cv(lo,hi,  &
 
   use meth_params_module, only : NVAR, URHO
 
+  use bl_fort_module, only : rt => c_real
   implicit none
   integer         , intent(in) :: lo(1),hi(1)
   integer         , intent(in) :: temp_l1,temp_h1, state_l1,state_h1
-  double precision, intent(in) :: state(state_l1:state_h1,NVAR)
-  double precision             :: temp(temp_l1:temp_h1) ! temp contains rhoe as input
-  double precision, intent(in) :: const_c_v, c_v_exp_m, c_v_exp_n
+  real(rt)        , intent(in) :: state(state_l1:state_h1,NVAR)
+  real(rt)                     :: temp(temp_l1:temp_h1) ! temp contains rhoe as input
+  real(rt)        , intent(in) :: const_c_v, c_v_exp_m, c_v_exp_n
 
   integer :: i
-  double precision :: ex, alpha, rhoal, teff
+  real(rt)         :: ex, alpha, rhoal, teff
 
-  ex = 1.d0 / (1.d0 - c_v_exp_n)
+  ex = 1.e0_rt / (1.e0_rt - c_v_exp_n)
 
   do i=lo(1), hi(1)
-     if (c_v_exp_m .eq. 0.d0) then
+     if (c_v_exp_m .eq. 0.e0_rt) then
         alpha = const_c_v
      else
         alpha = const_c_v * state(i,URHO) ** c_v_exp_m
      endif
-     rhoal = state(i,URHO) * alpha + 1.d-50
-     if (c_v_exp_n .eq. 0.d0) then
+     rhoal = state(i,URHO) * alpha + 1.e-50_rt
+     if (c_v_exp_n .eq. 0.e0_rt) then
         temp(i) = temp(i) / rhoal
      else
-        teff = max(temp(i), 1.d-50)
-        temp(i) = ((1.d0 - c_v_exp_n) * teff / rhoal) ** ex
+        teff = max(temp(i), 1.e-50_rt)
+        temp(i) = ((1.e0_rt - c_v_exp_n) * teff / rhoal) ** ex
      endif
   end do
 
@@ -166,28 +170,29 @@ subroutine ca_compute_temp_given_reye(lo, hi, &
   use meth_params_module, only : NVAR, URHO, UFS, UFX, &
        small_temp, allow_negative_energy
   
+  use bl_fort_module, only : rt => c_real
   implicit none
   integer         , intent(in) :: lo(1), hi(1)
   integer         , intent(in) :: temp_l1, temp_h1
   integer         , intent(in) :: re_l1, re_h1
   integer         , intent(in) :: ye_l1, ye_h1
   integer         , intent(in) :: state_l1, state_h1
-  double precision, intent(in) :: state(state_l1:state_h1,NVAR)
-  double precision, intent(in) :: rhoe(re_l1:re_h1)
-  double precision, intent(in) :: ye(ye_l1:ye_h1)
-  double precision             :: temp(temp_l1:temp_h1)
+  real(rt)        , intent(in) :: state(state_l1:state_h1,NVAR)
+  real(rt)        , intent(in) :: rhoe(re_l1:re_h1)
+  real(rt)        , intent(in) :: ye(ye_l1:ye_h1)
+  real(rt)                     :: temp(temp_l1:temp_h1)
 
   integer          :: i
-  double precision :: rhoInv
+  real(rt)         :: rhoInv
   type (eos_t) :: eos_state
   
   do i = lo(1), hi(1)
 
-     if(allow_negative_energy.eq.0 .and. rhoe(i).le.0.d0) then
+     if(allow_negative_energy.eq.0 .and. rhoe(i).le.0.e0_rt) then
         temp(i) = small_temp
      else
 
-        rhoInv = 1.d0 / state(i,URHO)
+        rhoInv = 1.e0_rt / state(i,URHO)
         eos_state % rho = state(i,URHO)
         ! set initial guess of temperature
         eos_state % T = temp(i)
@@ -201,7 +206,7 @@ subroutine ca_compute_temp_given_reye(lo, hi, &
 
         temp(i) = eos_state % T
 
-        if(temp(i).lt.0.d0) then
+        if(temp(i).lt.0.e0_rt) then
            print*,'negative temp in compute_temp_given_reye ', temp(i)
            call bl_error("Error:: ca_compute_temp_given_reye")
         endif
@@ -223,6 +228,7 @@ subroutine ca_compute_reye_given_ty(lo, hi, &
   use eos_module
   use meth_params_module, only : NVAR, URHO, UFS, UFX
 
+  use bl_fort_module, only : rt => c_real
   implicit none
   integer         , intent(in) :: lo(1), hi(1)
   integer         , intent(in) :: re_l1, re_h1
@@ -230,19 +236,19 @@ subroutine ca_compute_reye_given_ty(lo, hi, &
   integer         , intent(in) :: temp_l1, temp_h1
   integer         , intent(in) :: ye_l1, ye_h1
   integer         , intent(in) :: state_l1, state_h1
-  double precision, intent(in) :: state(state_l1:state_h1,NVAR)
-  double precision             :: rhoe(re_l1:re_h1)
-  double precision             :: rhoY(rY_l1:rY_h1)
-  double precision, intent(in) :: ye(ye_l1:ye_h1)
-  double precision, intent(in) :: temp(temp_l1:temp_h1)
+  real(rt)        , intent(in) :: state(state_l1:state_h1,NVAR)
+  real(rt)                     :: rhoe(re_l1:re_h1)
+  real(rt)                     :: rhoY(rY_l1:rY_h1)
+  real(rt)        , intent(in) :: ye(ye_l1:ye_h1)
+  real(rt)        , intent(in) :: temp(temp_l1:temp_h1)
   
   integer          :: i
-  double precision :: rhoInv
+  real(rt)         :: rhoInv
   type (eos_t) :: eos_state
 
   do i = lo(1), hi(1)
 
-     rhoInv = 1.d0 / state(i,URHO)
+     rhoInv = 1.e0_rt / state(i,URHO)
      eos_state % rho = state(i,URHO)
      eos_state % T = temp(i)
      eos_state % xn  = state(i,UFS:UFS+nspec-1) * rhoInv

--- a/Source/Radiation/RadSrc_1d/RadPlotvar_1d.f90
+++ b/Source/Radiation/RadSrc_1d/RadPlotvar_1d.f90
@@ -6,6 +6,7 @@ subroutine ca_er_com2lab(lo, hi, &
      Elab, El_l1, El_h1, ier, npv)
   use meth_params_module, only : NVAR, URHO, UMX
   use rad_params_module, only : ngroups, clight, nnuspec, ng0, ng1, dlognu
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: lo(1), hi(1)
@@ -13,28 +14,28 @@ subroutine ca_er_com2lab(lo, hi, &
   integer, intent(in) :: Ec_l1, Ec_h1
   integer, intent(in) ::  F_l1,  F_h1, iflx, nflx
   integer, intent(in) :: El_l1, El_h1, ier, npv
-  double precision,intent(in)   ::Snew( S_l1: S_h1,NVAR)
-  double precision,intent(in)   ::Ecom(Ec_l1:Ec_h1,0:ngroups-1)
-  double precision,intent(in)   ::F   ( F_l1: F_h1,0:nflx-1)
-  double precision,intent(inout)::Elab(El_l1:El_h1,0:npv-1)
+  real(rt)        ,intent(in)   ::Snew( S_l1: S_h1,NVAR)
+  real(rt)        ,intent(in)   ::Ecom(Ec_l1:Ec_h1,0:ngroups-1)
+  real(rt)        ,intent(in)   ::F   ( F_l1: F_h1,0:nflx-1)
+  real(rt)        ,intent(inout)::Elab(El_l1:El_h1,0:npv-1)
 
   integer :: i, g, ifx
-  double precision :: rhoInv, c2, vxc2
-  double precision :: nufnux(-1:ngroups)
-  double precision :: dlognuInv(0:ngroups-1)
+  real(rt)         :: rhoInv, c2, vxc2
+  real(rt)         :: nufnux(-1:ngroups)
+  real(rt)         :: dlognuInv(0:ngroups-1)
 
   ifx = iflx
 
-  c2 = 1.d0/clight**2
+  c2 = 1.e0_rt/clight**2
 
-  if (ngroups > 1) dlognuInv = 1.d0/dlognu
+  if (ngroups > 1) dlognuInv = 1.e0_rt/dlognu
 
   do i = lo(1), hi(1)
-     rhoInv = 1.d0/Snew(i,URHO)
+     rhoInv = 1.e0_rt/Snew(i,URHO)
      vxc2 = Snew(i,UMX)*rhoInv*c2
      
      do g = 0, ngroups-1
-        Elab(i,g+ier) = Ecom(i,g) + 2.d0*vxc2*F(i,ifx+g)
+        Elab(i,g+ier) = Ecom(i,g) + 2.e0_rt*vxc2*F(i,ifx+g)
      end do
      
      if (ngroups > 1) then
@@ -46,7 +47,7 @@ subroutine ca_er_com2lab(lo, hi, &
            nufnux(-1) = -nufnux(0)
            nufnux(ngroups) = -nufnux(ngroups-1)
            do g=0,ngroups-1
-              Elab(i,g+ier) = Elab(i,g+ier) - vxc2*0.5d0*(nufnux(g+1)-nufnux(g-1))
+              Elab(i,g+ier) = Elab(i,g+ier) - vxc2*0.5e0_rt*(nufnux(g+1)-nufnux(g-1))
            end do
            
         else
@@ -57,7 +58,7 @@ subroutine ca_er_com2lab(lo, hi, &
            nufnux(-1) = -nufnux(0)
            nufnux(ng0) = -nufnux(ng0-1)
            do g=0,ng0-1
-              Elab(i,g+ier) = Elab(i,g+ier) - vxc2*0.5d0*(nufnux(g+1)-nufnux(g-1))
+              Elab(i,g+ier) = Elab(i,g+ier) - vxc2*0.5e0_rt*(nufnux(g+1)-nufnux(g-1))
            end do
            
            if (nnuspec >= 2) then
@@ -68,7 +69,7 @@ subroutine ca_er_com2lab(lo, hi, &
               nufnux(ng0-1) = -nufnux(ng0)
               nufnux(ng0+ng1) = -nufnux(ng0+ng1-1)
               do g=ng0,ng0+ng1-1
-                 Elab(i,g+ier) = Elab(i,g+ier) - vxc2*0.5d0*(nufnux(g+1)-nufnux(g-1))
+                 Elab(i,g+ier) = Elab(i,g+ier) - vxc2*0.5e0_rt*(nufnux(g+1)-nufnux(g-1))
               end do
               
            end if
@@ -81,7 +82,7 @@ subroutine ca_er_com2lab(lo, hi, &
               nufnux(ng0+ng1-1) = -nufnux(ng0+ng1)
               nufnux(ngroups) = -nufnux(ngroups-1)
               do g=ng0+ng1,ngroups-1
-                 Elab(i,g+ier) = Elab(i,g+ier) - vxc2*0.5d0*(nufnux(g+1)-nufnux(g-1))
+                 Elab(i,g+ier) = Elab(i,g+ier) - vxc2*0.5e0_rt*(nufnux(g+1)-nufnux(g-1))
               end do
               
            end if
@@ -98,20 +99,21 @@ subroutine ca_compute_fcc(lo, hi, &
      Eddf, Eddf_l1, Eddf_h1)
   use rad_params_module, only : ngroups
   use fluxlimiter_module, only : Edd_factor
+  use bl_fort_module, only : rt => c_real
   implicit none
   integer, intent(in) :: lo(1), hi(1)
   integer, intent(in) :: lamx_l1, lamx_h1, nlam
   integer, intent(in) :: Eddf_l1, Eddf_h1
-  double precision,intent(in   )::lamx(lamx_l1:lamx_h1,0:nlam-1)
-  double precision,intent(inout)::Eddf(Eddf_l1:Eddf_h1,0:ngroups-1)
+  real(rt)        ,intent(in   )::lamx(lamx_l1:lamx_h1,0:nlam-1)
+  real(rt)        ,intent(inout)::Eddf(Eddf_l1:Eddf_h1,0:ngroups-1)
 
   integer :: i, g, ilam
-  double precision :: lamcc
+  real(rt)         :: lamcc
 
   do g=0,ngroups-1
      ilam = min(g,nlam-1)
      do i = lo(1), hi(1)
-        lamcc = 0.5d0*(lamx(i,ilam)+lamx(i+1,ilam))
+        lamcc = 0.5e0_rt*(lamx(i,ilam)+lamx(i+1,ilam))
         Eddf(i,g) = Edd_factor(lamcc)
      end do
   end do
@@ -126,43 +128,44 @@ subroutine ca_transform_flux (lo, hi, flag, &
      Fo,   Fo_l1, Fo_h1, ifo, nfo)
   use meth_params_module, only : NVAR, URHO, UMX
   use rad_params_module, only : ngroups, nnuspec, ng0, ng1, dlognu
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: lo(1), hi(1)
-  double precision, intent(in) :: flag
+  real(rt)        , intent(in) :: flag
   integer, intent(in) ::  S_l1,  S_h1
   integer, intent(in) ::  f_l1,  f_h1
   integer, intent(in) :: Er_l1, Er_h1
   integer, intent(in) :: Fi_l1, Fi_h1, ifi, nfi
   integer, intent(in) :: Fo_l1, Fo_h1, ifo, nfo
-  double precision,intent(in   )::Snew( S_l1: S_h1,NVAR)
-  double precision,intent(in   )::   f( f_l1: f_h1,0:ngroups-1)
-  double precision,intent(in   )::  Er(Er_l1:Er_h1,0:ngroups-1)
-  double precision,intent(in   )::  Fi(Fi_l1:Fi_h1,0:nfi-1)
-  double precision,intent(inout)::  Fo(Fo_l1:Fo_h1,0:nfo-1)
+  real(rt)        ,intent(in   )::Snew( S_l1: S_h1,NVAR)
+  real(rt)        ,intent(in   )::   f( f_l1: f_h1,0:ngroups-1)
+  real(rt)        ,intent(in   )::  Er(Er_l1:Er_h1,0:ngroups-1)
+  real(rt)        ,intent(in   )::  Fi(Fi_l1:Fi_h1,0:nfi-1)
+  real(rt)        ,intent(inout)::  Fo(Fo_l1:Fo_h1,0:nfo-1)
 
   integer :: i, g, ifix, ifox
-  double precision :: rhoInv,  vx, f1, f2, nx, foo, vdotn
-  double precision :: nuvpnux(-1:ngroups)
-  double precision :: dlognuInv(0:ngroups-1)
-  double precision :: vdotpx(0:ngroups-1)
+  real(rt)         :: rhoInv,  vx, f1, f2, nx, foo, vdotn
+  real(rt)         :: nuvpnux(-1:ngroups)
+  real(rt)         :: dlognuInv(0:ngroups-1)
+  real(rt)         :: vdotpx(0:ngroups-1)
 
   ifix = ifi
   ifox = ifo
 
-  if (ngroups > 1) dlognuInv = 1.d0/dlognu
+  if (ngroups > 1) dlognuInv = 1.e0_rt/dlognu
 
   do i = lo(1), hi(1)
-     rhoInv = 1.d0/Snew(i,URHO)
+     rhoInv = 1.e0_rt/Snew(i,URHO)
      vx = Snew(i,UMX)*rhoInv*flag
 
      do g = 0, ngroups-1
-        f1 = (1.d0-f(i,g))
-        f2 = (3.d0*f(i,g)-1.d0)
-        foo = 1.d0/abs(Fi(i,ifix+g)+1.d-50)
+        f1 = (1.e0_rt-f(i,g))
+        f2 = (3.e0_rt*f(i,g)-1.e0_rt)
+        foo = 1.e0_rt/abs(Fi(i,ifix+g)+1.e-50_rt)
         nx = Fi(i,ifix+g)*foo
         vdotn = vx*nx
-        vdotpx(g) = 0.5d0*Er(i,g)*(f1*vx + f2*vdotn*nx)
+        vdotpx(g) = 0.5e0_rt*Er(i,g)*(f1*vx + f2*vdotn*nx)
         Fo(i,ifox+g) = Fi(i,ifix+g) + vx*Er(i,g) + vdotpx(g)
      end do
 
@@ -175,7 +178,7 @@ subroutine ca_transform_flux (lo, hi, flag, &
            nuvpnux(-1) = -nuvpnux(0)
            nuvpnux(ngroups) = -nuvpnux(ngroups-1)
            do g=0,ngroups-1
-              Fo(i,ifox+g) = Fo(i,ifox+g) - 0.5d0*(nuvpnux(g+1)-nuvpnux(g-1))
+              Fo(i,ifox+g) = Fo(i,ifox+g) - 0.5e0_rt*(nuvpnux(g+1)-nuvpnux(g-1))
            end do
 
         else
@@ -186,7 +189,7 @@ subroutine ca_transform_flux (lo, hi, flag, &
            nuvpnux(-1) = -nuvpnux(0)
            nuvpnux(ng0) = -nuvpnux(ng0-1)
            do g=0,ng0-1
-              Fo(i,ifox+g) = Fo(i,ifox+g) - 0.5d0*(nuvpnux(g+1)-nuvpnux(g-1))
+              Fo(i,ifox+g) = Fo(i,ifox+g) - 0.5e0_rt*(nuvpnux(g+1)-nuvpnux(g-1))
            end do
 
            if (nnuspec >= 2) then
@@ -197,7 +200,7 @@ subroutine ca_transform_flux (lo, hi, flag, &
               nuvpnux(ng0-1) = -nuvpnux(ng0)
               nuvpnux(ng0+ng1) = -nuvpnux(ng0+ng1-1)
               do g=ng0,ng0+ng1-1
-                 Fo(i,ifox+g) = Fo(i,ifox+g) - 0.5d0*(nuvpnux(g+1)-nuvpnux(g-1))
+                 Fo(i,ifox+g) = Fo(i,ifox+g) - 0.5e0_rt*(nuvpnux(g+1)-nuvpnux(g-1))
               end do
 
            end if
@@ -210,7 +213,7 @@ subroutine ca_transform_flux (lo, hi, flag, &
               nuvpnux(ng0+ng1-1) = -nuvpnux(ng0+ng1)
               nuvpnux(ngroups) = -nuvpnux(ngroups-1)
               do g=ng0+ng1,ngroups-1
-                 Fo(i,ifox+g) = Fo(i,ifox+g) - 0.5d0*(nuvpnux(g+1)-nuvpnux(g-1))
+                 Fo(i,ifox+g) = Fo(i,ifox+g) - 0.5e0_rt*(nuvpnux(g+1)-nuvpnux(g-1))
               end do
 
            end if

--- a/Source/Radiation/RadSrc_1d/filt_prim_1d.f90
+++ b/Source/Radiation/RadSrc_1d/filt_prim_1d.f90
@@ -11,22 +11,23 @@ subroutine ca_filt_prim(lo, hi, &
        small_temp, small_dens, nadv
   use filter_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: lo(1), hi(1), domlo(1), domhi(1), level
   integer, intent(in) :: filt_T, S
-  double precision, intent(in) :: delta(1), xlo(1), problo(1), time
+  real(rt)        , intent(in) :: delta(1), xlo(1), problo(1), time
   integer, intent(in) ::   Stmp_l1,Stmp_h1
   integer, intent(in) ::   Snew_l1,Snew_h1
   integer, intent(in) ::   mask_l1,mask_h1
-  double precision :: Stmp(Stmp_l1:Stmp_h1,NVAR)
-  double precision :: Snew(Snew_l1:Snew_h1,NVAR)
-  double precision :: mask(mask_l1:mask_h1)
-  ! mask has three possible values: -1.d0, 0.d0, and 1.d0.
-  ! -1.d0 appears only in cells that are covered by neither this level nor the finer level.
+  real(rt)         :: Stmp(Stmp_l1:Stmp_h1,NVAR)
+  real(rt)         :: Snew(Snew_l1:Snew_h1,NVAR)
+  real(rt)         :: mask(mask_l1:mask_h1)
+  ! mask has three possible values: -1.e0_rt, 0.e0_rt, and 1.e0_rt.
+  ! -1.e0_rt appears only in cells that are covered by neither this level nor the finer level.
   !       It can only appear in ghost cells. 
-  !  0.d0 appears only in cells that are covered by only this level, but not the finer level.
-  !  1.d0 appears only in cells that are covered by the finer level.
+  !  0.e0_rt appears only in cells that are covered by only this level, but not the finer level.
+  !  1.e0_rt appears only in cells that are covered by the finer level.
   !       It can appear in either valid cells or ghost cells. 
 
 

--- a/Source/Radiation/RadSrc_1d/trace_ppm_rad_1d.f90
+++ b/Source/Radiation/RadSrc_1d/trace_ppm_rad_1d.f90
@@ -3,6 +3,7 @@
 
 module trace_ppm_rad_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   private
@@ -29,6 +30,7 @@ contains
     use rad_params_module, only : ngroups
     use ppm_module, only : ppm
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer ilo,ihi
@@ -37,21 +39,21 @@ contains
     integer dloga_l1,dloga_h1
     integer   qpd_l1,  qpd_h1
     integer   src_l1,  src_h1
-    double precision dx, dt
-    double precision     q( qd_l1: qd_h1, NQ)
-    double precision :: qaux(qd_l1:qd_h1, NQAUX)
-    double precision flatn(qd_l1:qd_h1)
-    double precision  srcQ(src_l1:src_h1,QVAR)
-    double precision dloga(dloga_l1:dloga_h1)
+    real(rt)         dx, dt
+    real(rt)             q( qd_l1: qd_h1, NQ)
+    real(rt)         :: qaux(qd_l1:qd_h1, NQAUX)
+    real(rt)         flatn(qd_l1:qd_h1)
+    real(rt)          srcQ(src_l1:src_h1,QVAR)
+    real(rt)         dloga(dloga_l1:dloga_h1)
 
-    double precision  qxm( qpd_l1: qpd_h1, NQ)
-    double precision  qxp( qpd_l1: qpd_h1, NQ)
+    real(rt)          qxm( qpd_l1: qpd_h1, NQ)
+    real(rt)          qxp( qpd_l1: qpd_h1, NQ)
 
     ! Local variables
     integer :: i, g
     integer :: n, ipassive
 
-    double precision :: hdt,dtdx
+    real(rt)         :: hdt,dtdx
 
     ! To allow for easy integration of radiation, we adopt the
     ! following conventions:
@@ -71,39 +73,39 @@ contains
     ! for pure hydro, we will only consider:
     !   rho, u, v, w, ptot, rhoe_g, cc, h_g
 
-    double precision :: cc, csq, cgassq, Clag
-    double precision :: rho, u, p, rhoe_g, h_g, tau
-    double precision :: ptot, gam_g, game
+    real(rt)         :: cc, csq, cgassq, Clag
+    real(rt)         :: rho, u, p, rhoe_g, h_g, tau
+    real(rt)         :: ptot, gam_g, game
 
-    double precision :: drho, dptot, drhoe_g
-    double precision :: dge, dtau
-    double precision :: dup, dptotp
-    double precision :: dum, dptotm
+    real(rt)         :: drho, dptot, drhoe_g
+    real(rt)         :: dge, dtau
+    real(rt)         :: dup, dptotp
+    real(rt)         :: dum, dptotm
 
-    double precision :: rho_ref, u_ref, p_ref, rhoe_g_ref, h_g_ref
-    double precision :: ptot_ref
-    double precision :: tau_ref
+    real(rt)         :: rho_ref, u_ref, p_ref, rhoe_g_ref, h_g_ref
+    real(rt)         :: ptot_ref
+    real(rt)         :: tau_ref
 
-    double precision :: gam_g_ref, game_ref, gfactor
+    real(rt)         :: gam_g_ref, game_ref, gfactor
 
-    double precision :: alpham, alphap, alpha0r, alpha0e_g
-    double precision :: sourcr, sourcp, source, courn, eta, dlogatmp
+    real(rt)         :: alpham, alphap, alpha0r, alpha0e_g
+    real(rt)         :: sourcr, sourcp, source, courn, eta, dlogatmp
 
-    double precision :: tau_s
+    real(rt)         :: tau_s
 
     logical :: fix_mass_flux_lo, fix_mass_flux_hi
 
-    double precision, dimension(0:ngroups-1) :: er, der, alphar, sourcer, qrtmp, hr
-    double precision, dimension(0:ngroups-1) :: lam0, lamp, lamm
+    real(rt)        , dimension(0:ngroups-1) :: er, der, alphar, sourcer, qrtmp, hr
+    real(rt)        , dimension(0:ngroups-1) :: lam0, lamp, lamm
 
-    double precision, dimension(0:ngroups-1) :: er_ref
-    double precision :: er_foo
+    real(rt)        , dimension(0:ngroups-1) :: er_ref
+    real(rt)         :: er_foo
 
-    double precision, allocatable :: Ip(:,:,:)
-    double precision, allocatable :: Im(:,:,:)
+    real(rt)        , allocatable :: Ip(:,:,:)
+    real(rt)        , allocatable :: Im(:,:,:)
 
-    double precision, allocatable :: Ip_src(:,:,:)
-    double precision, allocatable :: Im_src(:,:,:)
+    real(rt)        , allocatable :: Ip_src(:,:,:)
+    real(rt)        , allocatable :: Im_src(:,:,:)
 
 
     fix_mass_flux_lo = (fix_mass_flux == 1) .and. (physbc_lo(1) == Outflow) &
@@ -213,7 +215,7 @@ contains
        ptot = q(i,qptot)
 
        er(:) = q(i,qrad:qradhi)
-       hr(:) = (lam0+1.d0)*er/rho
+       hr(:) = (lam0+1.e0_rt)*er/rho
 
        Clag = rho*cc
 

--- a/Source/Radiation/RadSrc_2d/CastroRad_2d.f90
+++ b/Source/Radiation/RadSrc_2d/CastroRad_2d.f90
@@ -8,22 +8,23 @@ subroutine ca_compute_lamborder(Er, Er_l1, Er_l2, Er_h1, Er_h2, &
   use fluxlimiter_module, only : FLDlambda
   use filter_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: Er_l1, Er_l2, Er_h1, Er_h2, kap_l1, kap_l2, kap_h1, kap_h2, &
        lam_l1, lam_l2, lam_h1, lam_h2
   integer, intent(in) :: ngrow, limiter, filter_T, S
-  double precision, intent(in) :: dx(2)
-  double precision, intent(in) :: kap(kap_l1:kap_h1, kap_l2:kap_h2)
-  double precision, intent(in) :: Er(Er_l1:Er_h1, Er_l2:Er_h2, 0:ngroups-1)
-  double precision, intent(out) :: lam(lam_l1:lam_h1, lam_l2:lam_h2, 0:ngroups-1)
+  real(rt)        , intent(in) :: dx(2)
+  real(rt)        , intent(in) :: kap(kap_l1:kap_h1, kap_l2:kap_h2)
+  real(rt)        , intent(in) :: Er(Er_l1:Er_h1, Er_l2:Er_h2, 0:ngroups-1)
+  real(rt)        , intent(out) :: lam(lam_l1:lam_h1, lam_l2:lam_h2, 0:ngroups-1)
 
   integer :: i, j, reg_l1, reg_l2, reg_h1, reg_h2, g
-  double precision :: r, r1, r2
+  real(rt)         :: r, r1, r2
 
-  double precision, allocatable :: lamfil(:,:)
+  real(rt)        , allocatable :: lamfil(:,:)
 
-  lam = -1.d50
+  lam = -1.e50_rt
 
   reg_l1 = lam_l1 + ngrow
   reg_l2 = lam_l2 + ngrow
@@ -38,28 +39,28 @@ subroutine ca_compute_lamborder(Er, Er_l1, Er_l2, Er_h1, Er_h2, &
 
   do j=lam_l2, lam_h2
      do i=lam_l1, lam_h1
-        if (Er(i,j,g) .eq. -1.d0) then
+        if (Er(i,j,g) .eq. -1.e0_rt) then
            cycle
         end if
 
-        if (Er(i-1,j,g) .eq. -1.d0) then
+        if (Er(i-1,j,g) .eq. -1.e0_rt) then
            r1 = (Er(i+1,j,g) - Er(i,j,g)) / (dx(1))
-        else if (Er(i+1,j,g) .eq. -1.d0) then
+        else if (Er(i+1,j,g) .eq. -1.e0_rt) then
            r1 = (Er(i,j,g) - Er(i-1,j,g)) / (dx(1))
         else
-           r1 = (Er(i+1,j,g) - Er(i-1,j,g)) / (2.d0*dx(1))
+           r1 = (Er(i+1,j,g) - Er(i-1,j,g)) / (2.e0_rt*dx(1))
         end if
 
-        if (Er(i,j-1,g) .eq. -1.d0) then
+        if (Er(i,j-1,g) .eq. -1.e0_rt) then
            r2 = (Er(i,j+1,g) - Er(i,j,g)) / (dx(2))
-        else if (Er(i,j+1,g) .eq. -1.d0) then
+        else if (Er(i,j+1,g) .eq. -1.e0_rt) then
            r2 = (Er(i,j,g) - Er(i,j-1,g)) / (dx(2))
         else
-           r2 = (Er(i,j+1,g) - Er(i,j-1,g)) / (2.d0*dx(2))
+           r2 = (Er(i,j+1,g) - Er(i,j-1,g)) / (2.e0_rt*dx(2))
         end if
 
         r = sqrt(r1**2 + r2**2)
-        r = r / (kap(i,j) * max(Er(i,j,g), 1.d-50))
+        r = r / (kap(i,j) * max(Er(i,j,g), 1.e-50_rt))
 
         lam(i,j,g) = FLDlambda(r, limiter)
      end do
@@ -69,8 +70,8 @@ subroutine ca_compute_lamborder(Er, Er_l1, Er_l2, Er_h1, Er_h2, &
   if (filter_T .eq. 1) then
 
      do j=lam_l2, lam_h2
-        if (Er(reg_l1,j,g) .eq. -1.d0) then
-           lamfil(:,j) = -1.d-50
+        if (Er(reg_l1,j,g) .eq. -1.e0_rt) then
+           lamfil(:,j) = -1.e-50_rt
            cycle
         endif
 
@@ -79,12 +80,12 @@ subroutine ca_compute_lamborder(Er, Er_l1, Er_l2, Er_h1, Er_h2, &
                 &      + ff1(1) * (lam(i-1,j,g)+lam(i+1,j,g))
         end do
 
-        if (Er(reg_l1-1,j,g) .eq. -1.d0) then
+        if (Er(reg_l1-1,j,g) .eq. -1.e0_rt) then
             i = reg_l1
             lamfil(i,j) = dot_product(ff1b, lam(i:i+1,j,g))
          end if
 
-         if (Er(reg_h1+1,j,g) .eq. -1.d0) then
+         if (Er(reg_h1+1,j,g) .eq. -1.e0_rt) then
             i = reg_h1
             lamfil(i,j) = dot_product(ff1b(1:0:-1), lam(i-1:i,j,g))
          end if
@@ -94,31 +95,31 @@ subroutine ca_compute_lamborder(Er, Er_l1, Er_l2, Er_h1, Er_h2, &
         do i=reg_l1, reg_h1
            lam(i,j,g) = ff1(0) * lamfil(i,j) &
                 &     + ff1(1) * (lamfil(i,j-1)+lamfil(i,j+1))
-           lam(i,j,g) = min(1.d0/3.d0, max(1.d-25, lam(i,j,g)))
+           lam(i,j,g) = min(1.e0_rt/3.e0_rt, max(1.e-25_rt, lam(i,j,g)))
         end do
      end do
 
-     if (Er(reg_l1,reg_l2-1,g) .eq. -1.d0) then
+     if (Er(reg_l1,reg_l2-1,g) .eq. -1.e0_rt) then
         j = reg_l2
         do i=reg_l1,reg_h1
            lam(i,j,g) = dot_product(ff1b, lamfil(i,j:j+1))
-           lam(i,j,g) = min(1.d0/3.d0, max(1.d-25, lam(i,j,g)))
+           lam(i,j,g) = min(1.e0_rt/3.e0_rt, max(1.e-25_rt, lam(i,j,g)))
         end do
      end if
 
-     if (Er(reg_l1,reg_h2+1,g) .eq. -1.d0) then
+     if (Er(reg_l1,reg_h2+1,g) .eq. -1.e0_rt) then
         j = reg_h2
         do i=reg_l1,reg_h1
            lam(i,j,g) = dot_product(ff1b(1:0:-1), lamfil(i,j-1:j))
-           lam(i,j,g) = min(1.d0/3.d0, max(1.d-25, lam(i,j,g)))
+           lam(i,j,g) = min(1.e0_rt/3.e0_rt, max(1.e-25_rt, lam(i,j,g)))
         end do
      end if
 
   else if (filter_T .eq. 2) then
 
      do j=lam_l2, lam_h2
-        if (Er(reg_l1,j,g) .eq. -1.d0) then
-           lamfil(:,j) = -1.d-50
+        if (Er(reg_l1,j,g) .eq. -1.e0_rt) then
+           lamfil(:,j) = -1.e-50_rt
            cycle
         endif
 
@@ -128,7 +129,7 @@ subroutine ca_compute_lamborder(Er, Er_l1, Er_l2, Er_h1, Er_h2, &
                 &      + ff2(2,S) * (lam(i-2,j,g)+lam(i+2,j,g))
         end do
 
-        if (Er(reg_l1-1,j,g) .eq. -1.d0) then
+        if (Er(reg_l1-1,j,g) .eq. -1.e0_rt) then
             i = reg_l1
             lamfil(i,j) = dot_product(ff2b0, lam(i:i+2,j,g))
 
@@ -136,7 +137,7 @@ subroutine ca_compute_lamborder(Er, Er_l1, Er_l2, Er_h1, Er_h2, &
             lamfil(i,j) = dot_product(ff2b1, lam(i-1:i+2,j,g))
          end if
 
-         if (Er(reg_h1+1,j,g) .eq. -1.d0) then
+         if (Er(reg_h1+1,j,g) .eq. -1.e0_rt) then
             i = reg_h1 - 1
             lamfil(i,j) = dot_product(ff2b1(2:-1:-1), lam(i-2:i+1,j,g))
 
@@ -150,43 +151,43 @@ subroutine ca_compute_lamborder(Er, Er_l1, Er_l2, Er_h1, Er_h2, &
            lam(i,j,g) = ff2(0,S) * lamfil(i,j) &
                 &     + ff2(1,S) * (lamfil(i,j-1)+lamfil(i,j+1)) &
                 &     + ff2(2,S) * (lamfil(i,j-2)+lamfil(i,j+2))
-           lam(i,j,g) = min(1.d0/3.d0, max(1.d-25, lam(i,j,g)))
+           lam(i,j,g) = min(1.e0_rt/3.e0_rt, max(1.e-25_rt, lam(i,j,g)))
         end do
      end do
 
-     if (Er(reg_l1,reg_l2-1,g) .eq. -1.d0) then
+     if (Er(reg_l1,reg_l2-1,g) .eq. -1.e0_rt) then
         j = reg_l2
         do i=reg_l1,reg_h1
            lam(i,j,g) = dot_product(ff2b0, lamfil(i,j:j+2))
-           lam(i,j,g) = min(1.d0/3.d0, max(1.d-25, lam(i,j,g)))
+           lam(i,j,g) = min(1.e0_rt/3.e0_rt, max(1.e-25_rt, lam(i,j,g)))
         end do
 
         j = reg_l2 + 1
         do i=reg_l1,reg_h1
            lam(i,j,g) = dot_product(ff2b1, lamfil(i,j-1:j+2))
-           lam(i,j,g) = min(1.d0/3.d0, max(1.d-25, lam(i,j,g)))
+           lam(i,j,g) = min(1.e0_rt/3.e0_rt, max(1.e-25_rt, lam(i,j,g)))
         end do
      end if
 
-     if (Er(reg_l1,reg_h2+1,g) .eq. -1.d0) then
+     if (Er(reg_l1,reg_h2+1,g) .eq. -1.e0_rt) then
         j = reg_h2 - 1
         do i=reg_l1,reg_h1
            lam(i,j,g) = dot_product(ff2b1(2:-1:-1), lamfil(i,j-2:j+1))
-           lam(i,j,g) = min(1.d0/3.d0, max(1.d-25, lam(i,j,g)))
+           lam(i,j,g) = min(1.e0_rt/3.e0_rt, max(1.e-25_rt, lam(i,j,g)))
         end do
 
         j = reg_h2
         do i=reg_l1,reg_h1
            lam(i,j,g) = dot_product(ff2b0(2:0:-1), lamfil(i,j-2:j))
-           lam(i,j,g) = min(1.d0/3.d0, max(1.d-25, lam(i,j,g)))
+           lam(i,j,g) = min(1.e0_rt/3.e0_rt, max(1.e-25_rt, lam(i,j,g)))
         end do
      end if
 
   else if (filter_T .eq. 3) then
 
      do j=lam_l2, lam_h2
-        if (Er(reg_l1,j,g) .eq. -1.d0) then
-           lamfil(:,j) = -1.d-50
+        if (Er(reg_l1,j,g) .eq. -1.e0_rt) then
+           lamfil(:,j) = -1.e-50_rt
            cycle
         endif
 
@@ -197,7 +198,7 @@ subroutine ca_compute_lamborder(Er, Er_l1, Er_l2, Er_h1, Er_h2, &
                 &      + ff3(3,S) * (lam(i-3,j,g)+lam(i+3,j,g))
         end do
 
-        if (Er(reg_l1-1,j,g) .eq. -1.d0) then
+        if (Er(reg_l1-1,j,g) .eq. -1.e0_rt) then
             i = reg_l1
             lamfil(i,j) = dot_product(ff3b0, lam(i:i+3,j,g))
 
@@ -208,7 +209,7 @@ subroutine ca_compute_lamborder(Er, Er_l1, Er_l2, Er_h1, Er_h2, &
             lamfil(i,j) = dot_product(ff3b2, lam(i-2:i+3,j,g))
          end if
 
-         if (Er(reg_h1+1,j,g) .eq. -1.d0) then
+         if (Er(reg_h1+1,j,g) .eq. -1.e0_rt) then
             i = reg_h1 - 2
             lamfil(i,j) = dot_product(ff3b2(3:-2:-1), lam(i-3:i+2,j,g))
 
@@ -226,55 +227,55 @@ subroutine ca_compute_lamborder(Er, Er_l1, Er_l2, Er_h1, Er_h2, &
                 &     + ff3(1,S) * (lamfil(i,j-1)+lamfil(i,j+1)) &
                 &     + ff3(2,S) * (lamfil(i,j-2)+lamfil(i,j+2)) &
                 &     + ff3(3,S) * (lamfil(i,j-3)+lamfil(i,j+3))
-           lam(i,j,g) = min(1.d0/3.d0, max(1.d-25, lam(i,j,g)))
+           lam(i,j,g) = min(1.e0_rt/3.e0_rt, max(1.e-25_rt, lam(i,j,g)))
         end do
      end do
 
-     if (Er(reg_l1,reg_l2-1,g) .eq. -1.d0) then
+     if (Er(reg_l1,reg_l2-1,g) .eq. -1.e0_rt) then
         j = reg_l2
         do i=reg_l1,reg_h1
            lam(i,j,g) = dot_product(ff3b0, lamfil(i,j:j+3))
-           lam(i,j,g) = min(1.d0/3.d0, max(1.d-25, lam(i,j,g)))
+           lam(i,j,g) = min(1.e0_rt/3.e0_rt, max(1.e-25_rt, lam(i,j,g)))
         end do
 
         j = reg_l2 + 1
         do i=reg_l1,reg_h1
            lam(i,j,g) = dot_product(ff3b1, lamfil(i,j-1:j+3))
-           lam(i,j,g) = min(1.d0/3.d0, max(1.d-25, lam(i,j,g)))
+           lam(i,j,g) = min(1.e0_rt/3.e0_rt, max(1.e-25_rt, lam(i,j,g)))
         end do
 
         j = reg_l2 + 2
         do i=reg_l1,reg_h1
            lam(i,j,g) = dot_product(ff3b2, lamfil(i,j-2:j+3))
-           lam(i,j,g) = min(1.d0/3.d0, max(1.d-25, lam(i,j,g)))
+           lam(i,j,g) = min(1.e0_rt/3.e0_rt, max(1.e-25_rt, lam(i,j,g)))
         end do
      end if
 
-     if (Er(reg_l1,reg_h2+1,g) .eq. -1.d0) then
+     if (Er(reg_l1,reg_h2+1,g) .eq. -1.e0_rt) then
         j = reg_h2 - 2
         do i=reg_l1,reg_h1
            lam(i,j,g) = dot_product(ff3b2(3:-2:-1), lamfil(i,j-3:j+2))
-           lam(i,j,g) = min(1.d0/3.d0, max(1.d-25, lam(i,j,g)))
+           lam(i,j,g) = min(1.e0_rt/3.e0_rt, max(1.e-25_rt, lam(i,j,g)))
         end do
 
         j = reg_h2 - 1
         do i=reg_l1,reg_h1
            lam(i,j,g) = dot_product(ff3b1(3:-1:-1), lamfil(i,j-3:j+1))
-           lam(i,j,g) = min(1.d0/3.d0, max(1.d-25, lam(i,j,g)))
+           lam(i,j,g) = min(1.e0_rt/3.e0_rt, max(1.e-25_rt, lam(i,j,g)))
         end do
 
         j = reg_h2
         do i=reg_l1,reg_h1
            lam(i,j,g) = dot_product(ff3b0(3:0:-1), lamfil(i,j-3:j))
-           lam(i,j,g) = min(1.d0/3.d0, max(1.d-25, lam(i,j,g)))
+           lam(i,j,g) = min(1.e0_rt/3.e0_rt, max(1.e-25_rt, lam(i,j,g)))
         end do
      end if
 
   else if (filter_T .eq. 4) then
 
      do j=lam_l2, lam_h2
-        if (Er(reg_l1,j,g) .eq. -1.d0) then
-           lamfil(:,j) = -1.d-50
+        if (Er(reg_l1,j,g) .eq. -1.e0_rt) then
+           lamfil(:,j) = -1.e-50_rt
            cycle
         endif
 
@@ -286,7 +287,7 @@ subroutine ca_compute_lamborder(Er, Er_l1, Er_l2, Er_h1, Er_h2, &
                 &      + ff4(4,S) * (lam(i-4,j,g)+lam(i+4,j,g))
         end do
 
-        if (Er(reg_l1-1,j,g) .eq. -1.d0) then
+        if (Er(reg_l1-1,j,g) .eq. -1.e0_rt) then
             i = reg_l1
             lamfil(i,j) = dot_product(ff4b0, lam(i:i+4,j,g))
 
@@ -300,7 +301,7 @@ subroutine ca_compute_lamborder(Er, Er_l1, Er_l2, Er_h1, Er_h2, &
             lamfil(i,j) = dot_product(ff4b3, lam(i-3:i+4,j,g))
          end if
 
-         if (Er(reg_h1+1,j,g) .eq. -1.d0) then
+         if (Er(reg_h1+1,j,g) .eq. -1.e0_rt) then
             i = reg_h1 - 3
             lamfil(i,j) = dot_product(ff4b3(4:-3:-1), lam(i-4:i+3,j,g))
 
@@ -322,59 +323,59 @@ subroutine ca_compute_lamborder(Er, Er_l1, Er_l2, Er_h1, Er_h2, &
                 &     + ff4(2,S) * (lamfil(i,j-2)+lamfil(i,j+2)) &
                 &     + ff4(3,S) * (lamfil(i,j-3)+lamfil(i,j+3)) &
                 &     + ff4(4,S) * (lamfil(i,j-4)+lamfil(i,j+4))
-           lam(i,j,g) = min(1.d0/3.d0, max(1.d-25, lam(i,j,g)))
+           lam(i,j,g) = min(1.e0_rt/3.e0_rt, max(1.e-25_rt, lam(i,j,g)))
         end do
      end do
 
-     if (Er(reg_l1,reg_l2-1,g) .eq. -1.d0) then
+     if (Er(reg_l1,reg_l2-1,g) .eq. -1.e0_rt) then
         j = reg_l2
         do i=reg_l1,reg_h1
            lam(i,j,g) = dot_product(ff4b0, lamfil(i,j:j+4))
-           lam(i,j,g) = min(1.d0/3.d0, max(1.d-25, lam(i,j,g)))
+           lam(i,j,g) = min(1.e0_rt/3.e0_rt, max(1.e-25_rt, lam(i,j,g)))
         end do
 
         j = reg_l2 + 1
         do i=reg_l1,reg_h1
            lam(i,j,g) = dot_product(ff4b1, lamfil(i,j-1:j+4))
-           lam(i,j,g) = min(1.d0/3.d0, max(1.d-25, lam(i,j,g)))
+           lam(i,j,g) = min(1.e0_rt/3.e0_rt, max(1.e-25_rt, lam(i,j,g)))
         end do
 
         j = reg_l2 + 2
         do i=reg_l1,reg_h1
            lam(i,j,g) = dot_product(ff4b2, lamfil(i,j-2:j+4))
-           lam(i,j,g) = min(1.d0/3.d0, max(1.d-25, lam(i,j,g)))
+           lam(i,j,g) = min(1.e0_rt/3.e0_rt, max(1.e-25_rt, lam(i,j,g)))
         end do
 
         j = reg_l2 + 3
         do i=reg_l1,reg_h1
            lam(i,j,g) = dot_product(ff4b3, lamfil(i,j-3:j+4))
-           lam(i,j,g) = min(1.d0/3.d0, max(1.d-25, lam(i,j,g)))
+           lam(i,j,g) = min(1.e0_rt/3.e0_rt, max(1.e-25_rt, lam(i,j,g)))
         end do
      end if
 
-     if (Er(reg_l1,reg_h2+1,g) .eq. -1.d0) then
+     if (Er(reg_l1,reg_h2+1,g) .eq. -1.e0_rt) then
         j = reg_h2 - 3
         do i=reg_l1,reg_h1
            lam(i,j,g) = dot_product(ff4b3(4:-3:-1), lamfil(i,j-4:j+3))
-           lam(i,j,g) = min(1.d0/3.d0, max(1.d-25, lam(i,j,g)))
+           lam(i,j,g) = min(1.e0_rt/3.e0_rt, max(1.e-25_rt, lam(i,j,g)))
         end do
 
         j = reg_h2 - 2
         do i=reg_l1,reg_h1
            lam(i,j,g) = dot_product(ff4b2(4:-2:-1), lamfil(i,j-4:j+2))
-           lam(i,j,g) = min(1.d0/3.d0, max(1.d-25, lam(i,j,g)))
+           lam(i,j,g) = min(1.e0_rt/3.e0_rt, max(1.e-25_rt, lam(i,j,g)))
         end do
 
         j = reg_h2 - 1
         do i=reg_l1,reg_h1
            lam(i,j,g) = dot_product(ff4b1(4:-1:-1), lamfil(i,j-4:j+1))
-           lam(i,j,g) = min(1.d0/3.d0, max(1.d-25, lam(i,j,g)))
+           lam(i,j,g) = min(1.e0_rt/3.e0_rt, max(1.e-25_rt, lam(i,j,g)))
         end do
 
         j = reg_h2
         do i=reg_l1,reg_h1
            lam(i,j,g) = dot_product(ff4b0(4:0:-1), lamfil(i,j-4:j))
-           lam(i,j,g) = min(1.d0/3.d0, max(1.d-25, lam(i,j,g)))
+           lam(i,j,g) = min(1.e0_rt/3.e0_rt, max(1.e-25_rt, lam(i,j,g)))
         end do
      end if
 
@@ -383,7 +384,7 @@ subroutine ca_compute_lamborder(Er, Er_l1, Er_l2, Er_h1, Er_h2, &
   ! lo-x lo-y
   do j=lam_l2,reg_l2-1
      do i=lam_l1,reg_l1-1
-        if (Er(i,j,g).eq.-1.d0) then
+        if (Er(i,j,g).eq.-1.e0_rt) then
            lam(i,j,g) = lam(reg_l1,reg_l2,g)
         end if
      end do
@@ -392,7 +393,7 @@ subroutine ca_compute_lamborder(Er, Er_l1, Er_l2, Er_h1, Er_h2, &
   ! reg-x lo-y
   do j=lam_l2,reg_l2-1
      do i=reg_l1,reg_h1
-        if (Er(i,j,g).eq.-1.d0) then
+        if (Er(i,j,g).eq.-1.e0_rt) then
            lam(i,j,g) = lam(i,reg_l2,g)
         end if
      end do
@@ -401,7 +402,7 @@ subroutine ca_compute_lamborder(Er, Er_l1, Er_l2, Er_h1, Er_h2, &
   ! hi-x lo-y
   do j=lam_l2,reg_l2-1
      do i=reg_h1+1,lam_h1
-        if (Er(i,j,g).eq.-1.d0) then
+        if (Er(i,j,g).eq.-1.e0_rt) then
            lam(i,j,g) = lam(reg_h1,reg_l2,g)
         end if
      end do
@@ -410,7 +411,7 @@ subroutine ca_compute_lamborder(Er, Er_l1, Er_l2, Er_h1, Er_h2, &
   ! lo-x reg-y
   do j=reg_l2,reg_h2
      do i=lam_l1,reg_l1-1
-        if (Er(i,j,g).eq.-1.d0) then
+        if (Er(i,j,g).eq.-1.e0_rt) then
            lam(i,j,g) = lam(reg_l1,j,g)
         end if
      end do
@@ -419,7 +420,7 @@ subroutine ca_compute_lamborder(Er, Er_l1, Er_l2, Er_h1, Er_h2, &
   ! hi-x reg-y
   do j=reg_l2,reg_h2
      do i=reg_h1+1,lam_h1
-        if (Er(i,j,g).eq.-1.d0) then
+        if (Er(i,j,g).eq.-1.e0_rt) then
            lam(i,j,g) = lam(reg_h1,j,g)
         end if
      end do
@@ -428,7 +429,7 @@ subroutine ca_compute_lamborder(Er, Er_l1, Er_l2, Er_h1, Er_h2, &
   ! lo-x hi-y
   do j=reg_h2+1,lam_h2
      do i=lam_l1,reg_l1-1
-        if (Er(i,j,g).eq.-1.d0) then
+        if (Er(i,j,g).eq.-1.e0_rt) then
            lam(i,j,g) = lam(reg_l1,reg_h2,g)
         end if
      end do
@@ -437,7 +438,7 @@ subroutine ca_compute_lamborder(Er, Er_l1, Er_l2, Er_h1, Er_h2, &
   ! reg-x hi-y
   do j=reg_h2+1,lam_h2
      do i=reg_l1,reg_h1
-        if (Er(i,j,g).eq.-1.d0) then
+        if (Er(i,j,g).eq.-1.e0_rt) then
            lam(i,j,g) = lam(i,reg_h2,g)
         end if
      end do
@@ -446,7 +447,7 @@ subroutine ca_compute_lamborder(Er, Er_l1, Er_l2, Er_h1, Er_h2, &
   ! hi-x hi-y
   do j=reg_h2+1,lam_h2
      do i=reg_h1+1,lam_h1
-        if (Er(i,j,g).eq.-1.d0) then
+        if (Er(i,j,g).eq.-1.e0_rt) then
            lam(i,j,g) = lam(reg_h1,reg_h2,g)
         end if
      end do
@@ -476,6 +477,7 @@ subroutine ca_get_v_dcf(lo, hi, &
 
   use meth_params_module, only : NVAR, URHO, UMX, UMY
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: lo(2), hi(2)
@@ -484,21 +486,21 @@ subroutine ca_get_v_dcf(lo, hi, &
   integer, intent(in) :: kr_l1,kr_l2,kr_h1,kr_h2
   integer, intent(in) :: kp_l1,kp_l2,kp_h1,kp_h2,kp2_l1,kp2_l2,kp2_h1,kp2_h2
   integer, intent(in) :: v_l1,v_l2,v_h1,v_h2,dcf_l1,dcf_l2,dcf_h1,dcf_h2
-  double precision, intent(in)  ::  er( er_l1: er_h1,  er_l2: er_h2)
-  double precision, intent(in)  ::   s(  s_l1:  s_h1,   s_l2:  s_h2, NVAR)
-  double precision, intent(in)  ::   T(  T_l1:  T_h1,   T_l2:  T_h2)
-  double precision, intent(in)  :: c_v(c_v_l1:c_v_h1, c_v_l2:c_v_h2)
-  double precision, intent(in ) ::  kr( kr_l1: kr_h1,  kr_l2: kr_h2)
-  double precision, intent(in ) ::  kp( kp_l1: kp_h1,  kp_l2: kp_h2)
-  double precision, intent(in ) :: kp2(kp2_l1:kp2_h1, kp2_l2:kp2_h2)
-  double precision, intent(in) :: dtemp, dtime, sigma, c
-  double precision              ::   v(  v_l1:  v_h1,   v_l2:  v_h2, 2)
-  double precision              :: dcf(dcf_l1:dcf_h1, dcf_l2:dcf_h2)
+  real(rt)        , intent(in)  ::  er( er_l1: er_h1,  er_l2: er_h2)
+  real(rt)        , intent(in)  ::   s(  s_l1:  s_h1,   s_l2:  s_h2, NVAR)
+  real(rt)        , intent(in)  ::   T(  T_l1:  T_h1,   T_l2:  T_h2)
+  real(rt)        , intent(in)  :: c_v(c_v_l1:c_v_h1, c_v_l2:c_v_h2)
+  real(rt)        , intent(in ) ::  kr( kr_l1: kr_h1,  kr_l2: kr_h2)
+  real(rt)        , intent(in ) ::  kp( kp_l1: kp_h1,  kp_l2: kp_h2)
+  real(rt)        , intent(in ) :: kp2(kp2_l1:kp2_h1, kp2_l2:kp2_h2)
+  real(rt)        , intent(in) :: dtemp, dtime, sigma, c
+  real(rt)                      ::   v(  v_l1:  v_h1,   v_l2:  v_h2, 2)
+  real(rt)                      :: dcf(dcf_l1:dcf_h1, dcf_l2:dcf_h2)
 
   integer :: i, j
-  double precision :: etainv, fac0, fac2, alpha, frc
+  real(rt)         :: etainv, fac0, fac2, alpha, frc
 
-  fac0 = 4.d0 * sigma * dtime / dtemp
+  fac0 = 4.e0_rt * sigma * dtime / dtemp
   fac2 = c * dtime / dtemp
 
   do j=lo(2),hi(2)
@@ -510,10 +512,10 @@ subroutine ca_get_v_dcf(lo, hi, &
              -          kp (i,j) * (T(i,j)        ) ** 4)   &
              -  fac2 * (kp2(i,j) - kp(i,j)) * er(i,j)
 
-        frc = s(i,j,URHO) * c_v(i,j) + 1.0d-50
+        frc = s(i,j,URHO) * c_v(i,j) + 1.0e-50_rt
         etainv = frc / (alpha + frc)
 
-        dcf(i,j) = 2.d0 * etainv * (kp(i,j) / kr(i,j))
+        dcf(i,j) = 2.e0_rt * etainv * (kp(i,j) / kr(i,j))
      end do
   end do
 
@@ -527,6 +529,7 @@ subroutine ca_compute_dcoefs(lo, hi, &
                              dcf, dcf_l1, dcf_l2, dcf_h1, dcf_h2, &
                              r, idir)
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: lo(2), hi(2)
@@ -536,20 +539,20 @@ subroutine ca_compute_dcoefs(lo, hi, &
        & dcf_l1, dcf_l2, dcf_h1, dcf_h2, &
        idir
 
-  double precision              ::   d(  d_l1:  d_h1,   d_l2:  d_h2)
-  double precision, intent(in)  :: lam(lam_l1:lam_h1, lam_l2:lam_h2)
-  double precision, intent(in)  ::   v(  v_l1:  v_h1,   v_l2:  v_h2, 2)
-  double precision, intent(in)  :: dcf(dcf_l1:dcf_h1, dcf_l2:dcf_h2)
-  double precision, intent(in)  ::   r( lo(1): hi(1))
+  real(rt)                      ::   d(  d_l1:  d_h1,   d_l2:  d_h2)
+  real(rt)        , intent(in)  :: lam(lam_l1:lam_h1, lam_l2:lam_h2)
+  real(rt)        , intent(in)  ::   v(  v_l1:  v_h1,   v_l2:  v_h2, 2)
+  real(rt)        , intent(in)  :: dcf(dcf_l1:dcf_h1, dcf_l2:dcf_h2)
+  real(rt)        , intent(in)  ::   r( lo(1): hi(1))
 
   integer :: i, j
 
   if (idir.eq.0) then
      do j = lo(2), hi(2)
         do i = lo(1), hi(1)
-           if (v(i-1,j,1) + v(i,j,1) .gt. 0.d0) then
+           if (v(i-1,j,1) + v(i,j,1) .gt. 0.e0_rt) then
               d(i,j) = dcf(i-1,j) * v(i-1,j,1) * lam(i,j)
-           else if (v(i-1,j,1) + v(i,j,1) .lt. 0.d0) then
+           else if (v(i-1,j,1) + v(i,j,1) .lt. 0.e0_rt) then
               d(i,j) = dcf(i,j) * v(i,j,1) * lam(i,j)
            else
               d(i,j) = 0.0
@@ -560,9 +563,9 @@ subroutine ca_compute_dcoefs(lo, hi, &
   else
      do j = lo(2), hi(2)
         do i = lo(1), hi(1)
-           if (v(i,j-1,2) + v(i,j,2) .gt. 0.d0) then
+           if (v(i,j-1,2) + v(i,j,2) .gt. 0.e0_rt) then
               d(i,j) = dcf(i,j-1) * v(i,j-1,2) * lam(i,j)
-           else if (v(i,j-1,2) + v(i,j,2) .lt. 0.d0) then
+           else if (v(i,j-1,2) + v(i,j,2) .lt. 0.e0_rt) then
               d(i,j) = dcf(i,j) * v(i,j,2) * lam(i,j)
            else
               d(i,j) = 0.0
@@ -580,21 +583,22 @@ subroutine ca_update_dcf(lo, hi, &
                          etainv, eti_l1, eti_l2, eti_h1, eti_h2, &
                          kp, kp_l1, kp_l2, kp_h1, kp_h2, kr, kr_l1, kr_l2, kr_h1, kr_h2) bind(C, name="ca_update_dcf")
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: lo(2), hi(2)
   integer, intent(in) :: dcf_l1, dcf_l2, dcf_h1, dcf_h2, eti_l1, eti_l2, eti_h1, eti_h2, &
        kp_l1, kp_l2, kp_h1, kp_h2, kr_l1, kr_l2, kr_h1, kr_h2
-  double precision, intent(in) :: etainv(eti_l1:eti_h1, eti_l2:eti_h2)
-  double precision, intent(in) :: kp(kp_l1:kp_h1, kp_l2:kp_h2)
-  double precision, intent(in) :: kr(kr_l1:kr_h1, kr_l2:kr_h2)
-  double precision             :: dcf(dcf_l1:dcf_h1, dcf_l2:dcf_h2)
+  real(rt)        , intent(in) :: etainv(eti_l1:eti_h1, eti_l2:eti_h2)
+  real(rt)        , intent(in) :: kp(kp_l1:kp_h1, kp_l2:kp_h2)
+  real(rt)        , intent(in) :: kr(kr_l1:kr_h1, kr_l2:kr_h2)
+  real(rt)                     :: dcf(dcf_l1:dcf_h1, dcf_l2:dcf_h2)
 
   integer :: i, j
 
   do j=lo(2), hi(2)
      do i=lo(1), hi(1)
-        dcf(i,j) = 2.d0 * etainv(i,j) * (kp(i,j)/kr(i,j))
+        dcf(i,j) = 2.e0_rt * etainv(i,j) * (kp(i,j)/kr(i,j))
      end do
   end do
 
@@ -605,15 +609,16 @@ subroutine ca_set_dterm_face(lo, hi, &
                              Er, Er_l1, Er_l2, Er_h1, Er_h2, &
                              dc, dc_l1, dc_l2, dc_h1, dc_h2, &
                              dtf, dtf_l1, dtf_l2, dtf_h1, dtf_h2, dx, idir)
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: lo(2), hi(2)
   integer, intent(in) :: Er_l1, Er_l2, Er_h1, Er_h2,  &
        dc_l1, dc_l2, dc_h1, dc_h2, dtf_l1, dtf_l2, dtf_h1, dtf_h2, idir
-  double precision, intent(in) :: dx(2)
-  double precision, intent(in) :: Er(Er_l1:Er_h1,Er_l2:Er_h2)
-  double precision, intent(in) :: dc(dc_l1:dc_h1,dc_l2:dc_h2)
-  double precision             :: dtf(dtf_l1:dtf_h1,dtf_l2:dtf_h2)
+  real(rt)        , intent(in) :: dx(2)
+  real(rt)        , intent(in) :: Er(Er_l1:Er_h1,Er_l2:Er_h2)
+  real(rt)        , intent(in) :: dc(dc_l1:dc_h1,dc_l2:dc_h2)
+  real(rt)                     :: dtf(dtf_l1:dtf_h1,dtf_l2:dtf_h2)
   integer :: i, j
 
   if (idir .eq. 0) then
@@ -639,15 +644,16 @@ subroutine ca_face2center(lo, hi, &
                           fooy, fooy_l1, fooy_l2, fooy_h1, fooy_h2, &
                           fooc, fooc_l1, fooc_l2, fooc_h1, fooc_h2)
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: lo(2), hi(2), scomp,dcomp,ncomp,nf,nc
   integer, intent(in) :: foox_l1, foox_l2, foox_h1, foox_h2
   integer, intent(in) :: fooy_l1, fooy_l2, fooy_h1, fooy_h2
   integer, intent(in) :: fooc_l1, fooc_l2, fooc_h1, fooc_h2
-  double precision, intent(in)  :: foox(foox_l1:foox_h1,foox_l2:foox_h2,0:nf-1)
-  double precision, intent(in)  :: fooy(fooy_l1:fooy_h1,fooy_l2:fooy_h2,0:nf-1)
-  double precision              :: fooc(fooc_l1:fooc_h1,fooc_l2:fooc_h2,0:nc-1)
+  real(rt)        , intent(in)  :: foox(foox_l1:foox_h1,foox_l2:foox_h2,0:nf-1)
+  real(rt)        , intent(in)  :: fooy(fooy_l1:fooy_h1,fooy_l2:fooy_h2,0:nf-1)
+  real(rt)                      :: fooc(fooc_l1:fooc_h1,fooc_l2:fooc_h2,0:nc-1)
 
   integer :: i,j,n
 
@@ -655,7 +661,7 @@ subroutine ca_face2center(lo, hi, &
      do j=lo(2), hi(2)
         do i=lo(1), hi(1)
            fooc(i,j,dcomp+n) = (foox(i,j,scomp+n) + foox(i+1,j,scomp+n) &
-                &             + fooy(i,j,scomp+n) + fooy(i,j+1,scomp+n)) * 0.25d0
+                &             + fooy(i,j,scomp+n) + fooy(i,j+1,scomp+n)) * 0.25e0_rt
         end do
      end do
   end do
@@ -669,19 +675,20 @@ subroutine ca_correct_dterm(  &
                             dfy, dfy_l1, dfy_l2, dfy_h1, dfy_h2, &
                             re, rc)
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: dfx_l1, dfx_l2, dfx_h1, dfx_h2
   integer, intent(in) :: dfy_l1, dfy_l2, dfy_h1, dfy_h2
-  double precision, intent(inout) :: dfx(dfx_l1:dfx_h1,dfx_l2:dfx_h2)
-  double precision, intent(inout) :: dfy(dfy_l1:dfy_h1,dfy_l2:dfy_h2)
-  double precision, intent(in) :: re(dfx_l1:dfx_h1), rc(dfy_l1:dfy_h1)
+  real(rt)        , intent(inout) :: dfx(dfx_l1:dfx_h1,dfx_l2:dfx_h2)
+  real(rt)        , intent(inout) :: dfy(dfy_l1:dfy_h1,dfy_l2:dfy_h2)
+  real(rt)        , intent(in) :: re(dfx_l1:dfx_h1), rc(dfy_l1:dfy_h1)
 
   integer :: i, j
 
   do j=dfx_l2, dfx_h2
      do i=dfx_l1, dfx_h1
-        dfx(i,j) = dfx(i,j) / (re(i) + 1.d-50)
+        dfx(i,j) = dfx(i,j) / (re(i) + 1.e-50_rt)
      end do
   end do
 
@@ -703,16 +710,17 @@ subroutine ca_estdt_rad(u,u_l1,u_l2,u_h1,u_h2, &
   use meth_params_module, only : NVAR, URHO, UMX, UMY, UEINT, UTEMP, UFS, UFX, &
        allow_negative_energy
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer          :: u_l1,u_l2,u_h1,u_h2
   integer          :: gpr_l1,gpr_l2,gpr_h1,gpr_h2
   integer          :: lo(2), hi(2)
-  double precision :: u(u_l1:u_h1,u_l2:u_h2,NVAR)
-  double precision :: gpr(gpr_l1:gpr_h1,gpr_l2:gpr_h2)
-  double precision :: dx(2),dt
+  real(rt)         :: u(u_l1:u_h1,u_l2:u_h2,NVAR)
+  real(rt)         :: gpr(gpr_l1:gpr_h1,gpr_l2:gpr_h2)
+  real(rt)         :: dx(2),dt
 
-  double precision :: rhoInv,ux,uy,dt1,dt2,c
+  real(rt)         :: rhoInv,ux,uy,dt1,dt2,c
   integer          :: i,j
   type(eos_t) :: eos_state
 
@@ -720,7 +728,7 @@ subroutine ca_estdt_rad(u,u_l1,u_l2,u_h1,u_h2, &
   do j = lo(2),hi(2)
      do i = lo(1),hi(1)
 
-        rhoInv = 1.d0 / u(i,j,URHO)
+        rhoInv = 1.e0_rt / u(i,j,URHO)
 
         eos_state % rho = u(i,j,URHO)
         eos_state % T   = u(i,j,UTEMP)
@@ -728,11 +736,11 @@ subroutine ca_estdt_rad(u,u_l1,u_l2,u_h1,u_h2, &
         eos_state % xn  = u(i,j,UFS:UFS+nspec-1) * rhoInv
         eos_state % aux = u(i,j,UFX:UFX+naux -1) * rhoInv
 
-        if (eos_state % e .gt. 0.d0 .or. allow_negative_energy.eq.1) then
+        if (eos_state % e .gt. 0.e0_rt .or. allow_negative_energy.eq.1) then
            call eos(eos_input_re, eos_state)
            c = eos_state % cs
         else
-           c = 0.d0
+           c = 0.e0_rt
         end if
 
         c = sqrt(c**2 + gpr(i,j)*rhoInv)
@@ -755,20 +763,21 @@ subroutine ca_est_gpr0(Er, Er_l1, Er_l2, Er_h1, Er_h2, &
 
   use rad_params_module, only : ngroups
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: Er_l1, Er_l2, Er_h1, Er_h2, gpr_l1, gpr_l2, gpr_h1, gpr_h2
-  double precision, intent(in) :: Er(Er_l1:Er_h1,Er_l2:Er_h2, 0:ngroups-1)
-  double precision, intent(out) :: gPr(gPr_l1:gPr_h1,gPr_l2:gPr_h2)
+  real(rt)        , intent(in) :: Er(Er_l1:Er_h1,Er_l2:Er_h2, 0:ngroups-1)
+  real(rt)        , intent(out) :: gPr(gPr_l1:gPr_h1,gPr_l2:gPr_h2)
 
   integer :: i, j, g
 
-  gPr = 0.d0
+  gPr = 0.e0_rt
 
   do g = 0, ngroups-1
      do j = gPr_l2, gPr_h2
         do i = gPr_l1, gPr_h1
-           gPr(i,j) = gPr(i,j) + 4.d0/9.d0*Er(i,j,g)
+           gPr(i,j) = gPr(i,j) + 4.e0_rt/9.e0_rt*Er(i,j,g)
         end do
      end do
   end do
@@ -784,63 +793,64 @@ subroutine ca_est_gpr2(kap, kap_l1, kap_l2, kap_h1, kap_h2, &
   use rad_params_module, only : ngroups
   use fluxlimiter_module, only : FLDlambda, Edd_factor
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: kap_l1, kap_l2, kap_h1, kap_h2, &
        Er_l1, Er_l2, Er_h1, Er_h2, gPr_l1, gPr_l2, gPr_h1, gPr_h2
   integer, intent(in) :: vlo(2), vhi(2)  ! the region with valid Er
   integer, intent(in) :: limiter, comoving
-  double precision, intent(in) :: dx(2)
-  double precision, intent(in) :: kap(kap_l1:kap_h1,kap_l2:kap_h2, 0:ngroups-1), &
+  real(rt)        , intent(in) :: dx(2)
+  real(rt)        , intent(in) :: kap(kap_l1:kap_h1,kap_l2:kap_h2, 0:ngroups-1), &
        Er(Er_l1:Er_h1,Er_l2:Er_h2, 0:ngroups-1)
-  double precision, intent(out) :: gPr(gPr_l1:gPr_h1,gPr_l2:gPr_h2)
+  real(rt)        , intent(out) :: gPr(gPr_l1:gPr_h1,gPr_l2:gPr_h2)
 
   integer :: i, j, g
-  double precision :: gE(gPr_l1:gPr_h1,gPr_l2:gPr_h2)
-  double precision :: lam, gE1, gE2, r, f, gamr
+  real(rt)         :: gE(gPr_l1:gPr_h1,gPr_l2:gPr_h2)
+  real(rt)         :: lam, gE1, gE2, r, f, gamr
   integer :: im, ip, jm, jp
-  double precision :: xm, xp, ym, yp
+  real(rt)         :: xm, xp, ym, yp
 
   if (gPr_l1-1 .ge. vlo(1)) then
      im = 1
-     xm = 2.d0
+     xm = 2.e0_rt
   else
      im = 0
-     xm = 1.d0
+     xm = 1.e0_rt
   end if
 
   if (gPr_h1+1 .le. vhi(1)) then
      ip = 1
-     xp = 2.d0
+     xp = 2.e0_rt
   else
      ip = 0
-     xp = 1.d0
+     xp = 1.e0_rt
   end if
 
   if (gPr_l2-1 .ge. vlo(2)) then
      jm = 1
-     ym = 2.d0
+     ym = 2.e0_rt
   else
      jm = 0
-     ym = 1.d0
+     ym = 1.e0_rt
   end if
 
   if (gPr_h2+1 .le. vhi(2)) then
      jp = 1
-     yp = 2.d0
+     yp = 2.e0_rt
   else
      jp = 0
-     yp = 1.d0
+     yp = 1.e0_rt
   end if
 
-  gPr = 0.0d0
+  gPr = 0.0e0_rt
 
   do g = 0, ngroups-1
 
      do j = gPr_l2+1, gPr_h2-1
         do i = gPr_l1+1, gPr_h1-1
-           gE1 = (Er(i+1,j,g) - Er(i-1,j,g)) / (2.d0*dx(1))
-           gE2 = (Er(i,j+1,g) - Er(i,j-1,g)) / (2.d0*dx(2))
+           gE1 = (Er(i+1,j,g) - Er(i-1,j,g)) / (2.e0_rt*dx(1))
+           gE2 = (Er(i,j+1,g) - Er(i,j-1,g)) / (2.e0_rt*dx(2))
            gE(i,j) = sqrt(gE1**2 + gE2**2)
         end do
      end do
@@ -855,7 +865,7 @@ subroutine ca_est_gpr2(kap, kap_l1, kap_l2, kap_h1, kap_h2, &
      ! med-x lo-y side
      j = gPr_l2
      do i = gPr_l1+1, gPr_h1-1
-        gE1 = (Er(i+1,j  ,g) - Er(i-1,j   ,g)) / (2.d0*dx(1))
+        gE1 = (Er(i+1,j  ,g) - Er(i-1,j   ,g)) / (2.e0_rt*dx(1))
         gE2 = (Er(i  ,j+1,g) - Er(i  ,j-jm,g)) / (  ym*dx(2))
         gE(i,j) = sqrt(gE1**2 + gE2**2)
      end do
@@ -871,7 +881,7 @@ subroutine ca_est_gpr2(kap, kap_l1, kap_l2, kap_h1, kap_h2, &
      i = gPr_l1
      do j = gPr_l2+1, gPr_h2-1
         gE1 = (Er(i+1,j  ,g) - Er(i-im,j  ,g)) / (  xm*dx(1))
-        gE2 = (Er(i  ,j+1,g) - Er(i   ,j-1,g)) / (2.d0*dx(2))
+        gE2 = (Er(i  ,j+1,g) - Er(i   ,j-1,g)) / (2.e0_rt*dx(2))
         gE(i,j) = sqrt(gE1**2 + gE2**2)
      end do
 
@@ -879,7 +889,7 @@ subroutine ca_est_gpr2(kap, kap_l1, kap_l2, kap_h1, kap_h2, &
      i = gPr_h1
      do j = gPr_l2+1, gPr_h2-1
         gE1 = (Er(i+ip,j  ,g) - Er(i-1,j  ,g)) / (  xp*dx(1))
-        gE2 = (Er(i   ,j+1,g) - Er(i  ,j-1,g)) / (2.d0*dx(2))
+        gE2 = (Er(i   ,j+1,g) - Er(i  ,j-1,g)) / (2.e0_rt*dx(2))
         gE(i,j) = sqrt(gE1**2 + gE2**2)
      end do
 
@@ -893,7 +903,7 @@ subroutine ca_est_gpr2(kap, kap_l1, kap_l2, kap_h1, kap_h2, &
      ! med-x hi-y side
      j = gPr_h2
      do i = gPr_l1+1, gPr_h1-1
-        gE1 = (Er(i+1,j   ,g) - Er(i-1,j,g)) / (2.d0*dx(1))
+        gE1 = (Er(i+1,j   ,g) - Er(i-1,j,g)) / (2.e0_rt*dx(1))
         gE2 = (Er(i  ,j+jp,g) - Er(i,j-1,g)) / (  yp*dx(2))
         gE(i,j) = sqrt(gE1**2 + gE2**2)
      end do
@@ -907,13 +917,13 @@ subroutine ca_est_gpr2(kap, kap_l1, kap_l2, kap_h1, kap_h2, &
 
      do j = gPr_l2, gPr_h2
         do i = gPr_l1, gPr_h1
-           r = gE(i,j) / (kap(i,j,g) * max(Er(i,j,g), 1.d-50))
+           r = gE(i,j) / (kap(i,j,g) * max(Er(i,j,g), 1.e-50_rt))
            lam = FLDlambda(r, limiter)
            if (comoving .eq. 1) then
               f = Edd_factor(lam)
-              gamr = (3.d0-f)/2.d0
+              gamr = (3.e0_rt-f)/2.e0_rt
            else
-              gamr = lam + 1.d0
+              gamr = lam + 1.e0_rt
            end if
            gPr(i,j) = gPr(i,j) + lam * gamr * Er(i,j,g)
         end do

--- a/Source/Radiation/RadSrc_2d/HABEC_2D.F90
+++ b/Source/Radiation/RadSrc_2d/HABEC_2D.F90
@@ -11,6 +11,7 @@ module habec_module
 
   use bl_types
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
 contains
@@ -20,16 +21,17 @@ subroutine hacoef(mat, a, &
                   DIMS(reg), &
                   alpha) bind(C, name="hacoef")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(abox)
   integer :: DIMDEC(reg)
-  real*8 :: a(DIMV(abox))
-  real*8 :: mat(0:2, DIMV(reg))
-  real*8 :: alpha
+  real(rt)         :: a(DIMV(abox))
+  real(rt)         :: mat(0:2, DIMV(reg))
+  real(rt)         :: alpha
   integer :: i, j
-  if (alpha == 0.d0) then
+  if (alpha == 0.e0_rt) then
      do j = reg_l2, reg_h2
         do i = reg_l1, reg_h1
-           mat(2,i,j) = 0.d0
+           mat(2,i,j) = 0.e0_rt
         enddo
      enddo
   else
@@ -46,13 +48,14 @@ subroutine hbcoef(mat, b, &
                   DIMS(reg), &
                   beta, dx, n) bind(C, name="hbcoef")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(bbox)
   integer :: DIMDEC(reg)
   integer :: n
-  real*8 :: b(DIMV(bbox))
-  real*8 :: mat(0:2, DIMV(reg))
-  real*8 :: beta, dx(2)
-  real*8 :: fac
+  real(rt)         :: b(DIMV(bbox))
+  real(rt)         :: mat(0:2, DIMV(reg))
+  real(rt)         :: beta, dx(2)
+  real(rt)         :: fac
   integer :: i, j
   if (n == 0) then
      fac = beta / (dx(1)**2)
@@ -80,15 +83,16 @@ subroutine hbmat(mat, &
                  b, DIMS(bbox), &
                  beta, dx) bind(C, name="hbmat")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(reg)
   integer :: DIMDEC(msk)
   integer :: DIMDEC(bbox)
   integer :: cdir, bct
-  real*8 :: bcl, beta, dx(2)
-  real*8 :: mat(0:2, DIMV(reg))
+  real(rt)         :: bcl, beta, dx(2)
+  real(rt)         :: mat(0:2, DIMV(reg))
   integer :: mask(DIMV(msk))
-  real*8 :: b(DIMV(bbox))
-  real*8 :: h, fac, bfm, bfv
+  real(rt)         :: b(DIMV(bbox))
+  real(rt)         :: h, fac, bfm, bfv
   integer :: i, j
   if (cdir == 0 .OR. cdir == 2) then
      h = dx(1)
@@ -97,7 +101,7 @@ subroutine hbmat(mat, &
   endif
   fac = beta / (h**2)
   if (bct == LO_DIRICHLET) then
-     bfv = fac * h / (0.5d0 * h + bcl)
+     bfv = fac * h / (0.5e0_rt * h + bcl)
      bfm = bfv - fac
   else if (bct == LO_NEUMANN) then
      bfv = beta / h
@@ -112,7 +116,7 @@ subroutine hbmat(mat, &
      do j = reg_l2, reg_h2
         if (mask(i-1,j) > 0) then
            mat(2,i,j) = mat(2,i,j) + bfm * b(i,j)
-           mat(0,i,j) = 0.d0
+           mat(0,i,j) = 0.e0_rt
         endif
      enddo
   else if (cdir == 2) then
@@ -129,7 +133,7 @@ subroutine hbmat(mat, &
      do i = reg_l1, reg_h1
         if (mask(i,j-1) > 0) then
            mat(2,i,j) = mat(2,i,j) + bfm * b(i,j)
-           mat(1,i,j) = 0.d0
+           mat(1,i,j) = 0.e0_rt
         endif
      enddo
   else if (cdir == 3) then
@@ -154,19 +158,20 @@ subroutine hbmat3(mat, &
                   beta, dx, c, r, &
                   spa, DIMS(spabox)) bind(C, name="hbmat3")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(reg)
   integer :: DIMDEC(bcv)
   integer :: DIMDEC(msk)
   integer :: DIMDEC(bbox)
   integer :: DIMDEC(spabox)
   integer :: cdir, bctype, tf(DIMV(bcv))
-  real*8 :: bcl, beta, dx(2), c
-  real*8 :: mat(0:2, DIMV(reg))
+  real(rt)         :: bcl, beta, dx(2), c
+  real(rt)         :: mat(0:2, DIMV(reg))
   integer :: mask(DIMV(msk))
-  real*8 :: b(DIMV(bbox))
-  real*8 :: spa(DIMV(spabox))
-  real*8 :: r(reg_l1:reg_h1)
-  real*8 :: h, fac, bfm, bfv, r0
+  real(rt)         :: b(DIMV(bbox))
+  real(rt)         :: spa(DIMV(spabox))
+  real(rt)         :: r(reg_l1:reg_h1)
+  real(rt)         :: h, fac, bfm, bfv, r0
   integer :: i, j, bct
   if (cdir == 0 .OR. cdir == 2) then
      h = dx(1)
@@ -191,22 +196,22 @@ subroutine hbmat3(mat, &
               bct = bctype
            endif
            if (bct == LO_DIRICHLET) then
-              bfv = fac * h / (0.5d0 * h + bcl)
+              bfv = fac * h / (0.5e0_rt * h + bcl)
               bfm = bfv * b(i,j)
            else if (bct == LO_NEUMANN) then
-              bfm = 0.d0
+              bfm = 0.e0_rt
            else if (bct == LO_MARSHAK) then
-              bfv = 2.d0 * beta * r0 / h
-              bfm = 0.25d0 * c * bfv
+              bfv = 2.e0_rt * beta * r0 / h
+              bfm = 0.25e0_rt * c * bfv
            else if (bct == LO_SANCHEZ_POMRANING) then
-              bfv = 2.d0 * beta * r0 / h
+              bfv = 2.e0_rt * beta * r0 / h
               bfm = spa(i,j) * c * bfv
            else
               print *, "hbmat3: unsupported boundary type"
               stop
            endif
            mat(2,i,j) = mat(2,i,j) + bfm - fac * b(i,j)
-           mat(0,i,j) = 0.d0
+           mat(0,i,j) = 0.e0_rt
         endif
      enddo
   else if (cdir == 2) then
@@ -220,15 +225,15 @@ subroutine hbmat3(mat, &
               bct = bctype
            endif
            if (bct == LO_DIRICHLET) then
-              bfv = fac * h / (0.5d0 * h + bcl)
+              bfv = fac * h / (0.5e0_rt * h + bcl)
               bfm = bfv * b(i+1,j)
            else if (bct == LO_NEUMANN) then
-              bfm = 0.d0
+              bfm = 0.e0_rt
            else if (bct == LO_MARSHAK) then
-              bfv = 2.d0 * beta * r0 / h
-              bfm = 0.25d0 * c * bfv
+              bfv = 2.e0_rt * beta * r0 / h
+              bfm = 0.25e0_rt * c * bfv
            else if (bct == LO_SANCHEZ_POMRANING) then
-              bfv = 2.d0 * beta * r0 / h
+              bfv = 2.e0_rt * beta * r0 / h
               bfm = spa(i,j) * c * bfv
            else
               print *, "hbmat3: unsupported boundary type"
@@ -248,22 +253,22 @@ subroutine hbmat3(mat, &
               bct = bctype
            endif
            if (bct == LO_DIRICHLET) then
-              bfv = fac * h / (0.5d0 * h + bcl)
+              bfv = fac * h / (0.5e0_rt * h + bcl)
               bfm = bfv * b(i,j)
            else if (bct == LO_NEUMANN) then
-              bfm = 0.d0
+              bfm = 0.e0_rt
            else if (bct == LO_MARSHAK) then
-              bfv = 2.d0 * beta * r(i) / h
-              bfm = 0.25d0 * c * bfv
+              bfv = 2.e0_rt * beta * r(i) / h
+              bfm = 0.25e0_rt * c * bfv
            else if (bct == LO_SANCHEZ_POMRANING) then
-              bfv = 2.d0 * beta * r(i) / h
+              bfv = 2.e0_rt * beta * r(i) / h
               bfm = spa(i,j) * c * bfv
            else
               print *, "hbmat3: unsupported boundary type"
               stop
            endif
            mat(2,i,j) = mat(2,i,j) + bfm - fac * b(i,j)
-           mat(1,i,j) = 0.d0
+           mat(1,i,j) = 0.e0_rt
         endif
      enddo
   else if (cdir == 3) then
@@ -277,15 +282,15 @@ subroutine hbmat3(mat, &
               bct = bctype
            endif
            if (bct == LO_DIRICHLET) then
-              bfv = fac * h / (0.5d0 * h + bcl)
+              bfv = fac * h / (0.5e0_rt * h + bcl)
               bfm = bfv * b(i,j+1)
            else if (bct == LO_NEUMANN) then
-              bfm = 0.d0
+              bfm = 0.e0_rt
            else if (bct == LO_MARSHAK) then
-              bfv = 2.d0 * beta * r(i) / h
-              bfm = 0.25d0 * c * bfv
+              bfv = 2.e0_rt * beta * r(i) / h
+              bfm = 0.25e0_rt * c * bfv
            else if (bct == LO_SANCHEZ_POMRANING) then
-              bfv = 2.d0 * beta * r(i) / h
+              bfv = 2.e0_rt * beta * r(i) / h
               bfm = spa(i,j) * c * bfv
            else
               print *, "hbmat3: unsupported boundary type"
@@ -307,18 +312,19 @@ subroutine hbvec(vec, &
                  b, DIMS(bbox), &
                  beta, dx) bind(C, name="hbvec")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(reg)
   integer :: DIMDEC(bcv)
   integer :: DIMDEC(msk)
   integer :: DIMDEC(bbox)
   integer :: cdir, bct, bho
-  real*8 :: bcl, beta, dx(2)
-  real*8 :: vec(DIMV(reg))
-  real*8 :: bcval(DIMV(bcv))
+  real(rt)         :: bcl, beta, dx(2)
+  real(rt)         :: vec(DIMV(reg))
+  real(rt)         :: bcval(DIMV(bcv))
   integer :: mask(DIMV(msk))
-  real*8 :: b(DIMV(bbox))
-  real*8 :: h, bfv
-  real*8 :: h2, th2
+  real(rt)         :: b(DIMV(bbox))
+  real(rt)         :: h, bfv
+  real(rt)         :: h2, th2
   integer :: i, j
   if (cdir == 0 .OR. cdir == 2) then
      h = dx(1)
@@ -327,11 +333,11 @@ subroutine hbvec(vec, &
   endif
   if (bct == LO_DIRICHLET) then
      if (bho >= 1) then
-        h2 = 0.5d0 * h
-        th2 = 3.d0 * h2
-        bfv = 2.d0 * beta / ((bcl + h2) * (bcl + th2))
+        h2 = 0.5e0_rt * h
+        th2 = 3.e0_rt * h2
+        bfv = 2.e0_rt * beta / ((bcl + h2) * (bcl + th2))
      else
-        bfv = (beta / h) / (0.5d0 * h + bcl)
+        bfv = (beta / h) / (0.5e0_rt * h + bcl)
      endif
   else if (bct == LO_NEUMANN) then
      bfv = beta / h
@@ -384,19 +390,20 @@ subroutine hbvec3(vec, &
                   b, DIMS(bbox), &
                   beta, dx, r) bind(C, name="hbvec3")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(reg)
   integer :: DIMDEC(bcv)
   integer :: DIMDEC(msk)
   integer :: DIMDEC(bbox)
   integer :: cdir, bctype, tf(DIMV(bcv)), bho
-  real*8 :: bcl, beta, dx(2)
-  real*8 :: vec(DIMV(reg))
-  real*8 :: bcval(DIMV(bcv))
+  real(rt)         :: bcl, beta, dx(2)
+  real(rt)         :: vec(DIMV(reg))
+  real(rt)         :: bcval(DIMV(bcv))
   integer :: mask(DIMV(msk))
-  real*8 :: b(DIMV(bbox))
-  real*8 :: r(reg_l1:reg_h1)
-  real*8 :: h, bfv, r0
-  real*8 :: h2, th2
+  real(rt)         :: b(DIMV(bbox))
+  real(rt)         :: r(reg_l1:reg_h1)
+  real(rt)         :: h, bfv, r0
+  real(rt)         :: h2, th2
   integer :: i, j, bct
   if (cdir == 0 .OR. cdir == 2) then
      h = dx(1)
@@ -419,18 +426,18 @@ subroutine hbvec3(vec, &
            endif
            if (bct == LO_DIRICHLET) then
               if (bho >= 1) then
-                 h2 = 0.5d0 * h
-                 th2 = 3.d0 * h2
-                 bfv = 2.d0 * beta / ((bcl + h2) * (bcl + th2))
+                 h2 = 0.5e0_rt * h
+                 th2 = 3.e0_rt * h2
+                 bfv = 2.e0_rt * beta / ((bcl + h2) * (bcl + th2))
               else
-                 bfv = (beta / h) / (0.5d0 * h + bcl)
+                 bfv = (beta / h) / (0.5e0_rt * h + bcl)
               endif
               bfv = bfv * b(i,j)
            else if (bct == LO_NEUMANN) then
               bfv = beta * r0 / h
            else if (bct == LO_MARSHAK .OR. &
                 bct == LO_SANCHEZ_POMRANING) then
-              bfv = 2.d0 * beta * r0 / h
+              bfv = 2.e0_rt * beta * r0 / h
            else
               print *, "hbvec3: unsupported boundary type"
               stop
@@ -450,18 +457,18 @@ subroutine hbvec3(vec, &
            endif
            if (bct == LO_DIRICHLET) then
               if (bho >= 1) then
-                 h2 = 0.5d0 * h
-                 th2 = 3.d0 * h2
-                 bfv = 2.d0 * beta / ((bcl + h2) * (bcl + th2))
+                 h2 = 0.5e0_rt * h
+                 th2 = 3.e0_rt * h2
+                 bfv = 2.e0_rt * beta / ((bcl + h2) * (bcl + th2))
               else
-                 bfv = (beta / h) / (0.5d0 * h + bcl)
+                 bfv = (beta / h) / (0.5e0_rt * h + bcl)
               endif
               bfv = bfv * b(i+1,j)
            else if (bct == LO_NEUMANN) then
               bfv = beta * r0 / h
            else if (bct == LO_MARSHAK .OR. &
                 bct == LO_SANCHEZ_POMRANING) then
-              bfv = 2.d0 * beta * r0 / h
+              bfv = 2.e0_rt * beta * r0 / h
            else
               print *, "hbvec3: unsupported boundary type"
               stop
@@ -481,18 +488,18 @@ subroutine hbvec3(vec, &
            endif
            if (bct == LO_DIRICHLET) then
               if (bho >= 1) then
-                 h2 = 0.5d0 * h
-                 th2 = 3.d0 * h2
-                 bfv = 2.d0 * beta / ((bcl + h2) * (bcl + th2))
+                 h2 = 0.5e0_rt * h
+                 th2 = 3.e0_rt * h2
+                 bfv = 2.e0_rt * beta / ((bcl + h2) * (bcl + th2))
               else
-                 bfv = (beta / h) / (0.5d0 * h + bcl)
+                 bfv = (beta / h) / (0.5e0_rt * h + bcl)
               endif
               bfv = bfv * b(i,j)
            else if (bct == LO_NEUMANN) then
               bfv = beta * r(i) / h
            else if (bct == LO_MARSHAK .OR. &
                 bct == LO_SANCHEZ_POMRANING) then
-              bfv = 2.d0 * beta * r(i) / h
+              bfv = 2.e0_rt * beta * r(i) / h
            else
               print *, "hbvec3: unsupported boundary type"
               stop
@@ -512,18 +519,18 @@ subroutine hbvec3(vec, &
            endif
            if (bct == LO_DIRICHLET) then
               if (bho >= 1) then
-                 h2 = 0.5d0 * h
-                 th2 = 3.d0 * h2
-                 bfv = 2.d0 * beta / ((bcl + h2) * (bcl + th2))
+                 h2 = 0.5e0_rt * h
+                 th2 = 3.e0_rt * h2
+                 bfv = 2.e0_rt * beta / ((bcl + h2) * (bcl + th2))
               else
-                 bfv = (beta / h) / (0.5d0 * h + bcl)
+                 bfv = (beta / h) / (0.5e0_rt * h + bcl)
               endif
               bfv = bfv * b(i,j+1)
            else if (bct == LO_NEUMANN) then
               bfv = beta * r(i) / h
            else if (bct == LO_MARSHAK .OR. &
                 bct == LO_SANCHEZ_POMRANING) then
-              bfv = 2.d0 * beta * r(i) / h
+              bfv = 2.e0_rt * beta * r(i) / h
            else
               print *, "hbvec3: unsupported boundary type"
               stop
@@ -546,6 +553,7 @@ subroutine hbflx(flux, &
                  b, DIMS(bbox), &
                  beta, dx, inhom) bind(C, name="hbflx")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(fbox)
   integer :: DIMDEC(ebox)
   integer :: DIMDEC(reg)
@@ -553,14 +561,14 @@ subroutine hbflx(flux, &
   integer :: DIMDEC(msk)
   integer :: DIMDEC(bbox)
   integer :: cdir, bct, bho, inhom
-  real*8 :: bcl, beta, dx(2)
-  real*8 :: flux(DIMV(fbox))
-  real*8 :: er(DIMV(ebox))
-  real*8 :: bcval(DIMV(bcv))
+  real(rt)         :: bcl, beta, dx(2)
+  real(rt)         :: flux(DIMV(fbox))
+  real(rt)         :: er(DIMV(ebox))
+  real(rt)         :: bcval(DIMV(bcv))
   integer :: mask(DIMV(msk))
-  real*8 :: b(DIMV(bbox))
-  real*8 :: h, bfm, bfv
-  real*8 :: bfm2, h2, th2
+  real(rt)         :: b(DIMV(bbox))
+  real(rt)         :: h, bfm, bfv
+  real(rt)         :: bfm2, h2, th2
   integer :: i, j
   if (cdir == 0 .OR. cdir == 2) then
      h = dx(1)
@@ -569,13 +577,13 @@ subroutine hbflx(flux, &
   endif
   if (bct == LO_DIRICHLET) then
      if (bho >= 1) then
-        h2 = 0.5d0 * h
-        th2 = 3.d0 * h2
-        bfv = 2.d0 * beta * h / ((bcl + h2) * (bcl + th2))
+        h2 = 0.5e0_rt * h
+        th2 = 3.e0_rt * h2
+        bfv = 2.e0_rt * beta * h / ((bcl + h2) * (bcl + th2))
         bfm = (beta / h) * (th2 - bcl) / (bcl + h2)
         bfm2 = (beta / h) * (bcl - h2) / (bcl + th2)
      else
-        bfv = beta / (0.5d0 * h + bcl)
+        bfv = beta / (0.5e0_rt * h + bcl)
         bfm = bfv
      endif
   else
@@ -583,7 +591,7 @@ subroutine hbflx(flux, &
      stop
   endif
   if (inhom == 0) then
-     bfv = 0.d0
+     bfv = 0.e0_rt
   endif
   if (cdir == 0) then
      ! Left face of grid
@@ -645,6 +653,7 @@ subroutine hbflx3(flux, &
                   beta, dx, c, r, inhom, &
                   spa, DIMS(spabox)) bind(C, name="hbflx3")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(fbox)
   integer :: DIMDEC(ebox)
   integer :: DIMDEC(reg)
@@ -653,16 +662,16 @@ subroutine hbflx3(flux, &
   integer :: DIMDEC(bbox)
   integer :: DIMDEC(spabox)
   integer :: cdir, bctype, tf(DIMV(bcv)), bho, inhom
-  real*8 :: bcl, beta, dx(2), c
-  real*8 :: flux(DIMV(fbox))
-  real*8 :: er(DIMV(ebox))
-  real*8 :: bcval(DIMV(bcv))
+  real(rt)         :: bcl, beta, dx(2), c
+  real(rt)         :: flux(DIMV(fbox))
+  real(rt)         :: er(DIMV(ebox))
+  real(rt)         :: bcval(DIMV(bcv))
   integer :: mask(DIMV(msk))
-  real*8 :: b(DIMV(bbox))
-  real*8 :: spa(DIMV(spabox))
-  real*8 :: r(reg_l1:reg_h1)
-  real*8 :: h, bfm, bfv, r0
-  real*8 :: bfm2, h2, th2
+  real(rt)         :: b(DIMV(bbox))
+  real(rt)         :: spa(DIMV(spabox))
+  real(rt)         :: r(reg_l1:reg_h1)
+  real(rt)         :: h, bfm, bfv, r0
+  real(rt)         :: bfm2, h2, th2
   integer :: i, j, bct
   if (cdir == 0 .OR. cdir == 2) then
      h = dx(1)
@@ -685,32 +694,32 @@ subroutine hbflx3(flux, &
            endif
            if (bct == LO_DIRICHLET) then
               if (bho >= 1) then
-                 h2 = 0.5d0 * h
-                 th2 = 3.d0 * h2
-                 bfv = 2.d0 * beta * h / ((bcl + h2) * (bcl + th2)) * b(i,j)
+                 h2 = 0.5e0_rt * h
+                 th2 = 3.e0_rt * h2
+                 bfv = 2.e0_rt * beta * h / ((bcl + h2) * (bcl + th2)) * b(i,j)
                  bfm = (beta / h) * (th2 - bcl) / (bcl + h2)  * b(i,j)
                  bfm2 = (beta / h) * (bcl - h2) / (bcl + th2) * b(i,j)
               else
-                 bfv = beta / (0.5d0 * h + bcl) * b(i,j)
+                 bfv = beta / (0.5e0_rt * h + bcl) * b(i,j)
                  bfm = bfv
               endif
            else if (bct == LO_NEUMANN) then
               bfv  = beta * r0
-              bfm  = 0.d0
-              bfm2 = 0.d0
+              bfm  = 0.e0_rt
+              bfm2 = 0.e0_rt
            else if (bct == LO_MARSHAK) then
-              bfv = 2.d0 * beta * r0
+              bfv = 2.e0_rt * beta * r0
               if (bho >= 1) then
-                 bfm  =  0.375d0 * c * bfv
-                 bfm2 = -0.125d0 * c * bfv
+                 bfm  =  0.375e0_rt * c * bfv
+                 bfm2 = -0.125e0_rt * c * bfv
               else
-                 bfm = 0.25d0 * c * bfv
+                 bfm = 0.25e0_rt * c * bfv
               endif
            else if (bct == LO_SANCHEZ_POMRANING) then
-              bfv = 2.d0 * beta * r0
+              bfv = 2.e0_rt * beta * r0
               if (bho >= 1) then
-                 bfm  =  1.5d0 * spa(i,j) * c * bfv
-                 bfm2 = -0.5d0 * spa(i,j) * c * bfv
+                 bfm  =  1.5e0_rt * spa(i,j) * c * bfv
+                 bfm2 = -0.5e0_rt * spa(i,j) * c * bfv
               else
                  bfm = spa(i,j) * c * bfv
               endif
@@ -719,7 +728,7 @@ subroutine hbflx3(flux, &
               stop
            endif
            if (inhom == 0) then
-              bfv = 0.d0
+              bfv = 0.e0_rt
            endif
            flux(i,j) = (bfv * bcval(i-1,j) - bfm * er(i,j))
            if (bho >= 1) then
@@ -739,32 +748,32 @@ subroutine hbflx3(flux, &
            endif
            if (bct == LO_DIRICHLET) then
               if (bho >= 1) then
-                 h2 = 0.5d0 * h
-                 th2 = 3.d0 * h2
-                 bfv = 2.d0 * beta * h / ((bcl + h2) * (bcl + th2)) * b(i+1,j)
+                 h2 = 0.5e0_rt * h
+                 th2 = 3.e0_rt * h2
+                 bfv = 2.e0_rt * beta * h / ((bcl + h2) * (bcl + th2)) * b(i+1,j)
                  bfm = (beta / h) * (th2 - bcl) / (bcl + h2)  * b(i+1,j)
                  bfm2 = (beta / h) * (bcl - h2) / (bcl + th2) * b(i+1,j)
               else
-                 bfv = beta / (0.5d0 * h + bcl) * b(i+1,j)
+                 bfv = beta / (0.5e0_rt * h + bcl) * b(i+1,j)
                  bfm = bfv
               endif
            else if (bct == LO_NEUMANN) then
               bfv  = beta * r0
-              bfm  = 0.d0
-              bfm2 = 0.d0
+              bfm  = 0.e0_rt
+              bfm2 = 0.e0_rt
            else if (bct == LO_MARSHAK) then
-              bfv = 2.d0 * beta * r0
+              bfv = 2.e0_rt * beta * r0
               if (bho >= 1) then
-                 bfm  =  0.375d0 * c * bfv
-                 bfm2 = -0.125d0 * c * bfv
+                 bfm  =  0.375e0_rt * c * bfv
+                 bfm2 = -0.125e0_rt * c * bfv
               else
-                 bfm = 0.25d0 * c * bfv
+                 bfm = 0.25e0_rt * c * bfv
               endif
            else if (bct == LO_SANCHEZ_POMRANING) then
-              bfv = 2.d0 * beta * r0
+              bfv = 2.e0_rt * beta * r0
               if (bho >= 1) then
-                 bfm  =  1.5d0 * spa(i,j) * c * bfv
-                 bfm2 = -0.5d0 * spa(i,j) * c * bfv
+                 bfm  =  1.5e0_rt * spa(i,j) * c * bfv
+                 bfm2 = -0.5e0_rt * spa(i,j) * c * bfv
               else
                  bfm = spa(i,j) * c * bfv
               endif
@@ -773,7 +782,7 @@ subroutine hbflx3(flux, &
               stop
            endif
            if (inhom == 0) then
-              bfv = 0.d0
+              bfv = 0.e0_rt
            endif
            flux(i+1,j) = -(bfv * bcval(i+1,j) - bfm * er(i,j))
            if (bho >= 1) then
@@ -793,32 +802,32 @@ subroutine hbflx3(flux, &
            endif
            if (bct == LO_DIRICHLET) then
               if (bho >= 1) then
-                 h2 = 0.5d0 * h
-                 th2 = 3.d0 * h2
-                 bfv = 2.d0 * beta * h / ((bcl + h2) * (bcl + th2)) * b(i,j)
+                 h2 = 0.5e0_rt * h
+                 th2 = 3.e0_rt * h2
+                 bfv = 2.e0_rt * beta * h / ((bcl + h2) * (bcl + th2)) * b(i,j)
                  bfm = (beta / h) * (th2 - bcl) / (bcl + h2)  * b(i,j)
                  bfm2 = (beta / h) * (bcl - h2) / (bcl + th2) * b(i,j)
               else
-                 bfv = beta / (0.5d0 * h + bcl) * b(i,j)
+                 bfv = beta / (0.5e0_rt * h + bcl) * b(i,j)
                  bfm = bfv
               endif
            else if (bct == LO_NEUMANN) then
               bfv  = beta * r(i)
-              bfm  = 0.d0
-              bfm2 = 0.d0
+              bfm  = 0.e0_rt
+              bfm2 = 0.e0_rt
            else if (bct == LO_MARSHAK) then
-              bfv = 2.d0 * beta * r(i)
+              bfv = 2.e0_rt * beta * r(i)
               if (bho >= 1) then
-                 bfm  =  0.375d0 * c * bfv
-                 bfm2 = -0.125d0 * c * bfv
+                 bfm  =  0.375e0_rt * c * bfv
+                 bfm2 = -0.125e0_rt * c * bfv
               else
-                 bfm = 0.25d0 * c * bfv
+                 bfm = 0.25e0_rt * c * bfv
               endif
            else if (bct == LO_SANCHEZ_POMRANING) then
-              bfv = 2.d0 * beta * r(i)
+              bfv = 2.e0_rt * beta * r(i)
               if (bho >= 1) then
-                 bfm  =  1.5d0 * spa(i,j) * c * bfv
-                 bfm2 = -0.5d0 * spa(i,j) * c * bfv
+                 bfm  =  1.5e0_rt * spa(i,j) * c * bfv
+                 bfm2 = -0.5e0_rt * spa(i,j) * c * bfv
               else
                  bfm = spa(i,j) * c * bfv
               endif
@@ -827,7 +836,7 @@ subroutine hbflx3(flux, &
               stop
            endif
            if (inhom == 0) then
-              bfv = 0.d0
+              bfv = 0.e0_rt
            endif
            flux(i,j) = (bfv * bcval(i,j-1) - bfm * er(i,j))
            if (bho >= 1) then
@@ -847,32 +856,32 @@ subroutine hbflx3(flux, &
            endif
            if (bct == LO_DIRICHLET) then
               if (bho >= 1) then
-                 h2 = 0.5d0 * h
-                 th2 = 3.d0 * h2
-                 bfv = 2.d0 * beta * h / ((bcl + h2) * (bcl + th2)) * b(i,j+1)
+                 h2 = 0.5e0_rt * h
+                 th2 = 3.e0_rt * h2
+                 bfv = 2.e0_rt * beta * h / ((bcl + h2) * (bcl + th2)) * b(i,j+1)
                  bfm = (beta / h) * (th2 - bcl) / (bcl + h2)  * b(i,j+1)
                  bfm2 = (beta / h) * (bcl - h2) / (bcl + th2) * b(i,j+1)
               else
-                 bfv = beta / (0.5d0 * h + bcl) * b(i,j+1)
+                 bfv = beta / (0.5e0_rt * h + bcl) * b(i,j+1)
                  bfm = bfv
               endif
            else if (bct == LO_NEUMANN) then
               bfv  = beta * r(i)
-              bfm  = 0.d0
-              bfm2 = 0.d0
+              bfm  = 0.e0_rt
+              bfm2 = 0.e0_rt
            else if (bct == LO_MARSHAK) then
-              bfv = 2.d0 * beta * r(i)
+              bfv = 2.e0_rt * beta * r(i)
               if (bho >= 1) then
-                 bfm  =  0.375d0 * c * bfv
-                 bfm2 = -0.125d0 * c * bfv
+                 bfm  =  0.375e0_rt * c * bfv
+                 bfm2 = -0.125e0_rt * c * bfv
               else
-                 bfm = 0.25d0 * c * bfv
+                 bfm = 0.25e0_rt * c * bfv
               endif
            else if (bct == LO_SANCHEZ_POMRANING) then
-              bfv = 2.d0 * beta * r(i)
+              bfv = 2.e0_rt * beta * r(i)
               if (bho >= 1) then
-                 bfm  =  1.5d0 * spa(i,j) * c * bfv
-                 bfm2 = -0.5d0 * spa(i,j) * c * bfv
+                 bfm  =  1.5e0_rt * spa(i,j) * c * bfv
+                 bfm2 = -0.5e0_rt * spa(i,j) * c * bfv
               else
                  bfm = spa(i,j) * c * bfv
               endif
@@ -881,7 +890,7 @@ subroutine hbflx3(flux, &
               stop
            endif
            if (inhom == 0) then
-              bfv = 0.d0
+              bfv = 0.e0_rt
            endif
            flux(i,j+1) = -(bfv * bcval(i,j+1) - bfm * er(i,j))
            if (bho >= 1) then
@@ -904,6 +913,7 @@ subroutine hdterm(dterm, &
                   d, DIMS(dbox), &
                   dx) bind(C, name="hdterm")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(dtbox)
   integer :: DIMDEC(ebox)
   integer :: DIMDEC(reg)
@@ -911,13 +921,13 @@ subroutine hdterm(dterm, &
   integer :: DIMDEC(msk)
   integer :: DIMDEC(dbox)
   integer :: cdir, bct
-  real*8 :: bcl, dx(2)
-  real*8 :: dterm(DIMV(dtbox))
-  real*8 :: er(DIMV(ebox))
-  real*8 :: bcval(DIMV(bcv))
+  real(rt)         :: bcl, dx(2)
+  real(rt)         :: dterm(DIMV(dtbox))
+  real(rt)         :: er(DIMV(ebox))
+  real(rt)         :: bcval(DIMV(bcv))
   integer :: mask(DIMV(msk))
-  real*8 :: d(DIMV(dbox))
-  real*8 :: h
+  real(rt)         :: d(DIMV(dbox))
+  real(rt)         :: h
   integer :: i, j
   if (cdir == 0 .OR. cdir == 2) then
      h = dx(1)
@@ -930,7 +940,7 @@ subroutine hdterm(dterm, &
         i = reg_l1
         do j = reg_l2, reg_h2
            if (mask(i-1,j) > 0) then
-              dterm(i,j) = d(i,j)*(er(i,j)-bcval(i-1,j))/(0.5d0*h+bcl)
+              dterm(i,j) = d(i,j)*(er(i,j)-bcval(i-1,j))/(0.5e0_rt*h+bcl)
            endif
         enddo
      else if (cdir == 2) then
@@ -938,7 +948,7 @@ subroutine hdterm(dterm, &
         i = reg_h1
         do j = reg_l2, reg_h2
            if (mask(i+1,j) > 0) then
-              dterm(i+1,j) = d(i+1,j)*(bcval(i+1,j)-er(i,j))/(0.5d0*h+bcl)
+              dterm(i+1,j) = d(i+1,j)*(bcval(i+1,j)-er(i,j))/(0.5e0_rt*h+bcl)
            endif
         enddo
      else if (cdir == 1) then
@@ -946,7 +956,7 @@ subroutine hdterm(dterm, &
         j = reg_l2
         do i = reg_l1, reg_h1
            if (mask(i,j-1) > 0) then
-              dterm(i,j) = d(i,j)*(er(i,j)-bcval(i,j-1))/(0.5d0*h+bcl)
+              dterm(i,j) = d(i,j)*(er(i,j)-bcval(i,j-1))/(0.5e0_rt*h+bcl)
            endif
         enddo
      else if (cdir == 3) then
@@ -954,7 +964,7 @@ subroutine hdterm(dterm, &
         j = reg_h2
         do i = reg_l1, reg_h1
            if (mask(i,j+1) > 0) then
-              dterm(i,j+1) = d(i,j+1)*(bcval(i,j+1)-er(i,j))/(0.5d0*h+bcl)
+              dterm(i,j+1) = d(i,j+1)*(bcval(i,j+1)-er(i,j))/(0.5e0_rt*h+bcl)
            endif
         enddo
      else
@@ -976,6 +986,7 @@ subroutine hdterm3(dterm, &
                    d, DIMS(dbox), &
                    dx) bind(C, name="hdterm3")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(dtbox)
   integer :: DIMDEC(ebox)
   integer :: DIMDEC(reg)
@@ -983,13 +994,13 @@ subroutine hdterm3(dterm, &
   integer :: DIMDEC(msk)
   integer :: DIMDEC(dbox)
   integer :: cdir, bctype, tf(DIMV(bcv))
-  real*8 :: bcl, dx(2)
-  real*8 :: dterm(DIMV(dtbox))
-  real*8 :: er(DIMV(ebox))
-  real*8 :: bcval(DIMV(bcv))
+  real(rt)         :: bcl, dx(2)
+  real(rt)         :: dterm(DIMV(dtbox))
+  real(rt)         :: er(DIMV(ebox))
+  real(rt)         :: bcval(DIMV(bcv))
   integer :: mask(DIMV(msk))
-  real*8 :: d(DIMV(dbox))
-  real*8 :: h
+  real(rt)         :: d(DIMV(dbox))
+  real(rt)         :: h
   integer :: i, j, bct
   if (cdir == 0 .OR. cdir == 2) then
      h = dx(1)
@@ -1007,9 +1018,9 @@ subroutine hdterm3(dterm, &
               bct = bctype
            endif
            if (bct == LO_DIRICHLET) then
-              dterm(i,j) = d(i,j)*(er(i,j)-bcval(i-1,j))/(0.5d0*h+bcl)
-           else if (bct == LO_NEUMANN .AND. bcval(i-1,j) == 0.d0) then
-              dterm(i,j) = 0.d0
+              dterm(i,j) = d(i,j)*(er(i,j)-bcval(i-1,j))/(0.5e0_rt*h+bcl)
+           else if (bct == LO_NEUMANN .AND. bcval(i-1,j) == 0.e0_rt) then
+              dterm(i,j) = 0.e0_rt
            else
               print *, "hdterm3: unsupported boundary type"
               stop
@@ -1027,9 +1038,9 @@ subroutine hdterm3(dterm, &
               bct = bctype
            endif
            if (bct == LO_DIRICHLET) then
-              dterm(i+1,j) = d(i+1,j)*(bcval(i+1,j)-er(i,j))/(0.5d0*h+bcl)
-           else if (bct == LO_NEUMANN .AND. bcval(i+1,j) == 0.d0) then
-              dterm(i+1,j) = 0.d0
+              dterm(i+1,j) = d(i+1,j)*(bcval(i+1,j)-er(i,j))/(0.5e0_rt*h+bcl)
+           else if (bct == LO_NEUMANN .AND. bcval(i+1,j) == 0.e0_rt) then
+              dterm(i+1,j) = 0.e0_rt
            else
               print *, "hdterm3: unsupported boundary type"
               stop
@@ -1047,9 +1058,9 @@ subroutine hdterm3(dterm, &
               bct = bctype
            endif
            if (bct == LO_DIRICHLET) then
-              dterm(i,j) = d(i,j)*(er(i,j)-bcval(i,j-1))/(0.5d0*h+bcl)
-           else if (bct == LO_NEUMANN .AND. bcval(i,j-1) == 0.d0) then
-              dterm(i,j) = 0.d0
+              dterm(i,j) = d(i,j)*(er(i,j)-bcval(i,j-1))/(0.5e0_rt*h+bcl)
+           else if (bct == LO_NEUMANN .AND. bcval(i,j-1) == 0.e0_rt) then
+              dterm(i,j) = 0.e0_rt
            else
               print *, "hdterm3: unsupported boundary type"
               stop
@@ -1067,9 +1078,9 @@ subroutine hdterm3(dterm, &
               bct = bctype
            endif
            if (bct == LO_DIRICHLET) then
-              dterm(i,j+1) = d(i,j+1)*(bcval(i,j+1)-er(i,j))/(0.5d0*h+bcl)
-           else if (bct == LO_NEUMANN .AND. bcval(i,j+1) == 0.d0) then
-              dterm(i,j+1) = 0.d0
+              dterm(i,j+1) = d(i,j+1)*(bcval(i,j+1)-er(i,j))/(0.5e0_rt*h+bcl)
+           else if (bct == LO_NEUMANN .AND. bcval(i,j+1) == 0.e0_rt) then
+              dterm(i,j+1) = 0.e0_rt
            else
               print *, "hdterm3: unsupported boundary type"
               stop
@@ -1086,16 +1097,17 @@ subroutine hmac(mat, a, &
                 DIMS(reg), &
                 alpha) bind(C, name="hmac")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(abox)
   integer :: DIMDEC(reg)
-  real*8 :: a(DIMV(abox))
-  real*8 :: mat(0:4, DIMV(reg))
-  real*8 :: alpha
+  real(rt)         :: a(DIMV(abox))
+  real(rt)         :: mat(0:4, DIMV(reg))
+  real(rt)         :: alpha
   integer :: i, j
-  if (alpha == 0.d0) then
+  if (alpha == 0.e0_rt) then
      do j = reg_l2, reg_h2
         do i = reg_l1, reg_h1
-           mat(0,i,j) = 0.d0
+           mat(0,i,j) = 0.e0_rt
         enddo
      enddo
   else
@@ -1112,13 +1124,14 @@ subroutine hmbc(mat, b, &
                 DIMS(reg), &
                 beta, dx, n) bind(C, name="hmbc")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(bbox)
   integer :: DIMDEC(reg)
   integer :: n
-  real*8 :: b(DIMV(bbox))
-  real*8 :: mat(0:4, DIMV(reg))
-  real*8 :: beta, dx(2)
-  real*8 :: fac
+  real(rt)         :: b(DIMV(bbox))
+  real(rt)         :: mat(0:4, DIMV(reg))
+  real(rt)         :: beta, dx(2)
+  real(rt)         :: fac
   integer :: i, j
   if (n == 0) then
      fac = beta / (dx(1)**2)
@@ -1146,15 +1159,16 @@ subroutine hma2c(mat, a2, &
                  DIMS(reg), &
                  alpha2, n) bind(C, name="hma2c")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(bbox)
   integer :: DIMDEC(reg)
   integer :: n
-  real*8 :: a2(DIMV(bbox))
-  real*8 :: mat(0:4, DIMV(reg))
-  real*8 :: alpha2
-  real*8 :: fac
+  real(rt)         :: a2(DIMV(bbox))
+  real(rt)         :: mat(0:4, DIMV(reg))
+  real(rt)         :: alpha2
+  real(rt)         :: fac
   integer :: i, j
-  fac = 0.25d0 * alpha2
+  fac = 0.25e0_rt * alpha2
   if (n == 0) then
      do j = reg_l2, reg_h2
         do i = reg_l1, reg_h1
@@ -1179,16 +1193,17 @@ subroutine hmcc(mat, c, &
                 DIMS(reg), &
                 gamma, dx, n) bind(C, name="hmcc")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(bbox)
   integer :: DIMDEC(reg)
   integer :: n
-  real*8 :: c(DIMV(bbox))
-  real*8 :: mat(0:4, DIMV(reg))
-  real*8 :: gamma, dx(2)
-  real*8 :: fac
+  real(rt)         :: c(DIMV(bbox))
+  real(rt)         :: mat(0:4, DIMV(reg))
+  real(rt)         :: gamma, dx(2)
+  real(rt)         :: fac
   integer :: i, j
   if (n == 0) then
-     fac = 0.5d0 * gamma / dx(1)
+     fac = 0.5e0_rt * gamma / dx(1)
      do j = reg_l2, reg_h2
         do i = reg_l1, reg_h1
            mat(0,i,j) = mat(0,i,j) - fac * (c(i,j) - c(i+1,j))
@@ -1197,7 +1212,7 @@ subroutine hmcc(mat, c, &
         enddo
      enddo
   else
-     fac = 0.5d0 * gamma / dx(2)
+     fac = 0.5e0_rt * gamma / dx(2)
      do j = reg_l2, reg_h2
         do i = reg_l1, reg_h1
            mat(0,i,j) = mat(0,i,j) - fac * (c(i,j) - c(i,j+1))
@@ -1213,16 +1228,17 @@ subroutine hmd1c(mat, d1, &
                  DIMS(reg), &
                  delta1, dx, n) bind(C, name="hmd1c")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(abox)
   integer :: DIMDEC(reg)
   integer :: n
-  real*8 :: d1(DIMV(abox))
-  real*8 :: mat(0:4, DIMV(reg))
-  real*8 :: delta1, dx(2)
-  real*8 :: fac
+  real(rt)         :: d1(DIMV(abox))
+  real(rt)         :: mat(0:4, DIMV(reg))
+  real(rt)         :: delta1, dx(2)
+  real(rt)         :: fac
   integer :: i, j
   if (n == 0) then
-     fac = 0.5d0 * delta1 / dx(1)
+     fac = 0.5e0_rt * delta1 / dx(1)
      do j = reg_l2, reg_h2
         do i = reg_l1, reg_h1
            mat(1,i,j) = mat(1,i,j) - fac * d1(i,j)
@@ -1230,7 +1246,7 @@ subroutine hmd1c(mat, d1, &
         enddo
      enddo
   else
-     fac = 0.5d0 * delta1 / dx(2)
+     fac = 0.5e0_rt * delta1 / dx(2)
      do j = reg_l2, reg_h2
         do i = reg_l1, reg_h1
            mat(3,i,j) = mat(3,i,j) - fac * d1(i,j)
@@ -1245,16 +1261,17 @@ subroutine hmd2c(mat, d2, &
                  DIMS(reg), &
                  delta2, dx, n) bind(C, name="hmd2c")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(bbox)
   integer :: DIMDEC(reg)
   integer :: n
-  real*8 :: d2(DIMV(bbox))
-  real*8 :: mat(0:4, DIMV(reg))
-  real*8 :: delta2, dx(2)
-  real*8 :: fac
+  real(rt)         :: d2(DIMV(bbox))
+  real(rt)         :: mat(0:4, DIMV(reg))
+  real(rt)         :: delta2, dx(2)
+  real(rt)         :: fac
   integer :: i, j
   if (n == 0) then
-     fac = 0.5d0 * delta2 / dx(1)
+     fac = 0.5e0_rt * delta2 / dx(1)
      do j = reg_l2, reg_h2
         do i = reg_l1, reg_h1
            mat(0,i,j) = mat(0,i,j) + fac * (d2(i,j) - d2(i+1,j))
@@ -1263,7 +1280,7 @@ subroutine hmd2c(mat, d2, &
         enddo
      enddo
   else
-     fac = 0.5d0 * delta2 / dx(2)
+     fac = 0.5e0_rt * delta2 / dx(2)
      do j = reg_l2, reg_h2
         do i = reg_l1, reg_h1
            mat(0,i,j) = mat(0,i,j) + fac * (d2(i,j) - d2(i,j+1))
@@ -1281,16 +1298,17 @@ subroutine hmmat(mat, &
                  b, DIMS(bbox), &
                  beta, dx) bind(C, name="hmmat")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(reg)
   integer :: DIMDEC(msk)
   integer :: DIMDEC(bbox)
   integer :: cdir, bct, bho
-  real*8 :: bcl, beta, dx(2)
-  real*8 :: mat(0:4, DIMV(reg))
+  real(rt)         :: bcl, beta, dx(2)
+  real(rt)         :: mat(0:4, DIMV(reg))
   integer :: mask(DIMV(msk))
-  real*8 :: b(DIMV(bbox))
-  real*8 :: h, fac, bfm, bfv
-  real*8 :: bfm2, h2, th2
+  real(rt)         :: b(DIMV(bbox))
+  real(rt)         :: h, fac, bfm, bfv
+  real(rt)         :: bfm2, h2, th2
   integer :: i, j
   if (cdir == 0 .OR. cdir == 2) then
      h = dx(1)
@@ -1300,17 +1318,17 @@ subroutine hmmat(mat, &
   fac = beta / (h**2)
   if (bct == LO_DIRICHLET) then
      if (bho >= 1) then
-        h2 = 0.5d0 * h
-        th2 = 3.d0 * h2
+        h2 = 0.5e0_rt * h
+        th2 = 3.e0_rt * h2
         bfm = fac * (th2 - bcl) / (bcl + h2) - fac
         bfm2 = fac * (bcl - h2) / (bcl + th2)
      else
-        bfv = (beta / h) / (0.5d0 * h + bcl)
+        bfv = (beta / h) / (0.5e0_rt * h + bcl)
         bfm = bfv - fac
      endif
   else if (bct == LO_NEUMANN) then
      bfm = -fac
-     bfm2 = 0.d0
+     bfm2 = 0.e0_rt
   else
      print *, "hmmat: unsupported boundary type"
      stop
@@ -1321,7 +1339,7 @@ subroutine hmmat(mat, &
      do j = reg_l2, reg_h2
         if (mask(i-1,j) > 0) then
            mat(0,i,j) = mat(0,i,j) + bfm * b(i,j)
-           mat(1,i,j) = 0.d0
+           mat(1,i,j) = 0.e0_rt
            if (bho >= 1) then
               mat(2,i,j) = mat(2,i,j) + bfm2 * b(i,j)
            endif
@@ -1333,7 +1351,7 @@ subroutine hmmat(mat, &
      do j = reg_l2, reg_h2
         if (mask(i+1,j) > 0) then
            mat(0,i,j) = mat(0,i,j) + bfm * b(i+1,j)
-           mat(2,i,j) = 0.d0
+           mat(2,i,j) = 0.e0_rt
            if (bho >= 1) then
               mat(1,i,j) = mat(1,i,j) + bfm2 * b(i+1,j)
            endif
@@ -1345,7 +1363,7 @@ subroutine hmmat(mat, &
      do i = reg_l1, reg_h1
         if (mask(i,j-1) > 0) then
            mat(0,i,j) = mat(0,i,j) + bfm * b(i,j)
-           mat(3,i,j) = 0.d0
+           mat(3,i,j) = 0.e0_rt
            if (bho >= 1) then
               mat(4,i,j) = mat(4,i,j) + bfm2 * b(i,j)
            endif
@@ -1357,7 +1375,7 @@ subroutine hmmat(mat, &
      do i = reg_l1, reg_h1
         if (mask(i,j+1) > 0) then
            mat(0,i,j) = mat(0,i,j) + bfm * b(i,j+1)
-           mat(4,i,j) = 0.d0
+           mat(4,i,j) = 0.e0_rt
            if (bho >= 1) then
               mat(3,i,j) = mat(3,i,j) + bfm2 * b(i,j+1)
            endif
@@ -1377,20 +1395,21 @@ subroutine hmmat3(mat, &
                   beta, dx, c, r, &
                   spa, DIMS(spabox)) bind(C, name="hmmat3")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(reg)
   integer :: DIMDEC(bcv)
   integer :: DIMDEC(msk)
   integer :: DIMDEC(bbox)
   integer :: DIMDEC(spabox)
   integer :: cdir, bctype, tf(DIMV(bcv)), bho
-  real*8 :: bcl, beta, dx(2), c
-  real*8 :: mat(0:4, DIMV(reg))
+  real(rt)         :: bcl, beta, dx(2), c
+  real(rt)         :: mat(0:4, DIMV(reg))
   integer :: mask(DIMV(msk))
-  real*8 :: b(DIMV(bbox))
-  real*8 :: spa(DIMV(spabox))
-  real*8 :: r(reg_l1:reg_h1)
-  real*8 :: h, fac, bfm, bfv, r0
-  real*8 :: bfm2, h2, th2
+  real(rt)         :: b(DIMV(bbox))
+  real(rt)         :: spa(DIMV(spabox))
+  real(rt)         :: r(reg_l1:reg_h1)
+  real(rt)         :: h, fac, bfm, bfv, r0
+  real(rt)         :: bfm2, h2, th2
   integer :: i, j, bct
   if (cdir == 0 .OR. cdir == 2) then
      h = dx(1)
@@ -1416,30 +1435,30 @@ subroutine hmmat3(mat, &
            endif
            if (bct == LO_DIRICHLET) then
               if (bho >= 1) then
-                 h2 = 0.5d0 * h
-                 th2 = 3.d0 * h2
+                 h2 = 0.5e0_rt * h
+                 th2 = 3.e0_rt * h2
                  bfm = fac * (th2 - bcl) / (bcl + h2)  * b(i,j)
                  bfm2 = fac * (bcl - h2) / (bcl + th2) * b(i,j)
               else
-                 bfv = (beta / h) / (0.5d0 * h + bcl)
+                 bfv = (beta / h) / (0.5e0_rt * h + bcl)
                  bfm = bfv * b(i,j)
               endif
            else if (bct == LO_NEUMANN) then
-              bfm  = 0.d0
-              bfm2 = 0.d0
+              bfm  = 0.e0_rt
+              bfm2 = 0.e0_rt
            else if (bct == LO_MARSHAK) then
-              bfv = 2.d0 * beta * r0 / h
+              bfv = 2.e0_rt * beta * r0 / h
               if (bho >= 1) then
-                 bfm  =  0.375d0 * c * bfv
-                 bfm2 = -0.125d0 * c * bfv
+                 bfm  =  0.375e0_rt * c * bfv
+                 bfm2 = -0.125e0_rt * c * bfv
               else
-                 bfm = 0.25d0 * c * bfv
+                 bfm = 0.25e0_rt * c * bfv
               endif
            else if (bct == LO_SANCHEZ_POMRANING) then
-              bfv = 2.d0 * beta * r0 / h
+              bfv = 2.e0_rt * beta * r0 / h
               if (bho >= 1) then
-                 bfm  =  1.5d0 * spa(i,j) * c * bfv
-                 bfm2 = -0.5d0 * spa(i,j) * c * bfv
+                 bfm  =  1.5e0_rt * spa(i,j) * c * bfv
+                 bfm2 = -0.5e0_rt * spa(i,j) * c * bfv
               else
                  bfm = spa(i,j) * c * bfv
               endif
@@ -1448,7 +1467,7 @@ subroutine hmmat3(mat, &
               stop
            endif
            mat(0,i,j) = mat(0,i,j) + bfm - fac * b(i,j)
-           mat(1,i,j) = 0.d0
+           mat(1,i,j) = 0.e0_rt
            if (bho >= 1) then
               mat(2,i,j) = mat(2,i,j) + bfm2
            endif
@@ -1466,30 +1485,30 @@ subroutine hmmat3(mat, &
            endif
            if (bct == LO_DIRICHLET) then
               if (bho >= 1) then
-                 h2 = 0.5d0 * h
-                 th2 = 3.d0 * h2
+                 h2 = 0.5e0_rt * h
+                 th2 = 3.e0_rt * h2
                  bfm = fac * (th2 - bcl) / (bcl + h2)  * b(i+1,j)
                  bfm2 = fac * (bcl - h2) / (bcl + th2) * b(i+1,j)
               else
-                 bfv = (beta / h) / (0.5d0 * h + bcl)
+                 bfv = (beta / h) / (0.5e0_rt * h + bcl)
                  bfm = bfv * b(i+1,j)
               endif
            else if (bct == LO_NEUMANN) then
-              bfm  = 0.d0
-              bfm2 = 0.d0
+              bfm  = 0.e0_rt
+              bfm2 = 0.e0_rt
            else if (bct == LO_MARSHAK) then
-              bfv = 2.d0 * beta * r0 / h
+              bfv = 2.e0_rt * beta * r0 / h
               if (bho >= 1) then
-                 bfm  =  0.375d0 * c * bfv
-                 bfm2 = -0.125d0 * c * bfv
+                 bfm  =  0.375e0_rt * c * bfv
+                 bfm2 = -0.125e0_rt * c * bfv
               else
-                 bfm = 0.25d0 * c * bfv
+                 bfm = 0.25e0_rt * c * bfv
               endif
            else if (bct == LO_SANCHEZ_POMRANING) then
-              bfv = 2.d0 * beta * r0 / h
+              bfv = 2.e0_rt * beta * r0 / h
               if (bho >= 1) then
-                 bfm  =  1.5d0 * spa(i,j) * c * bfv
-                 bfm2 = -0.5d0 * spa(i,j) * c * bfv
+                 bfm  =  1.5e0_rt * spa(i,j) * c * bfv
+                 bfm2 = -0.5e0_rt * spa(i,j) * c * bfv
               else
                  bfm = spa(i,j) * c * bfv
               endif
@@ -1498,7 +1517,7 @@ subroutine hmmat3(mat, &
               stop
            endif
            mat(0,i,j) = mat(0,i,j) + bfm - fac * b(i+1,j)
-           mat(2,i,j) = 0.d0
+           mat(2,i,j) = 0.e0_rt
            if (bho >= 1) then
               mat(1,i,j) = mat(1,i,j) + bfm2
            endif
@@ -1516,30 +1535,30 @@ subroutine hmmat3(mat, &
            endif
            if (bct == LO_DIRICHLET) then
               if (bho >= 1) then
-                 h2 = 0.5d0 * h
-                 th2 = 3.d0 * h2
+                 h2 = 0.5e0_rt * h
+                 th2 = 3.e0_rt * h2
                  bfm = fac * (th2 - bcl) / (bcl + h2)  * b(i,j)
                  bfm2 = fac * (bcl - h2) / (bcl + th2) * b(i,j)
               else
-                 bfv = (beta / h) / (0.5d0 * h + bcl)
+                 bfv = (beta / h) / (0.5e0_rt * h + bcl)
                  bfm = bfv * b(i,j)
               endif
            else if (bct == LO_NEUMANN) then
-              bfm  = 0.d0
-              bfm2 = 0.d0
+              bfm  = 0.e0_rt
+              bfm2 = 0.e0_rt
            else if (bct == LO_MARSHAK) then
-              bfv = 2.d0 * beta * r(i) / h
+              bfv = 2.e0_rt * beta * r(i) / h
               if (bho >= 1) then
-                 bfm  =  0.375d0 * c * bfv
-                 bfm2 = -0.125d0 * c * bfv
+                 bfm  =  0.375e0_rt * c * bfv
+                 bfm2 = -0.125e0_rt * c * bfv
               else
-                 bfm = 0.25d0 * c * bfv
+                 bfm = 0.25e0_rt * c * bfv
               endif
            else if (bct == LO_SANCHEZ_POMRANING) then
-              bfv = 2.d0 * beta * r(i) / h
+              bfv = 2.e0_rt * beta * r(i) / h
               if (bho >= 1) then
-                 bfm  =  1.5d0 * spa(i,j) * c * bfv
-                 bfm2 = -0.5d0 * spa(i,j) * c * bfv
+                 bfm  =  1.5e0_rt * spa(i,j) * c * bfv
+                 bfm2 = -0.5e0_rt * spa(i,j) * c * bfv
               else
                  bfm = spa(i,j) * c * bfv
               endif
@@ -1548,7 +1567,7 @@ subroutine hmmat3(mat, &
               stop
            endif
            mat(0,i,j) = mat(0,i,j) + bfm - fac * b(i,j)
-           mat(3,i,j) = 0.d0
+           mat(3,i,j) = 0.e0_rt
            if (bho >= 1) then
               mat(4,i,j) = mat(4,i,j) + bfm2
            endif
@@ -1566,30 +1585,30 @@ subroutine hmmat3(mat, &
            endif
            if (bct == LO_DIRICHLET) then
               if (bho >= 1) then
-                 h2 = 0.5d0 * h
-                 th2 = 3.d0 * h2
+                 h2 = 0.5e0_rt * h
+                 th2 = 3.e0_rt * h2
                  bfm = fac * (th2 - bcl) / (bcl + h2)  * b(i,j+1)
                  bfm2 = fac * (bcl - h2) / (bcl + th2) * b(i,j+1)
               else
-                 bfv = (beta / h) / (0.5d0 * h + bcl)
+                 bfv = (beta / h) / (0.5e0_rt * h + bcl)
                  bfm = bfv * b(i,j+1)
               endif
            else if (bct == LO_NEUMANN) then
-              bfm  = 0.d0
-              bfm2 = 0.d0
+              bfm  = 0.e0_rt
+              bfm2 = 0.e0_rt
            else if (bct == LO_MARSHAK) then
-              bfv = 2.d0 * beta * r(i) / h
+              bfv = 2.e0_rt * beta * r(i) / h
               if (bho >= 1) then
-                 bfm  =  0.375d0 * c * bfv
-                 bfm2 = -0.125d0 * c * bfv
+                 bfm  =  0.375e0_rt * c * bfv
+                 bfm2 = -0.125e0_rt * c * bfv
               else
-                 bfm = 0.25d0 * c * bfv
+                 bfm = 0.25e0_rt * c * bfv
               endif
            else if (bct == LO_SANCHEZ_POMRANING) then
-              bfv = 2.d0 * beta * r(i) / h
+              bfv = 2.e0_rt * beta * r(i) / h
               if (bho >= 1) then
-                 bfm  =  1.5d0 * spa(i,j) * c * bfv
-                 bfm2 = -0.5d0 * spa(i,j) * c * bfv
+                 bfm  =  1.5e0_rt * spa(i,j) * c * bfv
+                 bfm2 = -0.5e0_rt * spa(i,j) * c * bfv
               else
                  bfm = spa(i,j) * c * bfv
               endif
@@ -1598,7 +1617,7 @@ subroutine hmmat3(mat, &
               stop
            endif
            mat(0,i,j) = mat(0,i,j) + bfm - fac * b(i,j+1)
-           mat(4,i,j) = 0.d0
+           mat(4,i,j) = 0.e0_rt
            if (bho >= 1) then
               mat(3,i,j) = mat(3,i,j) + bfm2
            endif
@@ -1617,17 +1636,18 @@ subroutine set_abec_flux( &
                          dx, &
                          flux, DIMS(flux)) bind(C, name="set_abec_flux")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(reg)
   integer :: DIMDEC(density)
   integer :: DIMDEC(dcoef)
   integer :: DIMDEC(flux)
 
-  real*8 :: density(DIMV(density))
-  real*8 :: dcoef(DIMV(dcoef))
-  real*8 :: flux(DIMV(flux))
+  real(rt)         :: density(DIMV(density))
+  real(rt)         :: dcoef(DIMV(dcoef))
+  real(rt)         :: flux(DIMV(flux))
 
   integer :: dir,i,j
-  real*8 :: beta, dx(BL_SPACEDIM), fac
+  real(rt)         :: beta, dx(BL_SPACEDIM), fac
 
 
   if( dir == 0 ) then

--- a/Source/Radiation/RadSrc_2d/MGFLD_2d.f90
+++ b/Source/Radiation/RadSrc_2d/MGFLD_2d.f90
@@ -9,6 +9,7 @@ subroutine ca_accel_acoe( lo, hi,  &
 
   use rad_params_module, only : ngroups, clight
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: lo(2), hi(2)
@@ -16,16 +17,16 @@ subroutine ca_accel_acoe( lo, hi,  &
   integer, intent(in) ::  spc_l1, spc_h1, spc_l2, spc_h2
   integer, intent(in) ::  kap_l1, kap_h1, kap_l2, kap_h2
   integer, intent(in) ::  aco_l1, aco_h1, aco_l2, aco_h2
-  double precision, intent(in ) :: eta1(eta1_l1:eta1_h1,eta1_l2:eta1_h2)
-  double precision, intent(in ) :: spc ( spc_l1: spc_h1, spc_l2: spc_h2,0:ngroups-1)
-  double precision, intent(in ) :: kap ( kap_l1: kap_h1, kap_l2: kap_h2,0:ngroups-1)
-  double precision              :: aco ( aco_l1: aco_h1, aco_l2: aco_h2)
-  double precision, intent(in) :: dt, tau
+  real(rt)        , intent(in ) :: eta1(eta1_l1:eta1_h1,eta1_l2:eta1_h2)
+  real(rt)        , intent(in ) :: spc ( spc_l1: spc_h1, spc_l2: spc_h2,0:ngroups-1)
+  real(rt)        , intent(in ) :: kap ( kap_l1: kap_h1, kap_l2: kap_h2,0:ngroups-1)
+  real(rt)                      :: aco ( aco_l1: aco_h1, aco_l2: aco_h2)
+  real(rt)        , intent(in) :: dt, tau
 
   integer :: i, j
-  double precision :: kbar, H1, dt1
+  real(rt)         :: kbar, H1, dt1
 
-  dt1 = (1.d0+tau)/dt
+  dt1 = (1.e0_rt+tau)/dt
 
   do j = lo(2), hi(2)
   do i = lo(1), hi(1)
@@ -48,6 +49,7 @@ subroutine ca_accel_rhs( lo, hi, &
 
   use rad_params_module, only : ngroups, clight
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: lo(2), hi(2)
@@ -56,15 +58,15 @@ subroutine ca_accel_rhs( lo, hi, &
   integer, intent(in) :: kap_l1, kap_h1, kap_l2, kap_h2
   integer, intent(in) ::etaT_l1,etaT_h1,etaT_l2,etaT_h2
   integer, intent(in) :: rhs_l1, rhs_h1, rhs_l2, rhs_h2
-  double precision, intent(in) ::Ern ( Ern_l1: Ern_h1, Ern_l2: Ern_h2,0:ngroups-1)
-  double precision, intent(in) ::Erl ( Erl_l1: Erl_h1, Erl_l2: Erl_h2,0:ngroups-1)
-  double precision, intent(in) :: kap( kap_l1: kap_h1, kap_l2: kap_h2,0:ngroups-1)
-  double precision, intent(in) ::etaT(etaT_l1:etaT_h1,etaT_l2:etaT_h2)
-  double precision             :: rhs( rhs_l1: rhs_h1, rhs_l2: rhs_h2)
-  double precision, intent(in) :: dt
+  real(rt)        , intent(in) ::Ern ( Ern_l1: Ern_h1, Ern_l2: Ern_h2,0:ngroups-1)
+  real(rt)        , intent(in) ::Erl ( Erl_l1: Erl_h1, Erl_l2: Erl_h2,0:ngroups-1)
+  real(rt)        , intent(in) :: kap( kap_l1: kap_h1, kap_l2: kap_h2,0:ngroups-1)
+  real(rt)        , intent(in) ::etaT(etaT_l1:etaT_h1,etaT_l2:etaT_h2)
+  real(rt)                     :: rhs( rhs_l1: rhs_h1, rhs_l2: rhs_h2)
+  real(rt)        , intent(in) :: dt
 
   integer :: i, j
-  double precision :: rt_term, H
+  real(rt)         :: rt_term, H
 
   do j = lo(2), hi(2)
   do i = lo(1), hi(1)
@@ -85,30 +87,31 @@ subroutine ca_accel_spec(lo, hi, &
 
   use rad_params_module, only : ngroups, clight
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: lo(2), hi(2)
   integer,intent(in):: kap_l1, kap_h1, kap_l2, kap_h2
   integer,intent(in)::mugT_l1,mugT_h1,mugT_l2,mugT_h2
   integer,intent(in)::spec_l1,spec_h1,spec_l2,spec_h2
-  double precision,intent(in)::kap ( kap_l1: kap_h1, kap_l2: kap_h2,0:ngroups-1)
-  double precision,intent(in)::mugT(mugT_l1:mugT_h1,mugT_l2:mugT_h2,0:ngroups-1)
-  double precision           ::spec(spec_l1:spec_h1,spec_l2:spec_h2,0:ngroups-1)
-  double precision,intent(in) :: dt, tau
+  real(rt)        ,intent(in)::kap ( kap_l1: kap_h1, kap_l2: kap_h2,0:ngroups-1)
+  real(rt)        ,intent(in)::mugT(mugT_l1:mugT_h1,mugT_l2:mugT_h2,0:ngroups-1)
+  real(rt)                   ::spec(spec_l1:spec_h1,spec_l2:spec_h2,0:ngroups-1)
+  real(rt)        ,intent(in) :: dt, tau
 
   integer :: i, j
-  double precision :: cdt1, sumeps
-  double precision,dimension(0:ngroups-1):: epsilon, kapt
+  real(rt)         :: cdt1, sumeps
+  real(rt)        ,dimension(0:ngroups-1):: epsilon, kapt
 
-  cdt1 = 1.d0/(clight*dt)
+  cdt1 = 1.e0_rt/(clight*dt)
 
   do j = lo(2), hi(2)
   do i = lo(1), hi(1)
-     kapt = kap(i,j,:) + (1.d0+tau)*cdt1
+     kapt = kap(i,j,:) + (1.e0_rt+tau)*cdt1
      epsilon = mugT(i,j,:) / kapt
      sumeps = sum(epsilon)
-     if (sumeps .eq. 0.d0) then
-        spec(i,j,:) = 0.d0
+     if (sumeps .eq. 0.e0_rt) then
+        spec(i,j,:) = 0.e0_rt
      else
         spec(i,j,:) = epsilon / sumeps
      end if
@@ -134,6 +137,7 @@ subroutine ca_check_conv( lo, hi, &
      dt)
   use rad_params_module, only : ngroups, clight
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer,intent(in)::lo(2),hi(2)
@@ -147,34 +151,34 @@ subroutine ca_check_conv( lo, hi, &
   integer,intent(in)::kap_l1, kap_h1, kap_l2, kap_h2
   integer,intent(in):: jg_l1,  jg_h1,  jg_l2,  jg_h2
   integer,intent(in)::deT_l1, deT_h1, deT_l2, deT_h2
-  double precision,intent(in   )::ren(ren_l1:ren_h1,ren_l2:ren_h2)
-  double precision,intent(in   )::res(res_l1:res_h1,res_l2:res_h2)
-  double precision,intent(in   )::re2(re2_l1:re2_h1,re2_l2:re2_h2)
-  double precision,intent(in   )::ern(ern_l1:ern_h1,ern_l2:ern_h2,0:ngroups-1)
-  double precision,intent(in   )::Tmn(Tmn_l1:Tmn_h1,Tmn_l2:Tmn_h2)
-  double precision,intent(in   )::Tms(Tms_l1:Tms_h1,Tms_l2:Tms_h2)
-  double precision,intent(in   )::rho(rho_l1:rho_h1,rho_l2:rho_h2)
-  double precision,intent(in   )::kap(kap_l1:kap_h1,kap_l2:kap_h2,0:ngroups-1)
-  double precision,intent(in   ):: jg( jg_l1: jg_h1, jg_l2: jg_h2,0:ngroups-1)
-  double precision,intent(in   )::deT(deT_l1:deT_h1,deT_l2:deT_h2)
-  double precision,intent(inout)::rel_re, abs_re 
-  double precision,intent(inout)::rel_FT, abs_FT,rel_T, abs_T
-  double precision,intent(in) :: dt
+  real(rt)        ,intent(in   )::ren(ren_l1:ren_h1,ren_l2:ren_h2)
+  real(rt)        ,intent(in   )::res(res_l1:res_h1,res_l2:res_h2)
+  real(rt)        ,intent(in   )::re2(re2_l1:re2_h1,re2_l2:re2_h2)
+  real(rt)        ,intent(in   )::ern(ern_l1:ern_h1,ern_l2:ern_h2,0:ngroups-1)
+  real(rt)        ,intent(in   )::Tmn(Tmn_l1:Tmn_h1,Tmn_l2:Tmn_h2)
+  real(rt)        ,intent(in   )::Tms(Tms_l1:Tms_h1,Tms_l2:Tms_h2)
+  real(rt)        ,intent(in   )::rho(rho_l1:rho_h1,rho_l2:rho_h2)
+  real(rt)        ,intent(in   )::kap(kap_l1:kap_h1,kap_l2:kap_h2,0:ngroups-1)
+  real(rt)        ,intent(in   ):: jg( jg_l1: jg_h1, jg_l2: jg_h2,0:ngroups-1)
+  real(rt)        ,intent(in   )::deT(deT_l1:deT_h1,deT_l2:deT_h2)
+  real(rt)        ,intent(inout)::rel_re, abs_re 
+  real(rt)        ,intent(inout)::rel_FT, abs_FT,rel_T, abs_T
+  real(rt)        ,intent(in) :: dt
 
   integer :: i, j
-  double precision :: chg, relchg, FT, cdt, FTdenom, dTe
+  real(rt)         :: chg, relchg, FT, cdt, FTdenom, dTe
 
   cdt = clight*dt
 
   do j=lo(2),hi(2)
   do i=lo(1),hi(1)
      chg = abs(ren(i,j) - res(i,j))
-     relchg = abs(chg/(ren(i,j)+1.d-50))
+     relchg = abs(chg/(ren(i,j)+1.e-50_rt))
      rel_re = max(rel_re,relchg)
      abs_re = max(abs_re,chg)
 
      chg = abs(Tmn(i,j) - Tms(i,j))
-     relchg = abs(chg/(Tmn(i,j)+1.d-50))
+     relchg = abs(chg/(Tmn(i,j)+1.e-50_rt))
      rel_T = max(rel_T,relchg)
      abs_T = max(abs_T,chg)
 
@@ -182,9 +186,9 @@ subroutine ca_check_conv( lo, hi, &
 
      dTe = Tmn(i,j)
      FTdenom = rho(i,j)*abs(deT(i,j)*dTe)
-!     FTdenom = max(abs(ren(i,j)-re2(i,j)), abs(ren(i,j)*1.d-15))
+!     FTdenom = max(abs(ren(i,j)-re2(i,j)), abs(ren(i,j)*1.e-15_rt))
 
-     rel_FT = max(rel_FT, FT/(FTdenom+1.d-50))
+     rel_FT = max(rel_FT, FT/(FTdenom+1.e-50_rt))
      abs_FT = max(abs_FT, FT)
   end do
   end do
@@ -202,6 +206,7 @@ subroutine ca_check_conv_er( lo, hi, &
 
   use rad_params_module, only : ngroups, clight
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer,intent(in):: lo(2), hi(2)
@@ -210,23 +215,23 @@ subroutine ca_check_conv_er( lo, hi, &
   integer,intent(in):: kap_l1, kap_h1, kap_l2, kap_h2
   integer,intent(in)::temp_l1,temp_h1,temp_l2,temp_h2
   integer,intent(in)::etTz_l1,etTz_h1,etTz_l2,etTz_h2
-  double precision,intent(in):: Ern( Ern_l1: Ern_h1, Ern_l2: Ern_h2,0:ngroups-1)
-  double precision,intent(in):: Erl( Erl_l1: Erl_h1, Erl_l2: Erl_h2,0:ngroups-1)
-  double precision,intent(in):: kap( kap_l1: kap_h1, kap_l2: kap_h2,0:ngroups-1)
-  double precision,intent(in)::etTz(etTz_l1:etTz_h1,etTz_l2:etTz_h2)
-  double precision,intent(in)::temp(temp_l1:temp_h1,temp_l2:temp_h2)
-  double precision, intent(inout) :: rela, abso, errr
-  double precision, intent(in) :: dt
+  real(rt)        ,intent(in):: Ern( Ern_l1: Ern_h1, Ern_l2: Ern_h2,0:ngroups-1)
+  real(rt)        ,intent(in):: Erl( Erl_l1: Erl_h1, Erl_l2: Erl_h2,0:ngroups-1)
+  real(rt)        ,intent(in):: kap( kap_l1: kap_h1, kap_l2: kap_h2,0:ngroups-1)
+  real(rt)        ,intent(in)::etTz(etTz_l1:etTz_h1,etTz_l2:etTz_h2)
+  real(rt)        ,intent(in)::temp(temp_l1:temp_h1,temp_l2:temp_h2)
+  real(rt)        , intent(inout) :: rela, abso, errr
+  real(rt)        , intent(in) :: dt
 
   integer :: i, j, g
-  double precision :: chg, tot, cdt, der, kde, err_T, err
+  real(rt)         :: chg, tot, cdt, der, kde, err_T, err
 
   cdt = clight * dt
   do j = lo(2), hi(2)
   do i = lo(1), hi(1)
-     chg = 0.d0
-     tot = 0.d0
-     kde = 0.d0
+     chg = 0.e0_rt
+     tot = 0.e0_rt
+     kde = 0.e0_rt
      do g=0,ngroups-1
         der = Ern(i,j,g)-Erl(i,j,g)
         chg = chg + abs(der)
@@ -234,10 +239,10 @@ subroutine ca_check_conv_er( lo, hi, &
         kde = kde + kap(i,j,g)*der
      end do
      abso = max(abso, chg)
-     rela = max(rela, chg / (tot + 1.d-50))
+     rela = max(rela, chg / (tot + 1.e-50_rt))
 
      err_T =  etTz(i,j)*kde
-     err = abs(err_T/(temp(i,j)+1.d-50))
+     err = abs(err_T/(temp(i,j)+1.e-50_rt))
      errr = max(errr, err)
   end do
   end do
@@ -253,6 +258,7 @@ subroutine ca_compute_coupt( lo, hi,  &
   
   use rad_params_module, only : ngroups
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: lo(2), hi(2)
@@ -260,14 +266,14 @@ subroutine ca_compute_coupt( lo, hi,  &
   integer, intent(in) :: kpp_l1, kpp_h1, kpp_l2, kpp_h2 
   integer, intent(in) ::  eg_l1,  eg_h1,  eg_l2,  eg_h2
   integer, intent(in) ::  jg_l1,  jg_h1,  jg_l2,  jg_h2
-  double precision             :: cpt(cpt_l1:cpt_h1,cpt_l2:cpt_h2)
-  double precision, intent(in) :: kpp(kpp_l1:kpp_h1,kpp_l2:kpp_h2,0:ngroups-1)
-  double precision, intent(in) ::  eg( eg_l1: eg_h1, eg_l2: eg_h2,0:ngroups-1)
-  double precision, intent(in) ::  jg( jg_l1: jg_h1, jg_l2: jg_h2,0:ngroups-1)
+  real(rt)                     :: cpt(cpt_l1:cpt_h1,cpt_l2:cpt_h2)
+  real(rt)        , intent(in) :: kpp(kpp_l1:kpp_h1,kpp_l2:kpp_h2,0:ngroups-1)
+  real(rt)        , intent(in) ::  eg( eg_l1: eg_h1, eg_l2: eg_h2,0:ngroups-1)
+  real(rt)        , intent(in) ::  jg( jg_l1: jg_h1, jg_l2: jg_h2,0:ngroups-1)
 
   integer :: i, j, g
 
-  cpt(lo(1):hi(1),lo(2):hi(2)) = 0.d0
+  cpt(lo(1):hi(1),lo(2):hi(2)) = 0.e0_rt
 
   do g=0, ngroups-1
      do j=lo(2),hi(2)
@@ -293,6 +299,7 @@ subroutine ca_compute_etat( lo, hi, &
 
   use rad_params_module, only : ngroups, clight
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: lo(2), hi(2)
@@ -304,29 +311,29 @@ subroutine ca_compute_etat( lo, hi, &
   integer, intent(in) :: dedT_l1, dedT_h1, dedT_l2, dedT_h2
   integer, intent(in) ::  Ers_l1,  Ers_h1,  Ers_l2,  Ers_h2
   integer, intent(in) ::  rho_l1,  rho_h1,  rho_l2,  rho_h2
-  double precision            ::etaT(etaT_l1:etaT_h1,etaT_l2:etaT_h2)
-  double precision            ::etTz(etTz_l1:etTz_h1,etTz_l2:etTz_h2)
-  double precision            ::eta1(eta1_l1:eta1_h1,eta1_l2:eta1_h2)
-  double precision            ::djdT(djdT_l1:djdT_h1,djdT_l2:djdT_h2,0:ngroups-1)
-  double precision,intent(in )::dkdT(dkdT_l1:dkdT_h1,dkdT_l2:dkdT_h2,0:ngroups-1)
-  double precision,intent(in )::dedT(dedT_l1:dedT_h1,dedT_l2:dedT_h2)
-  double precision,intent(in )::Ers ( Ers_l1: Ers_h1, Ers_l2: Ers_h2,0:ngroups-1)
-  double precision,intent(in )::rho ( rho_l1: rho_h1, rho_l2: rho_h2)
-  double precision,intent(in) :: dt, tau
+  real(rt)                    ::etaT(etaT_l1:etaT_h1,etaT_l2:etaT_h2)
+  real(rt)                    ::etTz(etTz_l1:etTz_h1,etTz_l2:etTz_h2)
+  real(rt)                    ::eta1(eta1_l1:eta1_h1,eta1_l2:eta1_h2)
+  real(rt)                    ::djdT(djdT_l1:djdT_h1,djdT_l2:djdT_h2,0:ngroups-1)
+  real(rt)        ,intent(in )::dkdT(dkdT_l1:dkdT_h1,dkdT_l2:dkdT_h2,0:ngroups-1)
+  real(rt)        ,intent(in )::dedT(dedT_l1:dedT_h1,dedT_l2:dedT_h2)
+  real(rt)        ,intent(in )::Ers ( Ers_l1: Ers_h1, Ers_l2: Ers_h2,0:ngroups-1)
+  real(rt)        ,intent(in )::rho ( rho_l1: rho_h1, rho_l2: rho_h2)
+  real(rt)        ,intent(in) :: dt, tau
 
   integer :: i, j
-  double precision :: cdt, sigma
-  double precision :: dZdT(0:ngroups-1), sumdZdT, foo, bar
+  real(rt)         :: cdt, sigma
+  real(rt)         :: dZdT(0:ngroups-1), sumdZdT, foo, bar
 
-  sigma = 1.d0 + tau
+  sigma = 1.e0_rt + tau
   cdt = clight * dt
 
   do j = lo(2), hi(2)
   do i = lo(1), hi(1)
      dZdT = djdT(i,j,:) - dkdT(i,j,:)*Ers(i,j,:)
      sumdZdT = sum(dZdT)
-     if (sumdZdT .eq. 0.d0) then
-        sumdZdT = 1.d-50
+     if (sumdZdT .eq. 0.e0_rt) then
+        sumdZdT = 1.e-50_rt
      end if
      foo = cdt * sumdZdT
      bar = sigma*rho(i,j)*dedT(i,j)
@@ -352,6 +359,7 @@ subroutine ca_compute_emissivity( lo, hi, &
        pi, clight, hplanck, kboltz, arad
   use blackbody_module, only : BdBdTIndefInteg
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in)  :: lo(2), hi(2) 
@@ -360,40 +368,40 @@ subroutine ca_compute_emissivity( lo, hi, &
   integer, intent(in) ::    T_l1,    T_h1,    T_l2,    T_h2
   integer, intent(in) ::  kap_l1,  kap_h1,  kap_l2,  kap_h2
   integer, intent(in) :: dkdT_l1, dkdT_h1, dkdT_l2, dkdT_h2
-  double precision             :: jg  (  jg_l1:  jg_h1,  jg_l2:  jg_h2,0:ngroups-1)
-  double precision             :: djdT(djdT_l1:djdT_h1,djdT_l2:djdT_h2,0:ngroups-1)
-  double precision, intent(in) ::    T(   T_l1:   T_h1,   T_l2:   T_h2)
-  double precision, intent(in) ::  kap( kap_l1: kap_h1, kap_l2: kap_h2,0:ngroups-1)
-  double precision, intent(in) :: dkdT(dkdT_l1:dkdT_h1,dkdT_l2:dkdT_h2,0:ngroups-1)
-  double precision, intent(in) :: pfc(0:ngroups-1)
+  real(rt)                     :: jg  (  jg_l1:  jg_h1,  jg_l2:  jg_h2,0:ngroups-1)
+  real(rt)                     :: djdT(djdT_l1:djdT_h1,djdT_l2:djdT_h2,0:ngroups-1)
+  real(rt)        , intent(in) ::    T(   T_l1:   T_h1,   T_l2:   T_h2)
+  real(rt)        , intent(in) ::  kap( kap_l1: kap_h1, kap_l2: kap_h2,0:ngroups-1)
+  real(rt)        , intent(in) :: dkdT(dkdT_l1:dkdT_h1,dkdT_l2:dkdT_h2,0:ngroups-1)
+  real(rt)        , intent(in) :: pfc(0:ngroups-1)
   integer, intent(in) :: use_WiensLaw, integrate_Planck
-  double precision, intent(in) :: Tf
+  real(rt)        , intent(in) :: Tf
 
   integer :: i, j, g
-  double precision :: dBdT, Bg
-  double precision :: Teff, nu, num, nup, hoverk
-  double precision :: cB, Tfix
-  double precision :: B0, B1, dBdT0, dBdT1
-  double precision :: dnu, nubar, expnubar, cdBdT
-  double precision :: xnu_full(0:ngroups)
+  real(rt)         :: dBdT, Bg
+  real(rt)         :: Teff, nu, num, nup, hoverk
+  real(rt)         :: cB, Tfix
+  real(rt)         :: B0, B1, dBdT0, dBdT1
+  real(rt)         :: dnu, nubar, expnubar, cdBdT
+  real(rt)         :: xnu_full(0:ngroups)
 
   if (ngroups .eq. 1) then
 
      do j = lo(2), hi(2)
      do i = lo(1), hi(1)
         Bg = arad*T(i,j)**4
-        dBdT = 4.d0*arad*T(i,j)**3
+        dBdT = 4.e0_rt*arad*T(i,j)**3
         g = 0
         jg(i,j,g) = Bg*kap(i,j,g)
         djdT(i,j,g) = dkdT(i,j,g)*Bg + dBdT*kap(i,j,g)
      end do     
      end do     
 
-  else if (pfc(0) > 0.d0) then  ! a special case for picket-fence model in Su-Olson test
+  else if (pfc(0) > 0.e0_rt) then  ! a special case for picket-fence model in Su-Olson test
      do j = lo(2), hi(2)
      do i = lo(1), hi(1)
         Bg = arad*T(i,j)**4
-        dBdT = 4.d0*arad*T(i,j)**3
+        dBdT = 4.e0_rt*arad*T(i,j)**3
         do g=0, ngroups-1
            jg(i,j,g) = pfc(g) * Bg*kap(i,j,g)
            djdT(i,j,g) = pfc(g) * (dkdT(i,j,g)*Bg + dBdT*kap(i,j,g))
@@ -411,7 +419,7 @@ subroutine ca_compute_emissivity( lo, hi, &
         nup = xnu(g+1)
         do j = lo(2), hi(2)
         do i = lo(1), hi(1)
-           if (Tf < 0.d0) then
+           if (Tf < 0.e0_rt) then
               Tfix = T(i,j)
            else
               Tfix = Tf
@@ -427,12 +435,12 @@ subroutine ca_compute_emissivity( lo, hi, &
   else if (integrate_Planck > 0) then
 
      xnu_full = xnu(0:ngroups)
-     xnu_full(0) = 0.d0
-     xnu_full(ngroups) = max(xnu(ngroups), 1.d25)
+     xnu_full(0) = 0.e0_rt
+     xnu_full(ngroups) = max(xnu(ngroups), 1.e25_rt)
 
      do j=lo(2), hi(2)
      do i=lo(1), hi(1)
-        Teff = max(T(i,j), 1.d-50)
+        Teff = max(T(i,j), 1.e-50_rt)
         call BdBdTIndefInteg(Teff, xnu_full(0), B1, dBdT1)
         do g=0, ngroups-1
            B0 = B1
@@ -449,8 +457,8 @@ subroutine ca_compute_emissivity( lo, hi, &
 
   else
 
-     cB = 8.d0*pi*hplanck / clight**3
-     cdBdT = 8.d0*pi*hplanck**2 / (kboltz*clight**3)
+     cB = 8.e0_rt*pi*hplanck / clight**3
+     cdBdT = 8.e0_rt*pi*hplanck**2 / (kboltz*clight**3)
 
      do g=0, ngroups-1
         nu = nugroup(g)
@@ -458,18 +466,18 @@ subroutine ca_compute_emissivity( lo, hi, &
 
         do j=lo(2), hi(2)
         do i=lo(1), hi(1)
-           Teff = max(T(i,j), 1.d-50)
+           Teff = max(T(i,j), 1.e-50_rt)
            nubar = hplanck * nu / (kboltz * Teff)
-           if (nubar > 100.d0) then
-              Bg = 0.d0
-              dBdT = 0.d0
-           else if (nubar < 1.d-15) then
-              Bg = 0.d0
-              dBdT = 0.d0           
+           if (nubar > 100.e0_rt) then
+              Bg = 0.e0_rt
+              dBdT = 0.e0_rt
+           else if (nubar < 1.e-15_rt) then
+              Bg = 0.e0_rt
+              dBdT = 0.e0_rt           
            else
               expnubar = exp(nubar)
-              Bg = cB * nu**3 / (expnubar - 1.d0) * dnu
-              dBdT = cdBdT * nu**4 / Teff**2 * expnubar / (expnubar-1.d0)**2 * dnu
+              Bg = cB * nu**3 / (expnubar - 1.e0_rt) * dnu
+              dBdT = cdBdT * nu**4 / Teff**2 * expnubar / (expnubar-1.e0_rt)**2 * dnu
            end if
 
            jg(i,j,g) = Bg*kap(i,j,g)
@@ -499,6 +507,7 @@ subroutine ca_compute_kappas(lo, hi, &
   use fundamental_constants_module, only : hplanck, k_B
   use meth_params_module, only : NVAR, URHO
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in)  :: lo(2), hi(2) 
@@ -508,19 +517,19 @@ subroutine ca_compute_kappas(lo, hi, &
   integer, intent(in) :: kpr_l1, kpr_h1, kpr_l2, kpr_h2
   integer, intent(in) :: kpT_l1, kpT_h1, kpT_l2, kpT_h2
   integer, intent(in) :: do_stme, use_dkdT
-  double precision, intent(in)  :: stt(stt_l1:stt_h1,stt_l2:stt_h2,NVAR)
-  double precision, intent(in)  ::   T(  T_l1:  T_h1,  T_l2:  T_h2)
-  double precision              :: kpp(kpp_l1:kpp_h1,kpp_l2:kpp_h2,0:ngroups-1)
-  double precision              :: kpr(kpr_l1:kpr_h1,kpr_l2:kpr_h2,0:ngroups-1)
-  double precision              :: kpT(kpT_l1:kpT_h1,kpT_l2:kpT_h2,0:ngroups-1)
-  double precision, intent(in)  :: c_kpp, kpp_m, kpp_n, kpp_p 
-  double precision, intent(in)  :: c_kpr, kpr_m, kpr_n, kpr_p 
-  double precision, intent(in)  :: c_sct, sct_m, sct_n, sct_p 
-  double precision, intent(in)  :: Tfloor
+  real(rt)        , intent(in)  :: stt(stt_l1:stt_h1,stt_l2:stt_h2,NVAR)
+  real(rt)        , intent(in)  ::   T(  T_l1:  T_h1,  T_l2:  T_h2)
+  real(rt)                      :: kpp(kpp_l1:kpp_h1,kpp_l2:kpp_h2,0:ngroups-1)
+  real(rt)                      :: kpr(kpr_l1:kpr_h1,kpr_l2:kpr_h2,0:ngroups-1)
+  real(rt)                      :: kpT(kpT_l1:kpT_h1,kpT_l2:kpT_h2,0:ngroups-1)
+  real(rt)        , intent(in)  :: c_kpp, kpp_m, kpp_n, kpp_p 
+  real(rt)        , intent(in)  :: c_kpr, kpr_m, kpr_n, kpr_p 
+  real(rt)        , intent(in)  :: c_sct, sct_m, sct_n, sct_p 
+  real(rt)        , intent(in)  :: Tfloor
 
   integer :: i, j, g
-  double precision, parameter :: tiny = 1.0d-50
-  double precision :: Teff, nup_kpp, nup_kpr, nup_sct, sct, foo, hnuoverkt, exptmp
+  real(rt)        , parameter :: tiny = 1.0e-50_rt
+  real(rt)         :: Teff, nup_kpp, nup_kpr, nup_sct, sct, foo, hnuoverkt, exptmp
 
   do g=0, ngroups-1
      nup_kpp = nugroup(g)**kpp_p
@@ -537,17 +546,17 @@ subroutine ca_compute_kappas(lo, hi, &
            foo = kpp(i,j,g)
            hnuoverkt = hplanck*nugroup(g)/(k_B*Teff)
            exptmp = exp(-hnuoverkt)
-           kpp(i,j,g) = foo * (1.d0 - exptmp)
-           kpT(i,j,g) = foo*(-kpp_n/Teff)*(1.d0-exptmp) - foo*exptmp*(hnuoverkt/Teff)
+           kpp(i,j,g) = foo * (1.e0_rt - exptmp)
+           kpT(i,j,g) = foo*(-kpp_n/Teff)*(1.e0_rt-exptmp) - foo*exptmp*(hnuoverkt/Teff)
         else
            kpT(i,j,g) = kpp(i,j,g) * (-kpp_n/Teff)           
         end if
 
         if (use_dkdT.eq.0) then
-           kpT(i,j,g) = 0.d0
+           kpT(i,j,g) = 0.e0_rt
         end if
 
-        if (c_kpr < 0.0d0) then
+        if (c_kpr < 0.0e0_rt) then
            sct       = c_sct * (stt(i,j,URHO) ** sct_m) * (Teff ** (-sct_n)) * nup_sct
            kpr(i,j,g) = kpp(i,j,g) + sct
         else
@@ -575,6 +584,7 @@ subroutine ca_compute_rhs( lo, hi,  &
 
   use rad_params_module, only : ngroups, clight
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer,intent(in) :: lo(2), hi(2) 
@@ -587,23 +597,23 @@ subroutine ca_compute_rhs( lo, hi,  &
   integer,intent(in):: re2_l1, re2_h1, re2_l2, re2_h2
   integer,intent(in):: Ers_l1, Ers_h1, Ers_l2, Ers_h2
   integer,intent(in):: res_l1, res_h1, res_l2, res_h2
-  double precision           ::rhs ( rhs_l1: rhs_h1, rhs_l2: rhs_h2)
-  double precision,intent(in)::jg  (  jg_l1:  jg_h1,  jg_l2:  jg_h2,0:ngroups-1)
-  double precision,intent(in)::mugT(mugT_l1:mugT_h1,mugT_l2:mugT_h2,0:ngroups-1)
-  double precision,intent(in)::cpT ( cpT_l1: cpT_h1, cpT_l2: cpT_h2)
-  double precision,intent(in)::etaT(etaT_l1:etaT_h1,etaT_l2:etaT_h2)
-  double precision,intent(in)::Er2 ( Er2_l1: Er2_h1, Er2_l2: Er2_h2,0:ngroups-1)
-  double precision,intent(in)::re2 ( re2_l1: re2_h1, re2_l2: re2_h2)
-  double precision,intent(in)::Ers ( Ers_l1: Ers_h1, Ers_l2: Ers_h2,0:ngroups-1)
-  double precision,intent(in)::res ( res_l1: res_h1, res_l2: res_h2)
-  double precision,intent(in) ::   r(lo(1):hi(1))
-  double precision,intent(in) :: dt, tau
+  real(rt)                   ::rhs ( rhs_l1: rhs_h1, rhs_l2: rhs_h2)
+  real(rt)        ,intent(in)::jg  (  jg_l1:  jg_h1,  jg_l2:  jg_h2,0:ngroups-1)
+  real(rt)        ,intent(in)::mugT(mugT_l1:mugT_h1,mugT_l2:mugT_h2,0:ngroups-1)
+  real(rt)        ,intent(in)::cpT ( cpT_l1: cpT_h1, cpT_l2: cpT_h2)
+  real(rt)        ,intent(in)::etaT(etaT_l1:etaT_h1,etaT_l2:etaT_h2)
+  real(rt)        ,intent(in)::Er2 ( Er2_l1: Er2_h1, Er2_l2: Er2_h2,0:ngroups-1)
+  real(rt)        ,intent(in)::re2 ( re2_l1: re2_h1, re2_l2: re2_h2)
+  real(rt)        ,intent(in)::Ers ( Ers_l1: Ers_h1, Ers_l2: Ers_h2,0:ngroups-1)
+  real(rt)        ,intent(in)::res ( res_l1: res_h1, res_l2: res_h2)
+  real(rt)        ,intent(in) ::   r(lo(1):hi(1))
+  real(rt)        ,intent(in) :: dt, tau
   integer, intent(in) :: igroup
 
   integer :: i, j
-  double precision :: Hg, dt1
+  real(rt)         :: Hg, dt1
 
-  dt1 = 1.d0/dt
+  dt1 = 1.e0_rt/dt
   do j=lo(2), hi(2)
   do i=lo(1), hi(1)
      Hg = mugT(i,j,igroup) * etaT(i,j)
@@ -632,6 +642,7 @@ subroutine ca_compute_rhs_so( lo, hi,  & ! MG Su-Olson
 
   use rad_params_module, only : ngroups, clight
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer,intent(in):: lo(2), hi(2) 
@@ -643,24 +654,24 @@ subroutine ca_compute_rhs_so( lo, hi,  & ! MG Su-Olson
   integer,intent(in):: Er2_l1, Er2_h1, Er2_l2, Er2_h2
   integer,intent(in):: re2_l1, re2_h1, re2_l2, re2_h2
   integer,intent(in):: res_l1, res_h1, res_l2, res_h2
-  double precision           ::rhs ( rhs_l1: rhs_h1, rhs_l2: rhs_h2)
-  double precision,intent(in)::jg  (  jg_l1:  jg_h1,  jg_l2:  jg_h2,0:ngroups-1)
-  double precision,intent(in)::mugT(mugT_l1:mugT_h1,mugT_l2:mugT_h2,0:ngroups-1)
-  double precision,intent(in)::cpt ( cpt_l1: cpt_h1, cpt_l2: cpt_h2)
-  double precision,intent(in)::eta ( eta_l1: eta_h1, eta_l2: eta_h2)
-  double precision,intent(in)::Er2 ( Er2_l1: Er2_h1, Er2_l2: Er2_h2,0:ngroups-1)
-  double precision,intent(in)::re2 ( re2_l1: re2_h1, re2_l2: re2_h2)
-  double precision,intent(in)::res ( res_l1: res_h1, res_l2: res_h2)
-  double precision,intent(in) :: x(lo(1):hi(1))
-  double precision,intent(in) :: t, dt
+  real(rt)                   ::rhs ( rhs_l1: rhs_h1, rhs_l2: rhs_h2)
+  real(rt)        ,intent(in)::jg  (  jg_l1:  jg_h1,  jg_l2:  jg_h2,0:ngroups-1)
+  real(rt)        ,intent(in)::mugT(mugT_l1:mugT_h1,mugT_l2:mugT_h2,0:ngroups-1)
+  real(rt)        ,intent(in)::cpt ( cpt_l1: cpt_h1, cpt_l2: cpt_h2)
+  real(rt)        ,intent(in)::eta ( eta_l1: eta_h1, eta_l2: eta_h2)
+  real(rt)        ,intent(in)::Er2 ( Er2_l1: Er2_h1, Er2_l2: Er2_h2,0:ngroups-1)
+  real(rt)        ,intent(in)::re2 ( re2_l1: re2_h1, re2_l2: re2_h2)
+  real(rt)        ,intent(in)::res ( res_l1: res_h1, res_l2: res_h2)
+  real(rt)        ,intent(in) :: x(lo(1):hi(1))
+  real(rt)        ,intent(in) :: t, dt
   integer, intent(in) :: igroup
 
-  double precision, parameter :: x0 = 0.5d0
-  double precision, parameter :: t0 = 3.3356409519815202d-10 
-  double precision, parameter :: qn = 1.134074546528399d20 
+  real(rt)        , parameter :: x0 = 0.5e0_rt
+  real(rt)        , parameter :: t0 = 3.3356409519815202e-10_rt 
+  real(rt)        , parameter :: qn = 1.134074546528399e20_rt 
 
   integer :: i, j
-  double precision :: Hg
+  real(rt)         :: Hg
 
   do j=lo(2), hi(2)
   do i=lo(1), hi(1)
@@ -686,6 +697,7 @@ subroutine ca_local_accel( lo, hi,  &
 
   use rad_params_module, only : ngroups, clight
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer,intent(in):: lo(2), hi(2)
@@ -694,18 +706,18 @@ subroutine ca_local_accel( lo, hi,  &
   integer,intent(in):: kap_l1, kap_h1, kap_l2, kap_h2
   integer,intent(in)::etaT_l1,etaT_h1,etaT_l2,etaT_h2
   integer,intent(in)::mugT_l1,mugT_h1,mugT_l2,mugT_h2
-  double precision           ::Ern ( Ern_l1: Ern_h1, Ern_l2: Ern_h2,0:ngroups-1)
-  double precision,intent(in)::Erl ( Erl_l1: Erl_h1, Erl_l2: Erl_h2,0:ngroups-1)
-  double precision,intent(in)::kap ( kap_l1: kap_h1, kap_l2: kap_h2,0:ngroups-1)
-  double precision,intent(in)::etaT(etaT_l1:etaT_h1,etaT_l2:etaT_h2)
-  double precision,intent(in)::mugT(mugT_l1:mugT_h1,mugT_l2:mugT_h2,0:ngroups-1)
-  double precision,intent(in) :: dt, tau
+  real(rt)                   ::Ern ( Ern_l1: Ern_h1, Ern_l2: Ern_h2,0:ngroups-1)
+  real(rt)        ,intent(in)::Erl ( Erl_l1: Erl_h1, Erl_l2: Erl_h2,0:ngroups-1)
+  real(rt)        ,intent(in)::kap ( kap_l1: kap_h1, kap_l2: kap_h2,0:ngroups-1)
+  real(rt)        ,intent(in)::etaT(etaT_l1:etaT_h1,etaT_l2:etaT_h2)
+  real(rt)        ,intent(in)::mugT(mugT_l1:mugT_h1,mugT_l2:mugT_h2,0:ngroups-1)
+  real(rt)        ,intent(in) :: dt, tau
 
   integer :: i, j
-  double precision :: cdt1, rt_term, p
-  double precision,dimension(0:ngroups-1)::Hg, epsilon, kapt, kk
+  real(rt)         :: cdt1, rt_term, p
+  real(rt)        ,dimension(0:ngroups-1)::Hg, epsilon, kapt, kk
 
-  cdt1 = 1.d0/(clight*dt)
+  cdt1 = 1.e0_rt/(clight*dt)
 
   do j = lo(2), hi(2)
   do i = lo(1), hi(1)
@@ -713,11 +725,11 @@ subroutine ca_local_accel( lo, hi,  &
 
      Hg = mugT(i,j,:)*etaT(i,j)
 
-     kapt = kap(i,j,:) + (1.d0+tau)*cdt1
+     kapt = kap(i,j,:) + (1.e0_rt+tau)*cdt1
      kk = kap(i,j,:) / kapt
 
-     p = 1.d0-sum(Hg*kk)
-     epsilon = (Hg * rt_term) / (kapt*p + 1.d-50)
+     p = 1.e0_rt-sum(Hg*kk)
+     epsilon = (Hg * rt_term) / (kapt*p + 1.e-50_rt)
 
      Ern(i,j,:) = Ern(i,j,:) + epsilon
   end do
@@ -735,6 +747,7 @@ subroutine ca_state_update( lo, hi, &
 
   use meth_params_module, only : NVAR, UEDEN, UEINT, UTEMP
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: lo(2), hi(2) 
@@ -742,25 +755,25 @@ subroutine ca_state_update( lo, hi, &
   integer, intent(in) ::  rhoe_l1,  rhoe_h1,  rhoe_l2,  rhoe_h2
   integer, intent(in) ::  temp_l1,  temp_h1,  temp_l2,  temp_h2
   integer, intent(in) ::   msk_l1,   msk_h1,   msk_l2,   msk_h2
-  double precision, intent(in) :: rhoe( rhoe_l1: rhoe_h1, rhoe_l2: rhoe_h2)
-  double precision, intent(in) :: temp( temp_l1: temp_h1, temp_l2: temp_h2)
-  double precision, intent(in) ::  msk(  msk_l1:  msk_h1,  msk_l2:  msk_h2)
-  double precision             ::state(state_l1:state_h1,state_l2:state_h2,NVAR)
-  double precision, intent(inout) :: derat, dTrat
+  real(rt)        , intent(in) :: rhoe( rhoe_l1: rhoe_h1, rhoe_l2: rhoe_h2)
+  real(rt)        , intent(in) :: temp( temp_l1: temp_h1, temp_l2: temp_h2)
+  real(rt)        , intent(in) ::  msk(  msk_l1:  msk_h1,  msk_l2:  msk_h2)
+  real(rt)                     ::state(state_l1:state_h1,state_l2:state_h2,NVAR)
+  real(rt)        , intent(inout) :: derat, dTrat
 
   integer :: i, j
-  double precision :: ei, ek, Told
+  real(rt)         :: ei, ek, Told
 
   do j=lo(2), hi(2)
   do i=lo(1), hi(1)
      ei = state(i,j,UEINT)
-     derat = max(derat, abs((rhoe(i,j) - ei)*msk(i,j)/ max(ei, 1.d-50)))
+     derat = max(derat, abs((rhoe(i,j) - ei)*msk(i,j)/ max(ei, 1.e-50_rt)))
      ek = state(i,j,UEDEN) - state(i,j,UEINT)
      state(i,j,UEINT) = rhoe(i,j)
      state(i,j,UEDEN) = rhoe(i,j) + ek
 
      Told = state(i,j,UTEMP);
-     dTrat = max(dTrat, abs((temp(i,j)-Told)*msk(i,j)/ max(Told, 1.d-50)))
+     dTrat = max(dTrat, abs((temp(i,j)-Told)*msk(i,j)/ max(Told, 1.e-50_rt)))
      state(i,j,UTEMP) = temp(i,j)
   end do
   end do
@@ -784,6 +797,7 @@ subroutine ca_update_matter( lo, hi,  &
   use rad_params_module, only : ngroups, clight
   use meth_params_module, only : NVAR
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer,intent(in)::lo(2),hi(2)
@@ -797,20 +811,20 @@ subroutine ca_update_matter( lo, hi,  &
   integer,intent(in):: kpp_l1,  kpp_h1,  kpp_l2,  kpp_h2
   integer,intent(in)::mugT_l1, mugT_h1, mugT_l2, mugT_h2
   integer,intent(in)::Snew_l1, Snew_h1, Snew_l2, Snew_h2
-  double precision           ::re_n(re_n_l1:re_n_h1,re_n_l2:re_n_h2)
-  double precision,intent(in)::Er_n(Er_n_l1:Er_n_h1,Er_n_l2:Er_n_h2,0:ngroups-1)
-  double precision,intent(in)::Er_l(Er_l_l1:Er_l_h1,Er_l_l2:Er_l_h2,0:ngroups-1)
-  double precision,intent(in)::re_s(re_s_l1:re_s_h1,re_s_l2:re_s_h2)
-  double precision,intent(in)::re_2(re_2_l1:re_2_h1,re_2_l2:re_2_h2)
-  double precision,intent(in)::eta1(eta1_l1:eta1_h1,eta1_l2:eta1_h2)
-  double precision,intent(in):: cpt( cpt_l1: cpt_h1, cpt_l2: cpt_h2)
-  double precision,intent(in):: kpp( kpp_l1: kpp_h1, kpp_l2: kpp_h2,0:ngroups-1)
-  double precision,intent(in)::mugT(mugT_l1:mugT_h1,mugT_l2:mugT_h2,0:ngroups-1)
-  double precision,intent(in)::Snew(Snew_l1:Snew_h1,Snew_l2:Snew_h2,NVAR)
-  double precision,intent(in) :: dt, tau
+  real(rt)                   ::re_n(re_n_l1:re_n_h1,re_n_l2:re_n_h2)
+  real(rt)        ,intent(in)::Er_n(Er_n_l1:Er_n_h1,Er_n_l2:Er_n_h2,0:ngroups-1)
+  real(rt)        ,intent(in)::Er_l(Er_l_l1:Er_l_h1,Er_l_l2:Er_l_h2,0:ngroups-1)
+  real(rt)        ,intent(in)::re_s(re_s_l1:re_s_h1,re_s_l2:re_s_h2)
+  real(rt)        ,intent(in)::re_2(re_2_l1:re_2_h1,re_2_l2:re_2_h2)
+  real(rt)        ,intent(in)::eta1(eta1_l1:eta1_h1,eta1_l2:eta1_h2)
+  real(rt)        ,intent(in):: cpt( cpt_l1: cpt_h1, cpt_l2: cpt_h2)
+  real(rt)        ,intent(in):: kpp( kpp_l1: kpp_h1, kpp_l2: kpp_h2,0:ngroups-1)
+  real(rt)        ,intent(in)::mugT(mugT_l1:mugT_h1,mugT_l2:mugT_h2,0:ngroups-1)
+  real(rt)        ,intent(in)::Snew(Snew_l1:Snew_h1,Snew_l2:Snew_h2,NVAR)
+  real(rt)        ,intent(in) :: dt, tau
 
   integer :: i,j
-  double precision :: cdt, H1, dkEE, chg
+  real(rt)         :: cdt, H1, dkEE, chg
 
   cdt = clight * dt
   do j = lo(2), hi(2)
@@ -823,7 +837,7 @@ subroutine ca_update_matter( lo, hi,  &
 
      re_n(i,j) = re_s(i,j) + chg
 
-     re_n(i,j) = (re_n(i,j) + tau*re_s(i,j)) / (1.d0+tau)
+     re_n(i,j) = (re_n(i,j) + tau*re_s(i,j)) / (1.e0_rt+tau)
 
      ! temperature will be updated after exiting this subroutine
   end do
@@ -844,6 +858,7 @@ subroutine ca_ncupdate_matter( lo, hi,  &
 
   use rad_params_module, only : ngroups, clight
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer,intent(in)::lo(2),hi(2)
@@ -854,25 +869,25 @@ subroutine ca_ncupdate_matter( lo, hi,  &
   integer,intent(in)::etTz_l1,etTz_h1,etTz_l2,etTz_h2
   integer,intent(in):: kpp_l1, kpp_h1, kpp_l2, kpp_h2
   integer,intent(in)::  jg_l1,  jg_h1,  jg_l2,  jg_h2
-  double precision           ::Tp_n(Tp_n_l1:Tp_n_h1,Tp_n_l2:Tp_n_h2)
-  double precision,intent(in)::Er_n(Er_n_l1:Er_n_h1,Er_n_l2:Er_n_h2,0:ngroups-1)
-  double precision,intent(in)::re_s(re_s_l1:re_s_h1,re_s_l2:re_s_h2)
-  double precision,intent(in)::re_2(re_2_l1:re_2_h1,re_2_l2:re_2_h2)
-  double precision,intent(in)::etTz(etTz_l1:etTz_h1,etTz_l2:etTz_h2)
-  double precision,intent(in):: kpp( kpp_l1: kpp_h1, kpp_l2: kpp_h2,0:ngroups-1)
-  double precision,intent(in)::  jg(  jg_l1:  jg_h1,  jg_l2:  jg_h2,0:ngroups-1)
-  double precision,intent(in) :: dt
+  real(rt)                   ::Tp_n(Tp_n_l1:Tp_n_h1,Tp_n_l2:Tp_n_h2)
+  real(rt)        ,intent(in)::Er_n(Er_n_l1:Er_n_h1,Er_n_l2:Er_n_h2,0:ngroups-1)
+  real(rt)        ,intent(in)::re_s(re_s_l1:re_s_h1,re_s_l2:re_s_h2)
+  real(rt)        ,intent(in)::re_2(re_2_l1:re_2_h1,re_2_l2:re_2_h2)
+  real(rt)        ,intent(in)::etTz(etTz_l1:etTz_h1,etTz_l2:etTz_h2)
+  real(rt)        ,intent(in):: kpp( kpp_l1: kpp_h1, kpp_l2: kpp_h2,0:ngroups-1)
+  real(rt)        ,intent(in)::  jg(  jg_l1:  jg_h1,  jg_l2:  jg_h2,0:ngroups-1)
+  real(rt)        ,intent(in) :: dt
 
    integer :: i,j,g
-   double precision :: cdt1, cpT, scrch_re
-   double precision :: dTemp
-   double precision, parameter :: fac = 0.01d0
+   real(rt)         :: cdt1, cpT, scrch_re
+   real(rt)         :: dTemp
+   real(rt)        , parameter :: fac = 0.01e0_rt
 
-   cdt1 = 1.d0 / (clight * dt)
+   cdt1 = 1.e0_rt / (clight * dt)
    do j = lo(2), hi(2)
    do i = lo(1), hi(1)
 
-      cpT = 0.d0
+      cpT = 0.e0_rt
       do g = 0, ngroups-1
          cpT = cpT + kpp(i,j,g)*Er_n(i,j,g) - jg(i,j,g)
       end do
@@ -881,7 +896,7 @@ subroutine ca_ncupdate_matter( lo, hi,  &
 
       dTemp = etTz(i,j)*scrch_re
 
-      if (abs(dTemp/(Tp_n(i,j)+1.d-50)) > fac) then
+      if (abs(dTemp/(Tp_n(i,j)+1.e-50_rt)) > fac) then
          dTemp = sign(fac*Tp_n(i,j), dTemp)
       end if
 
@@ -907,6 +922,7 @@ subroutine ca_opacs( lo, hi,  &
   use network, only : naux
   use meth_params_module, only : NVAR, URHO, UFX
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: lo(2), hi(2)
@@ -916,24 +932,24 @@ subroutine ca_opacs( lo, hi,  &
   integer, intent(in) ::  kpp_l1,  kpp_h1,  kpp_l2,  kpp_h2 
   integer, intent(in) ::  kpr_l1,  kpr_h1,  kpr_l2,  kpr_h2
   integer, intent(in) :: dkdT_l1, dkdT_h1, dkdT_l2, dkdT_h2
-  double precision, intent(in) :: Snew(Snew_l1:Snew_h1,Snew_l2:Snew_h2,NVAR)
-  double precision, intent(in) :: T   (   T_l1:   T_h1,   T_l2:   T_h2)
-  double precision, intent(in) :: Ts  (  Ts_l1:  Ts_h1,  Ts_l2:  Ts_h2)
-  double precision             :: kpp ( kpp_l1: kpp_h1, kpp_l2: kpp_h2,0:ngroups-1)
-  double precision             :: kpr ( kpr_l1: kpr_h1, kpr_l2: kpr_h2,0:ngroups-1)
-  double precision             :: dkdT(dkdT_l1:dkdT_h1,dkdT_l2:dkdT_h2,0:ngroups-1)
+  real(rt)        , intent(in) :: Snew(Snew_l1:Snew_h1,Snew_l2:Snew_h2,NVAR)
+  real(rt)        , intent(in) :: T   (   T_l1:   T_h1,   T_l2:   T_h2)
+  real(rt)        , intent(in) :: Ts  (  Ts_l1:  Ts_h1,  Ts_l2:  Ts_h2)
+  real(rt)                     :: kpp ( kpp_l1: kpp_h1, kpp_l2: kpp_h2,0:ngroups-1)
+  real(rt)                     :: kpr ( kpr_l1: kpr_h1, kpr_l2: kpr_h2,0:ngroups-1)
+  real(rt)                     :: dkdT(dkdT_l1:dkdT_h1,dkdT_l2:dkdT_h2,0:ngroups-1)
   integer, intent(in) :: use_dkdT, validStar, lag_opac
 
   integer :: i, j, g
-  double precision :: kp, kr, nu, rho, temp, Ye
-  double precision :: kp1, kr1
-  double precision :: kp2, kr2
-  double precision :: dT
+  real(rt)         :: kp, kr, nu, rho, temp, Ye
+  real(rt)         :: kp1, kr1
+  real(rt)         :: kp2, kr2
+  real(rt)         :: dT
   logical :: comp_kp, comp_kr
-  double precision, parameter :: fac = 0.5d0, minfrac = 1.d-8
+  real(rt)        , parameter :: fac = 0.5e0_rt, minfrac = 1.e-8_rt
 
   if (lag_opac .eq. 1) then
-     dkdT(lo(1):hi(1),lo(2):hi(2),:) = 0.d0
+     dkdT(lo(1):hi(1),lo(2):hi(2),:) = 0.e0_rt
      return
   end if
 
@@ -945,14 +961,14 @@ subroutine ca_opacs( lo, hi,  &
      if (naux > 0) then
         Ye = Snew(i,j,UFX)
      else
-        Ye = 0.d0
+        Ye = 0.e0_rt
      end if
 
      if (validStar > 0) then
         dT = fac*abs(Ts(i,j) - T(i,j))
         dT = max(dT, minfrac*T(i,j))
      else
-        dT = T(i,j) * 1.d-3 + 1.d-50
+        dT = T(i,j) * 1.e-3_rt + 1.e-50_rt
      end if
 
      do g=0, ngroups-1
@@ -967,7 +983,7 @@ subroutine ca_opacs( lo, hi,  &
         kpr(i,j,g) = kr 
 
         if (use_dkdT .eq. 0) then        
-           dkdT(i,j,g) = 0.d0
+           dkdT(i,j,g) = 0.e0_rt
         else
 
            comp_kp = .true.
@@ -976,7 +992,7 @@ subroutine ca_opacs( lo, hi,  &
            call get_opacities(kp1, kr1, rho, temp-dT, Ye, nu, comp_kp, comp_kr)
            call get_opacities(kp2, kr2, rho, temp+dT, Ye, nu, comp_kp, comp_kr)
 
-           dkdT(i,j,g) = (kp2-kp1)/(2.d0*dT)
+           dkdT(i,j,g) = (kp2-kp1)/(2.e0_rt*dT)
 
         end if
 
@@ -996,16 +1012,17 @@ subroutine ca_compute_rosseland( lo, hi, &
   use network, only : naux
   use meth_params_module, only : NVAR, URHO, UTEMP, UFX
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: lo(2), hi(2)
   integer, intent(in) ::  kpr_l1, kpr_l2, kpr_h1, kpr_h2
   integer, intent(in) :: stat_l1,stat_l2,stat_h1,stat_h2
-  double precision             :: kpr ( kpr_l1: kpr_h1, kpr_l2: kpr_h2,0:ngroups-1)
-  double precision, intent(in) :: stat(stat_l1:stat_h1,stat_l2:stat_h2,NVAR)
+  real(rt)                     :: kpr ( kpr_l1: kpr_h1, kpr_l2: kpr_h2,0:ngroups-1)
+  real(rt)        , intent(in) :: stat(stat_l1:stat_h1,stat_l2:stat_h2,NVAR)
 
   integer :: i, j, g
-  double precision :: kp, kr, nu, rho, temp, Ye
+  real(rt)         :: kp, kr, nu, rho, temp, Ye
   logical, parameter :: comp_kp = .false. 
   logical, parameter :: comp_kr = .true.
 
@@ -1021,7 +1038,7 @@ subroutine ca_compute_rosseland( lo, hi, &
         if (naux > 0) then
            Ye = stat(i,j,UFX)
         else
-           Ye = 0.d0
+           Ye = 0.e0_rt
         end if
 
         call get_opacities(kp, kr, rho, temp, Ye, nu, comp_kp, comp_kr)
@@ -1044,16 +1061,17 @@ subroutine ca_compute_planck( lo, hi,  &
   use network, only : naux
   use meth_params_module, only : NVAR, URHO, UTEMP, UFX
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: lo(2), hi(2)
   integer, intent(in) ::  kpp_l1, kpp_l2, kpp_h1, kpp_h2
   integer, intent(in) :: stat_l1,stat_l2,stat_h1,stat_h2
-  double precision             :: kpp ( kpp_l1: kpp_h1, kpp_l2: kpp_h2,0:ngroups-1)
-  double precision, intent(in) :: stat(stat_l1:stat_h1,stat_l2:stat_h2,NVAR)
+  real(rt)                     :: kpp ( kpp_l1: kpp_h1, kpp_l2: kpp_h2,0:ngroups-1)
+  real(rt)        , intent(in) :: stat(stat_l1:stat_h1,stat_l2:stat_h2,NVAR)
 
   integer :: i, j, g
-  double precision :: kp, kr, nu, rho, temp, Ye
+  real(rt)         :: kp, kr, nu, rho, temp, Ye
   logical, parameter :: comp_kp = .true. 
   logical, parameter :: comp_kr = .false.
 
@@ -1069,7 +1087,7 @@ subroutine ca_compute_planck( lo, hi,  &
         if (naux > 0) then
            Ye = stat(i,j,UFX)
         else
-           Ye = 0.d0
+           Ye = 0.e0_rt
         end if
 
         call get_opacities(kp, kr, rho, temp, Ye, nu, comp_kp, comp_kr)
@@ -1096,35 +1114,36 @@ subroutine ca_accel_ccoe( lo, hi, &
 
   use rad_params_module, only : ngroups
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: lo(2), hi(2)
   integer, intent(in) :: bcgr_l1, bcgr_h1, bcgr_l2, bcgr_h2
   integer, intent(in) :: spec_l1, spec_h1, spec_l2, spec_h2
   integer, intent(in) :: ccoe_l1, ccoe_h1, ccoe_l2, ccoe_h2
-  double precision,intent(in)::bcgr(bcgr_l1:bcgr_h1,bcgr_l2:bcgr_h2)
-  double precision,intent(in)::spec(spec_l1:spec_h1,spec_l2:spec_h2,0:ngroups-1)
-  double precision           ::ccoe(ccoe_l1:ccoe_h1,ccoe_l2:ccoe_h2,0:1)
-  double precision, intent(in) :: dx(2)
+  real(rt)        ,intent(in)::bcgr(bcgr_l1:bcgr_h1,bcgr_l2:bcgr_h2)
+  real(rt)        ,intent(in)::spec(spec_l1:spec_h1,spec_l2:spec_h2,0:ngroups-1)
+  real(rt)                   ::ccoe(ccoe_l1:ccoe_h1,ccoe_l2:ccoe_h2,0:1)
+  real(rt)        , intent(in) :: dx(2)
   integer, intent(in) :: idim, igroup
 
   integer :: i, j, ioff, joff
-  double precision :: grad_spec, foo, h1
+  real(rt)         :: grad_spec, foo, h1
 
   if (idim .eq. 0) then
      ioff = 1
      joff = 0
-     h1 = 1.d0/dx(1)
+     h1 = 1.e0_rt/dx(1)
   else
      ioff = 0
      joff = 1
-     h1 = 1.d0/dx(2)
+     h1 = 1.e0_rt/dx(2)
   end if
 
   do j = lo(2), hi(2)
   do i = lo(1), hi(1)
      grad_spec = (spec(i,j,igroup) - spec(i-ioff,j-joff,igroup)) * h1
-     foo = - 0.5d0 * bcgr(i,j) * grad_spec
+     foo = - 0.5e0_rt * bcgr(i,j) * grad_spec
      ccoe(i,j,0) = ccoe(i,j,0) + foo
      ccoe(i,j,1) = ccoe(i,j,1) + foo
   end do
@@ -1139,6 +1158,7 @@ subroutine ca_flux_face2center( lo, hi, &
      x, x_l1, x_h1, nt, idim, iflx)
 
   use rad_params_module, only : ngroups
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer,intent(in):: lo(2), hi(2)
@@ -1146,9 +1166,9 @@ subroutine ca_flux_face2center( lo, hi, &
   integer,intent(in)::f_l1,f_h1,f_l2,f_h2
   integer,intent(in)::x_l1,x_h1
   integer,intent(in) :: nt, idim, iflx
-  double precision           ::t(t_l1:t_h1,t_l2:t_h2,0:nt-1)
-  double precision,intent(in)::f(f_l1:f_h1,f_l2:f_h2)
-  double precision,intent(in)::x(x_l1:x_h1)
+  real(rt)                   ::t(t_l1:t_h1,t_l2:t_h2,0:nt-1)
+  real(rt)        ,intent(in)::f(f_l1:f_h1,f_l2:f_h2)
+  real(rt)        ,intent(in)::x(x_l1:x_h1)
 
   integer it, i, j
 
@@ -1157,13 +1177,13 @@ subroutine ca_flux_face2center( lo, hi, &
   if (idim .eq. 0) then
      do j=lo(2), hi(2)
         do i=lo(1), hi(1)
-           t(i,j,it) = (f(i,j)/(x(i)+1.d-50) + f(i+1,j)/x(i+1)) * 0.5d0
+           t(i,j,it) = (f(i,j)/(x(i)+1.e-50_rt) + f(i+1,j)/x(i+1)) * 0.5e0_rt
         end do
      end do
   else 
      do j=lo(2), hi(2)
         do i=lo(1), hi(1)
-           t(i,j,it) = (f(i,j)/x(i) + f(i,j+1)/x(i)) * 0.5d0
+           t(i,j,it) = (f(i,j)/x(i) + f(i,j+1)/x(i)) * 0.5e0_rt
         end do
      end do
   end if
@@ -1173,11 +1193,12 @@ end subroutine ca_flux_face2center
 subroutine ca_rhstoer( lo, hi, &
      rhs, rhs_l1, rhs_l2, rhs_h1, rhs_h2, &
      r, dt)
+  use bl_fort_module, only : rt => c_real
   implicit none
   integer,intent(in):: lo(2), hi(2), rhs_l1, rhs_h1, rhs_l2, rhs_h2
-  double precision :: rhs ( rhs_l1: rhs_h1, rhs_l2: rhs_h2)
-  double precision,intent(in) :: r(lo(1):hi(1))
-  double precision,intent(in) :: dt
+  real(rt)         :: rhs ( rhs_l1: rhs_h1, rhs_l2: rhs_h2)
+  real(rt)        ,intent(in) :: r(lo(1):hi(1))
+  real(rt)        ,intent(in) :: dt
   integer :: i, j
   do j=lo(2), hi(2)
   do i=lo(1), hi(1)
@@ -1199,22 +1220,23 @@ subroutine ca_compute_powerlaw_kappa_s( lo, hi, &
   use rad_params_module, only : ngroups, nugroup
   use meth_params_module, only : NVAR, URHO, UTEMP
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: lo(2), hi(2)
   integer, intent(in) :: k_l1, k_l2, k_h1, k_h2, &
                          u_l1, u_l2, u_h1, u_h2
-  double precision             :: kappa(k_l1:k_h1, k_l2:k_h2, 0:ngroups-1) 
-  double precision, intent(in) ::     u(u_l1:u_h1, u_l2:u_h2, NVAR)
-  double precision, intent(in) :: kappa0, m, n, p, Tfloor, kfloor
-  double precision, intent(in) :: s0, sm, sn, sp
+  real(rt)                     :: kappa(k_l1:k_h1, k_l2:k_h2, 0:ngroups-1) 
+  real(rt)        , intent(in) ::     u(u_l1:u_h1, u_l2:u_h2, NVAR)
+  real(rt)        , intent(in) :: kappa0, m, n, p, Tfloor, kfloor
+  real(rt)        , intent(in) :: s0, sm, sn, sp
 
   integer :: i, j, g
-  double precision, parameter :: tiny = 1.0d-50
-  double precision :: Teff, kf, sct, nup, nusp
+  real(rt)        , parameter :: tiny = 1.0e-50_rt
+  real(rt)         :: Teff, kf, sct, nup, nusp
 
-  if (  m.eq.0.d0 .and.  n.eq.0.d0 .and.  p.eq.0.d0 .and. &
-       sm.eq.0.d0 .and. sn.eq.0.d0 .and. sp.eq.0.d0 ) then
+  if (  m.eq.0.e0_rt .and.  n.eq.0.e0_rt .and.  p.eq.0.e0_rt .and. &
+       sm.eq.0.e0_rt .and. sn.eq.0.e0_rt .and. sp.eq.0.e0_rt ) then
      kappa(lo(1):hi(1),lo(2):hi(2),:) = kappa0 + s0
   else
      do g = 0, ngroups-1
@@ -1243,20 +1265,21 @@ subroutine ca_compute_powerlaw_kappa( lo, hi,  &
   use rad_params_module, only : ngroups, nugroup
   use meth_params_module, only : NVAR, URHO, UTEMP
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: lo(2), hi(2)
   integer, intent(in) :: k_l1, k_l2, k_h1, k_h2, &
                          u_l1, u_l2, u_h1, u_h2
-  double precision             :: kappa(k_l1:k_h1, k_l2:k_h2, 0:ngroups-1)
-  double precision, intent(in) ::     u(u_l1:u_h1, u_l2:u_h2, NVAR)
-  double precision, intent(in) :: kappa0, m, n, p, Tfloor, kfloor
+  real(rt)                     :: kappa(k_l1:k_h1, k_l2:k_h2, 0:ngroups-1)
+  real(rt)        , intent(in) ::     u(u_l1:u_h1, u_l2:u_h2, NVAR)
+  real(rt)        , intent(in) :: kappa0, m, n, p, Tfloor, kfloor
 
   integer :: i, j, g
-  double precision, parameter :: tiny = 1.0d-50
-  double precision :: Teff, kf, nup
+  real(rt)        , parameter :: tiny = 1.0e-50_rt
+  real(rt)         :: Teff, kf, nup
 
-  if (  m.eq.0.d0 .and.  n.eq.0.d0 .and.  p.eq.0.d0 ) then
+  if (  m.eq.0.e0_rt .and.  n.eq.0.e0_rt .and.  p.eq.0.e0_rt ) then
      kappa(lo(1):hi(1),lo(2):hi(2),:) = kappa0
   else
      do g = 0, ngroups-1
@@ -1284,23 +1307,24 @@ subroutine ca_spalpha( lo, hi, &
 
   use rad_params_module, only : ngroups
   use fluxlimiter_module, only : FLDalpha
+  use bl_fort_module, only : rt => c_real
   implicit none
   integer, intent(in) :: lo(2), hi(2)
   integer, intent(in) :: spa_l1, spa_h1, spa_l2, spa_h2
   integer, intent(in) :: lmx_l1, lmx_h1, lmx_l2, lmx_h2
   integer, intent(in) :: lmy_l1, lmy_h1, lmy_l2, lmy_h2
   integer, intent(in) :: igroup
-  double precision             :: spa(spa_l1:spa_h1,spa_l2:spa_h2)
-  double precision, intent(in) :: lmx(lmx_l1:lmx_h1,lmx_l2:lmx_h2,0:ngroups-1)
-  double precision, intent(in) :: lmy(lmy_l1:lmy_h1,lmy_l2:lmy_h2,0:ngroups-1)
+  real(rt)                     :: spa(spa_l1:spa_h1,spa_l2:spa_h2)
+  real(rt)        , intent(in) :: lmx(lmx_l1:lmx_h1,lmx_l2:lmx_h2,0:ngroups-1)
+  real(rt)        , intent(in) :: lmy(lmy_l1:lmy_h1,lmy_l2:lmy_h2,0:ngroups-1)
   integer :: i,j
-  double precision :: lam
+  real(rt)         :: lam
 
   do j = lo(2), hi(2)
   do i = lo(1), hi(1)
      if ( i.eq.spa_l1 .or. i.eq.spa_h1 .or.  &
           j.eq.spa_l2 .or. j.eq.spa_h2 ) then
-        lam = 0.25d0*(lmx(i,j,igroup) + lmx(i+1,j  ,igroup)  &
+        lam = 0.25e0_rt*(lmx(i,j,igroup) + lmx(i+1,j  ,igroup)  &
              +        lmy(i,j,igroup) + lmy(i  ,j+1,igroup))
         spa(i,j) = FLDalpha(lam)
      end if

--- a/Source/Radiation/RadSrc_2d/MGFLDneut_2d.f90
+++ b/Source/Radiation/RadSrc_2d/MGFLDneut_2d.f90
@@ -10,6 +10,7 @@ subroutine ca_accel_acoe_neut( lo, hi,  &
 
   use rad_params_module, only : ngroups, clight, erg2rhoYe
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: lo(2), hi(2)
@@ -19,23 +20,23 @@ subroutine ca_accel_acoe_neut( lo, hi,  &
   integer, intent(in) ::  spc_l1, spc_h1, spc_l2, spc_h2
   integer, intent(in) ::  kap_l1, kap_h1, kap_l2, kap_h2
   integer, intent(in) ::  aco_l1, aco_h1, aco_l2, aco_h2
-  double precision, intent(in) :: eta1(eta1_l1:eta1_h1,eta1_l2:eta1_h2)
-  double precision, intent(in) :: theT(theT_l1:theT_h1,theT_l2:theT_h2)
-  double precision, intent(in) :: theY(theY_l1:theY_h1,theY_l2:theY_h2)
-  double precision, intent(in) :: spc ( spc_l1: spc_h1, spc_l2: spc_h2,0:ngroups-1)
-  double precision, intent(in) :: kap ( kap_l1: kap_h1, kap_l2: kap_h2,0:ngroups-1)
-  double precision             :: aco ( aco_l1: aco_h1, aco_l2: aco_h2)
-  double precision, intent(in) :: dt, tau
+  real(rt)        , intent(in) :: eta1(eta1_l1:eta1_h1,eta1_l2:eta1_h2)
+  real(rt)        , intent(in) :: theT(theT_l1:theT_h1,theT_l2:theT_h2)
+  real(rt)        , intent(in) :: theY(theY_l1:theY_h1,theY_l2:theY_h2)
+  real(rt)        , intent(in) :: spc ( spc_l1: spc_h1, spc_l2: spc_h2,0:ngroups-1)
+  real(rt)        , intent(in) :: kap ( kap_l1: kap_h1, kap_l2: kap_h2,0:ngroups-1)
+  real(rt)                     :: aco ( aco_l1: aco_h1, aco_l2: aco_h2)
+  real(rt)        , intent(in) :: dt, tau
 
   integer :: i, j, g
-  double precision :: kbar, kybar, H1, Theta, dt1, foo
+  real(rt)         :: kbar, kybar, H1, Theta, dt1, foo
 
-  dt1 = (1.d0+tau)/dt
+  dt1 = (1.e0_rt+tau)/dt
 
   do j = lo(2), hi(2)
   do i = lo(1), hi(1)
-     kbar = 0.d0
-     kybar = 0.d0
+     kbar = 0.e0_rt
+     kybar = 0.e0_rt
      do g=0, ngroups-1
         foo = spc(i,j,g) * kap(i,j,g)
         kbar = kbar + foo
@@ -65,6 +66,7 @@ subroutine ca_accel_rhs_neut( lo, hi, &
 
   use rad_params_module, only : ngroups, clight, erg2rhoYe
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: lo(2), hi(2)
@@ -76,23 +78,23 @@ subroutine ca_accel_rhs_neut( lo, hi, &
   integer, intent(in) ::theT_l1,theT_h1,theT_l2,theT_h2
   integer, intent(in) ::theY_l1,theY_h1,theY_l2,theY_h2
   integer, intent(in) :: rhs_l1, rhs_h1, rhs_l2, rhs_h2
-  double precision, intent(in) ::Ern ( Ern_l1: Ern_h1, Ern_l2: Ern_h2,0:ngroups-1)
-  double precision, intent(in) ::Erl ( Erl_l1: Erl_h1, Erl_l2: Erl_h2,0:ngroups-1)
-  double precision, intent(in) :: kap( kap_l1: kap_h1, kap_l2: kap_h2,0:ngroups-1)
-  double precision, intent(in) ::etaT(etaT_l1:etaT_h1,etaT_l2:etaT_h2)
-  double precision, intent(in) ::etaY(etaY_l1:etaY_h1,etaY_l2:etaY_h2)
-  double precision, intent(in) ::theT(theT_l1:theT_h1,theT_l2:theT_h2)
-  double precision, intent(in) ::theY(theY_l1:theY_h1,theY_l2:theY_h2)
-  double precision             :: rhs( rhs_l1: rhs_h1, rhs_l2: rhs_h2)
-  double precision, intent(in) :: dt
+  real(rt)        , intent(in) ::Ern ( Ern_l1: Ern_h1, Ern_l2: Ern_h2,0:ngroups-1)
+  real(rt)        , intent(in) ::Erl ( Erl_l1: Erl_h1, Erl_l2: Erl_h2,0:ngroups-1)
+  real(rt)        , intent(in) :: kap( kap_l1: kap_h1, kap_l2: kap_h2,0:ngroups-1)
+  real(rt)        , intent(in) ::etaT(etaT_l1:etaT_h1,etaT_l2:etaT_h2)
+  real(rt)        , intent(in) ::etaY(etaY_l1:etaY_h1,etaY_l2:etaY_h2)
+  real(rt)        , intent(in) ::theT(theT_l1:theT_h1,theT_l2:theT_h2)
+  real(rt)        , intent(in) ::theY(theY_l1:theY_h1,theY_l2:theY_h2)
+  real(rt)                     :: rhs( rhs_l1: rhs_h1, rhs_l2: rhs_h2)
+  real(rt)        , intent(in) :: dt
 
   integer :: i, j, g
-  double precision :: rt, ry, H, Theta, foo
+  real(rt)         :: rt, ry, H, Theta, foo
 
   do j = lo(2), hi(2)
   do i = lo(1), hi(1)
-     rt = 0.d0
-     ry = 0.d0
+     rt = 0.e0_rt
+     ry = 0.e0_rt
      do g=0,ngroups-1
         foo = kap(i,j,g)*(Ern(i,j,g)-Erl(i,j,g))
         rt = rt + foo
@@ -124,6 +126,7 @@ subroutine ca_accel_spec_neut( lo, hi, &
 
   use rad_params_module, only : ngroups, clight, erg2rhoYe
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: lo(2), hi(2)
@@ -137,29 +140,29 @@ subroutine ca_accel_spec_neut( lo, hi, &
   integer,intent(in)::mugT_l1,mugT_h1,mugT_l2,mugT_h2
   integer,intent(in)::mugY_l1,mugY_h1,mugY_l2,mugY_h2
   integer,intent(in)::spec_l1,spec_h1,spec_l2,spec_h2
-  double precision,intent(in)::Ern ( Ern_l1: Ern_h1, Ern_l2: Ern_h2,0:ngroups-1)
-  double precision,intent(in)::Erl ( Erl_l1: Erl_h1, Erl_l2: Erl_h2,0:ngroups-1)
-  double precision,intent(in)::kap ( kap_l1: kap_h1, kap_l2: kap_h2,0:ngroups-1)
-  double precision,intent(in)::etaT(etaT_l1:etaT_h1,etaT_l2:etaT_h2)
-  double precision,intent(in)::etaY(etaY_l1:etaY_h1,etaY_l2:etaY_h2)
-  double precision,intent(in)::theT(theT_l1:theT_h1,theT_l2:theT_h2)
-  double precision,intent(in)::theY(theY_l1:theY_h1,theY_l2:theY_h2)
-  double precision,intent(in)::mugT(mugT_l1:mugT_h1,mugT_l2:mugT_h2,0:ngroups-1)
-  double precision,intent(in)::mugY(mugY_l1:mugY_h1,mugY_l2:mugY_h2,0:ngroups-1)
-  double precision           ::spec(spec_l1:spec_h1,spec_l2:spec_h2,0:ngroups-1)
-  double precision,intent(in) :: dt, tau
+  real(rt)        ,intent(in)::Ern ( Ern_l1: Ern_h1, Ern_l2: Ern_h2,0:ngroups-1)
+  real(rt)        ,intent(in)::Erl ( Erl_l1: Erl_h1, Erl_l2: Erl_h2,0:ngroups-1)
+  real(rt)        ,intent(in)::kap ( kap_l1: kap_h1, kap_l2: kap_h2,0:ngroups-1)
+  real(rt)        ,intent(in)::etaT(etaT_l1:etaT_h1,etaT_l2:etaT_h2)
+  real(rt)        ,intent(in)::etaY(etaY_l1:etaY_h1,etaY_l2:etaY_h2)
+  real(rt)        ,intent(in)::theT(theT_l1:theT_h1,theT_l2:theT_h2)
+  real(rt)        ,intent(in)::theY(theY_l1:theY_h1,theY_l2:theY_h2)
+  real(rt)        ,intent(in)::mugT(mugT_l1:mugT_h1,mugT_l2:mugT_h2,0:ngroups-1)
+  real(rt)        ,intent(in)::mugY(mugY_l1:mugY_h1,mugY_l2:mugY_h2,0:ngroups-1)
+  real(rt)                   ::spec(spec_l1:spec_h1,spec_l2:spec_h2,0:ngroups-1)
+  real(rt)        ,intent(in) :: dt, tau
 
   integer :: i, j, g
-  double precision :: cdt1, rt, ry, p, q, r, s, foo, sumeps
-  double precision,dimension(0:ngroups-1)::Hg, Tg, epsilon, kapt, kk
+  real(rt)         :: cdt1, rt, ry, p, q, r, s, foo, sumeps
+  real(rt)        ,dimension(0:ngroups-1)::Hg, Tg, epsilon, kapt, kk
 
-  cdt1 = 1.d0/(clight*dt)
+  cdt1 = 1.e0_rt/(clight*dt)
 
   do j = lo(2), hi(2)
   do i = lo(1), hi(1)
 
-     rt = 0.d0
-     ry = 0.d0
+     rt = 0.e0_rt
+     ry = 0.e0_rt
      do g=0,ngroups-1
         foo = kap(i,j,g)*(Ern(i,j,g)-Erl(i,j,g))
         rt = rt + foo
@@ -169,19 +172,19 @@ subroutine ca_accel_spec_neut( lo, hi, &
      Hg = mugT(i,j,:)*etaT(i,j) - mugY(i,j,:)*etaY(i,j)
      Tg = -mugT(i,j,:)*theT(i,j) + mugY(i,j,:)*theY(i,j)
 
-     kapt = kap(i,j,:) + (1.d0+tau)*cdt1
+     kapt = kap(i,j,:) + (1.e0_rt+tau)*cdt1
      kk = kap(i,j,:) / kapt
 
-     p = 1.d0 - sum(Hg*kk)
-     q = 1.d0 - sum(Tg*erg2rhoYe*kk)
+     p = 1.e0_rt - sum(Hg*kk)
+     q = 1.e0_rt - sum(Tg*erg2rhoYe*kk)
      r = sum(Hg*erg2rhoYe*kk)
      s = sum(Tg*kk)
 
      epsilon = ((r*Tg + q*Hg) * rt + (s*Hg + p*Tg) * ry) / kapt
 
      sumeps = sum(epsilon)
-     if (sumeps .eq. 0.d0) then
-        sumeps = 1.d-50
+     if (sumeps .eq. 0.e0_rt) then
+        sumeps = 1.e-50_rt
      end if
      
      spec(i,j,:) = epsilon / sumeps
@@ -212,6 +215,7 @@ subroutine ca_check_conv_neut( lo, hi, &
      dt)
   use rad_params_module, only : ngroups, clight, erg2rhoYe
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer,intent(in)::lo(2),hi(2)
@@ -229,44 +233,44 @@ subroutine ca_check_conv_neut( lo, hi, &
   integer,intent(in):: jg_l1,  jg_h1,  jg_l2,  jg_h2
   integer,intent(in)::deT_l1, deT_h1, deT_l2, deT_h2
   integer,intent(in)::deY_l1, deY_h1, deY_l2, deY_h2
-  double precision,intent(in   )::ren(ren_l1:ren_h1,ren_l2:ren_h2)
-  double precision,intent(in   )::res(res_l1:res_h1,res_l2:res_h2)
-  double precision,intent(in   )::re2(re2_l1:re2_h1,re2_l2:re2_h2)
-  double precision,intent(in   )::ern(ern_l1:ern_h1,ern_l2:ern_h2,0:ngroups-1)
-  double precision,intent(in   )::Tmn(Tmn_l1:Tmn_h1,Tmn_l2:Tmn_h2)
-  double precision,intent(in   )::Tms(Tms_l1:Tms_h1,Tms_l2:Tms_h2)
-  double precision,intent(in   )::rYn(rYn_l1:rYn_h1,rYn_l2:rYn_h2)
-  double precision,intent(in   )::rYs(rYs_l1:rYs_h1,rYs_l2:rYs_h2)
-  double precision,intent(in   )::rY2(rY2_l1:rY2_h1,rY2_l2:rY2_h2)
-  double precision,intent(in   )::rho(rho_l1:rho_h1,rho_l2:rho_h2)
-  double precision,intent(in   )::kap(kap_l1:kap_h1,kap_l2:kap_h2,0:ngroups-1)
-  double precision,intent(in   ):: jg( jg_l1: jg_h1, jg_l2: jg_h2,0:ngroups-1)
-  double precision,intent(in   )::deT(deT_l1:deT_h1,deT_l2:deT_h2)
-  double precision,intent(in   )::deY(deY_l1:deY_h1,deY_l2:deY_h2)
-  double precision,intent(inout)::rel_re, abs_re
-  double precision,intent(inout)::rel_FT, abs_FT,rel_T, abs_T
-  double precision,intent(inout)::rel_FY, abs_FY,rel_Y, abs_Y
-  double precision,intent(in) :: dt
+  real(rt)        ,intent(in   )::ren(ren_l1:ren_h1,ren_l2:ren_h2)
+  real(rt)        ,intent(in   )::res(res_l1:res_h1,res_l2:res_h2)
+  real(rt)        ,intent(in   )::re2(re2_l1:re2_h1,re2_l2:re2_h2)
+  real(rt)        ,intent(in   )::ern(ern_l1:ern_h1,ern_l2:ern_h2,0:ngroups-1)
+  real(rt)        ,intent(in   )::Tmn(Tmn_l1:Tmn_h1,Tmn_l2:Tmn_h2)
+  real(rt)        ,intent(in   )::Tms(Tms_l1:Tms_h1,Tms_l2:Tms_h2)
+  real(rt)        ,intent(in   )::rYn(rYn_l1:rYn_h1,rYn_l2:rYn_h2)
+  real(rt)        ,intent(in   )::rYs(rYs_l1:rYs_h1,rYs_l2:rYs_h2)
+  real(rt)        ,intent(in   )::rY2(rY2_l1:rY2_h1,rY2_l2:rY2_h2)
+  real(rt)        ,intent(in   )::rho(rho_l1:rho_h1,rho_l2:rho_h2)
+  real(rt)        ,intent(in   )::kap(kap_l1:kap_h1,kap_l2:kap_h2,0:ngroups-1)
+  real(rt)        ,intent(in   ):: jg( jg_l1: jg_h1, jg_l2: jg_h2,0:ngroups-1)
+  real(rt)        ,intent(in   )::deT(deT_l1:deT_h1,deT_l2:deT_h2)
+  real(rt)        ,intent(in   )::deY(deY_l1:deY_h1,deY_l2:deY_h2)
+  real(rt)        ,intent(inout)::rel_re, abs_re
+  real(rt)        ,intent(inout)::rel_FT, abs_FT,rel_T, abs_T
+  real(rt)        ,intent(inout)::rel_FY, abs_FY,rel_Y, abs_Y
+  real(rt)        ,intent(in) :: dt
 
   integer :: i, j
-  double precision :: chg, relchg, FT, FY, cdt, FTdenom, FYdenom, dTe, dYe
+  real(rt)         :: chg, relchg, FT, FY, cdt, FTdenom, FYdenom, dTe, dYe
 
   cdt = clight*dt
 
   do j=lo(2),hi(2)
   do i=lo(1),hi(1)
      chg = abs(ren(i,j) - res(i,j))
-     relchg = abs(chg/(ren(i,j)+1.d-50))
+     relchg = abs(chg/(ren(i,j)+1.e-50_rt))
      rel_re = max(rel_re,relchg)
      abs_re = max(abs_re,chg)
 
      chg = abs(Tmn(i,j) - Tms(i,j))
-     relchg = abs(chg/(Tmn(i,j)+1.d-50))
+     relchg = abs(chg/(Tmn(i,j)+1.e-50_rt))
      rel_T = max(rel_T,relchg)
      abs_T = max(abs_T,chg)
 
      chg = abs(rYn(i,j) - rYs(i,j))
-     relchg = abs(chg/(rYn(i,j)+1.d-50))
+     relchg = abs(chg/(rYn(i,j)+1.e-50_rt))
      rel_Y = max(rel_Y,relchg)
      abs_Y = max(abs_Y,chg/rho(i,j))
 
@@ -278,10 +282,10 @@ subroutine ca_check_conv_neut( lo, hi, &
      FTdenom = rho(i,j)*(abs(deT(i,j)*dTe)+abs(deY(i,j)*dYe))
      FYdenom = rYn(i,j)
 
-     rel_FT = max(rel_FT, FT/(FTdenom+1.d-50))
+     rel_FT = max(rel_FT, FT/(FTdenom+1.e-50_rt))
      abs_FT = max(abs_FT, FT)
 
-     rel_FY = max(rel_FY, FY/(FYdenom+1.d-50))
+     rel_FY = max(rel_FY, FY/(FYdenom+1.e-50_rt))
      abs_FY = max(abs_FY, FY)
   end do
   end do
@@ -303,6 +307,7 @@ subroutine ca_check_conv_er_neut( lo, hi,  &
 
   use rad_params_module, only : ngroups, clight, erg2rhoYe
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer,intent(in):: lo(2), hi(2)
@@ -315,28 +320,28 @@ subroutine ca_check_conv_er_neut( lo, hi,  &
   integer,intent(in)::etYz_l1,etYz_h1,etYz_l2,etYz_h2
   integer,intent(in)::thTz_l1,thTz_h1,thTz_l2,thTz_h2
   integer,intent(in)::thYz_l1,thYz_h1,thYz_l2,thYz_h2
-  double precision,intent(in):: Ern( Ern_l1: Ern_h1, Ern_l2: Ern_h2,0:ngroups-1)
-  double precision,intent(in):: Erl( Erl_l1: Erl_h1, Erl_l2: Erl_h2,0:ngroups-1)
-  double precision,intent(in):: kap( kap_l1: kap_h1, kap_l2: kap_h2,0:ngroups-1)
-  double precision,intent(in)::etTz(etTz_l1:etTz_h1,etTz_l2:etTz_h2)
-  double precision,intent(in)::etYz(etYz_l1:etYz_h1,etYz_l2:etYz_h2)
-  double precision,intent(in)::thTz(thTz_l1:thTz_h1,thTz_l2:thTz_h2)
-  double precision,intent(in)::thYz(thYz_l1:thYz_h1,thYz_l2:thYz_h2)
-  double precision,intent(in)::temp(temp_l1:temp_h1,temp_l2:temp_h2)
-  double precision,intent(in)::Ye  (  Ye_l1:  Ye_h1,  Ye_l2:  Ye_h2)
-  double precision, intent(inout) :: rela, abso, errr
-  double precision, intent(in) :: dt
+  real(rt)        ,intent(in):: Ern( Ern_l1: Ern_h1, Ern_l2: Ern_h2,0:ngroups-1)
+  real(rt)        ,intent(in):: Erl( Erl_l1: Erl_h1, Erl_l2: Erl_h2,0:ngroups-1)
+  real(rt)        ,intent(in):: kap( kap_l1: kap_h1, kap_l2: kap_h2,0:ngroups-1)
+  real(rt)        ,intent(in)::etTz(etTz_l1:etTz_h1,etTz_l2:etTz_h2)
+  real(rt)        ,intent(in)::etYz(etYz_l1:etYz_h1,etYz_l2:etYz_h2)
+  real(rt)        ,intent(in)::thTz(thTz_l1:thTz_h1,thTz_l2:thTz_h2)
+  real(rt)        ,intent(in)::thYz(thYz_l1:thYz_h1,thYz_l2:thYz_h2)
+  real(rt)        ,intent(in)::temp(temp_l1:temp_h1,temp_l2:temp_h2)
+  real(rt)        ,intent(in)::Ye  (  Ye_l1:  Ye_h1,  Ye_l2:  Ye_h2)
+  real(rt)        , intent(inout) :: rela, abso, errr
+  real(rt)        , intent(in) :: dt
 
   integer :: i, j, g
-  double precision :: chg, tot, cdt, der, kdeT, kdeY, err_T, err_Y, err
+  real(rt)         :: chg, tot, cdt, der, kdeT, kdeY, err_T, err_Y, err
 
   cdt = clight * dt
   do j = lo(2), hi(2)
   do i = lo(1), hi(1)
-     chg = 0.d0
-     tot = 0.d0
-     kdeT = 0.d0
-     kdeY = 0.d0
+     chg = 0.e0_rt
+     tot = 0.e0_rt
+     kdeT = 0.e0_rt
+     kdeY = 0.e0_rt
      do g=0,ngroups-1
         der = Ern(i,j,g)-Erl(i,j,g)
         chg = chg + abs(der)
@@ -345,11 +350,11 @@ subroutine ca_check_conv_er_neut( lo, hi,  &
         kdeY = kdeY + erg2rhoYe(g)*kap(i,j,g)*der
      end do
      abso = max(abso, chg)
-     rela = max(rela, chg / (tot + 1.d-50))
+     rela = max(rela, chg / (tot + 1.e-50_rt))
 
      err_T =  etTz(i,j)*kdeT - thTz(i,j)*kdeY 
      err_Y = -etYz(i,j)*kdeT + thYz(i,j)*kdeY 
-     err = max(abs(err_T/(temp(i,j)+1.d-50)), abs(err_Y/(Ye(i,j)+1.d-50)))
+     err = max(abs(err_T/(temp(i,j)+1.e-50_rt)), abs(err_Y/(Ye(i,j)+1.e-50_rt)))
      errr = max(errr, err)
   end do
   end do
@@ -366,6 +371,7 @@ subroutine ca_compute_coupty( lo, hi, &
   
   use rad_params_module, only : ngroups, erg2rhoYe
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: lo(2), hi(2)
@@ -374,17 +380,17 @@ subroutine ca_compute_coupty( lo, hi, &
   integer, intent(in) :: kpp_l1, kpp_h1, kpp_l2, kpp_h2
   integer, intent(in) ::  eg_l1,  eg_h1,  eg_l2,  eg_h2
   integer, intent(in) ::  jg_l1,  jg_h1,  jg_l2,  jg_h2
-  double precision             :: cpt(cpt_l1:cpt_h1,cpt_l2:cpt_h2)
-  double precision             :: cpy(cpy_l1:cpy_h1,cpy_l2:cpy_h2)
-  double precision, intent(in) :: kpp(kpp_l1:kpp_h1,kpp_l2:kpp_h2,0:ngroups-1)
-  double precision, intent(in) ::  eg( eg_l1: eg_h1, eg_l2: eg_h2,0:ngroups-1)
-  double precision, intent(in) ::  jg( jg_l1: jg_h1, jg_l2: jg_h2,0:ngroups-1)
+  real(rt)                     :: cpt(cpt_l1:cpt_h1,cpt_l2:cpt_h2)
+  real(rt)                     :: cpy(cpy_l1:cpy_h1,cpy_l2:cpy_h2)
+  real(rt)        , intent(in) :: kpp(kpp_l1:kpp_h1,kpp_l2:kpp_h2,0:ngroups-1)
+  real(rt)        , intent(in) ::  eg( eg_l1: eg_h1, eg_l2: eg_h2,0:ngroups-1)
+  real(rt)        , intent(in) ::  jg( jg_l1: jg_h1, jg_l2: jg_h2,0:ngroups-1)
 
   integer :: i, j, g
-  double precision :: foo
+  real(rt)         :: foo
 
-  cpt(lo(1):hi(1),lo(2):hi(2)) = 0.d0
-  cpy(lo(1):hi(1),lo(2):hi(2)) = 0.d0
+  cpt(lo(1):hi(1),lo(2):hi(2)) = 0.e0_rt
+  cpy(lo(1):hi(1),lo(2):hi(2)) = 0.e0_rt
 
   do g=0, ngroups-1
      do j=lo(2),hi(2)
@@ -413,6 +419,7 @@ subroutine ca_compute_dedx( lo, hi,  &
   use network, only : nspec, naux
   use meth_params_module, only : NVAR, URHO, UFS
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: lo(2), hi(2)
@@ -423,25 +430,25 @@ subroutine ca_compute_dedx( lo, hi,  &
   integer, intent(in) ::  Yes_l1,  Yes_h1,  Yes_l2,  Yes_h2
   integer, intent(in) :: dedT_l1, dedT_h1, dedT_l2, dedT_h2
   integer, intent(in) :: dedY_l1, dedY_h1, dedY_l2, dedY_h2
-  double precision, intent(in) :: S   (   S_l1:   S_h1,   S_l2:   S_h2,NVAR)
-  double precision, intent(in) :: T   (   T_l1:   T_h1,   T_l2:   T_h2)
-  double precision, intent(in) :: Ye  (  Ye_l1:  Ye_h1,  Ye_l2:  Ye_h2)
-  double precision, intent(in) :: Ts  (  Ts_l1:  Ts_h1,  Ts_l2:  Ts_h2)
-  double precision, intent(in) :: Yes ( Yes_l1: Yes_h1, Yes_l2: Yes_h2)
-  double precision             :: dedT(dedT_l1:dedT_h1,dedT_l2:dedT_h2)
-  double precision             :: dedY(dedY_l1:dedY_h1,dedY_l2:dedY_h2)
+  real(rt)        , intent(in) :: S   (   S_l1:   S_h1,   S_l2:   S_h2,NVAR)
+  real(rt)        , intent(in) :: T   (   T_l1:   T_h1,   T_l2:   T_h2)
+  real(rt)        , intent(in) :: Ye  (  Ye_l1:  Ye_h1,  Ye_l2:  Ye_h2)
+  real(rt)        , intent(in) :: Ts  (  Ts_l1:  Ts_h1,  Ts_l2:  Ts_h2)
+  real(rt)        , intent(in) :: Yes ( Yes_l1: Yes_h1, Yes_l2: Yes_h2)
+  real(rt)                     :: dedT(dedT_l1:dedT_h1,dedT_l2:dedT_h2)
+  real(rt)                     :: dedY(dedY_l1:dedY_h1,dedY_l2:dedY_h2)
   integer, intent(in) :: validStar
 
   integer :: i, j
-  double precision :: rhoinv, e1, e2
+  real(rt)         :: rhoinv, e1, e2
   type(eos_t) :: eos_state
-  double precision :: dT, dYe, T1, T2, Ye1, Ye2
-  double precision, parameter :: fac = 0.5d0, minfrac = 1.d-8
+  real(rt)         :: dT, dYe, T1, T2, Ye1, Ye2
+  real(rt)        , parameter :: fac = 0.5e0_rt, minfrac = 1.e-8_rt
 
   do j=lo(2),hi(2)
   do i=lo(1),hi(1)
 
-     rhoinv = 1.d0/S(i,j,URHO)
+     rhoinv = 1.e0_rt/S(i,j,URHO)
      eos_state % rho = S(i,j,URHO)
      eos_state % xn  = S(i,j,UFS:UFS+nspec-1) * rhoinv
      eos_state % aux = ye(i,j)
@@ -452,18 +459,18 @@ subroutine ca_compute_dedx( lo, hi,  &
         dYe = fac*abs(Yes(i,j) - Ye(i,j))
         dYe = max(dYe, minfrac*Ye(i,j))
      else
-        dT = T(i,j) * 1.d-3 + 1.d-50
-        dYe = 1.d-4
+        dT = T(i,j) * 1.e-3_rt + 1.e-50_rt
+        dYe = 1.e-4_rt
      end if
 
      T1 = T(i,j) - dT
-     if (T1 < Tmin*(1.d0+1.d-6)) then
+     if (T1 < Tmin*(1.e0_rt+1.e-6_rt)) then
         T1 = T(i,j)
      end if
      T2 = T(i,j) + dT
 
      Ye1 = Ye(i,j) - dYe
-     if (Ye1 < Ymin*(1.d0+1.d-6)) then
+     if (Ye1 < Ymin*(1.e0_rt+1.e-6_rt)) then
         Ye1 = Ye(i,j)
      end if
      Ye2 = Ye(i,j) + dYe
@@ -519,6 +526,7 @@ subroutine ca_compute_eta_the( lo, hi, &
 
   use rad_params_module, only : ngroups, clight, erg2rhoYe
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: lo(2), hi(2)
@@ -540,32 +548,32 @@ subroutine ca_compute_eta_the( lo, hi, &
   integer, intent(in) :: dedY_l1, dedY_h1, dedY_l2, dedY_h2
   integer, intent(in) ::  Ers_l1,  Ers_h1,  Ers_l2,  Ers_h2
   integer, intent(in) ::  rho_l1,  rho_h1,  rho_l2,  rho_h2
-  double precision           ::etaT(etaT_l1:etaT_h1,etaT_l2:etaT_h2)
-  double precision           ::etTz(etTz_l1:etTz_h1,etTz_l2:etTz_h2)
-  double precision           ::etaY(etaY_l1:etaY_h1,etaY_l2:etaY_h2)
-  double precision           ::etYz(etYz_l1:etYz_h1,etYz_l2:etYz_h2)
-  double precision           ::eta1(eta1_l1:eta1_h1,eta1_l2:eta1_h2)
-  double precision           ::theT(theT_l1:theT_h1,theT_l2:theT_h2)
-  double precision           ::thTz(thTz_l1:thTz_h1,thTz_l2:thTz_h2)
-  double precision           ::theY(theY_l1:theY_h1,theY_l2:theY_h2)
-  double precision           ::thYz(thYz_l1:thYz_h1,thYz_l2:thYz_h2)
-  double precision           ::the1(the1_l1:the1_h1,the1_l2:the1_h2)
-  double precision           ::djdT(djdT_l1:djdT_h1,djdT_l2:djdT_h2,0:ngroups-1)
-  double precision           ::djdY(djdY_l1:djdY_h1,djdY_l2:djdY_h2,0:ngroups-1)
-  double precision,intent(in)::dkdT(dkdT_l1:dkdT_h1,dkdT_l2:dkdT_h2,0:ngroups-1)
-  double precision,intent(in)::dkdY(dkdY_l1:dkdY_h1,dkdY_l2:dkdY_h2,0:ngroups-1)
-  double precision,intent(in)::dedT(dedT_l1:dedT_h1,dedT_l2:dedT_h2)
-  double precision,intent(in)::dedY(dedY_l1:dedY_h1,dedY_l2:dedY_h2)
-  double precision,intent(in)::Ers ( Ers_l1: Ers_h1, Ers_l2: Ers_h2,0:ngroups-1)
-  double precision,intent(in)::rho ( rho_l1: rho_h1, rho_l2: rho_h2)
-  double precision,intent(in) :: dt, tau
+  real(rt)                   ::etaT(etaT_l1:etaT_h1,etaT_l2:etaT_h2)
+  real(rt)                   ::etTz(etTz_l1:etTz_h1,etTz_l2:etTz_h2)
+  real(rt)                   ::etaY(etaY_l1:etaY_h1,etaY_l2:etaY_h2)
+  real(rt)                   ::etYz(etYz_l1:etYz_h1,etYz_l2:etYz_h2)
+  real(rt)                   ::eta1(eta1_l1:eta1_h1,eta1_l2:eta1_h2)
+  real(rt)                   ::theT(theT_l1:theT_h1,theT_l2:theT_h2)
+  real(rt)                   ::thTz(thTz_l1:thTz_h1,thTz_l2:thTz_h2)
+  real(rt)                   ::theY(theY_l1:theY_h1,theY_l2:theY_h2)
+  real(rt)                   ::thYz(thYz_l1:thYz_h1,thYz_l2:thYz_h2)
+  real(rt)                   ::the1(the1_l1:the1_h1,the1_l2:the1_h2)
+  real(rt)                   ::djdT(djdT_l1:djdT_h1,djdT_l2:djdT_h2,0:ngroups-1)
+  real(rt)                   ::djdY(djdY_l1:djdY_h1,djdY_l2:djdY_h2,0:ngroups-1)
+  real(rt)        ,intent(in)::dkdT(dkdT_l1:dkdT_h1,dkdT_l2:dkdT_h2,0:ngroups-1)
+  real(rt)        ,intent(in)::dkdY(dkdY_l1:dkdY_h1,dkdY_l2:dkdY_h2,0:ngroups-1)
+  real(rt)        ,intent(in)::dedT(dedT_l1:dedT_h1,dedT_l2:dedT_h2)
+  real(rt)        ,intent(in)::dedY(dedY_l1:dedY_h1,dedY_l2:dedY_h2)
+  real(rt)        ,intent(in)::Ers ( Ers_l1: Ers_h1, Ers_l2: Ers_h2,0:ngroups-1)
+  real(rt)        ,intent(in)::rho ( rho_l1: rho_h1, rho_l2: rho_h2)
+  real(rt)        ,intent(in) :: dt, tau
 
   integer :: i, j
-  double precision :: cdt, det, et, ey, tt, ty, sigma
-  double precision :: dZdT(0:ngroups-1), dZdY(0:ngroups-1)
-  double precision :: sumdZdT, sumdZdY, fooT, fooY, barT, barY
+  real(rt)         :: cdt, det, et, ey, tt, ty, sigma
+  real(rt)         :: dZdT(0:ngroups-1), dZdY(0:ngroups-1)
+  real(rt)         :: sumdZdT, sumdZdY, fooT, fooY, barT, barY
 
-  sigma = 1.d0 + tau
+  sigma = 1.e0_rt + tau
   cdt = clight * dt
 
   do j = lo(2), hi(2)
@@ -576,12 +584,12 @@ subroutine ca_compute_eta_the( lo, hi, &
      sumdZdT = sum(dZdT)
      sumdZdY = sum(dZdY)
 
-     if (sumdZdT .eq. 0.d0) then
-        sumdZdT = 1.d-50
+     if (sumdZdT .eq. 0.e0_rt) then
+        sumdZdT = 1.e-50_rt
      end if
 
-     if (sumdZdY .eq. 0.d0) then
-        sumdZdY = 1.d-50
+     if (sumdZdY .eq. 0.e0_rt) then
+        sumdZdY = 1.e-50_rt
      end if
 
      fooT = cdt * sumdZdT
@@ -636,6 +644,7 @@ subroutine ca_compute_rhs_neut( lo, hi, &
 
   use rad_params_module, only : ngroups, clight
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer,intent(in):: lo(2), hi(2)
@@ -655,30 +664,30 @@ subroutine ca_compute_rhs_neut( lo, hi, &
   integer,intent(in):: Ers_l1, Ers_h1, Ers_l2, Ers_h2
   integer,intent(in):: res_l1, res_h1, res_l2, res_h2
   integer,intent(in):: rYs_l1, rYs_h1, rYs_l2, rYs_h2
-  double precision           ::rhs ( rhs_l1: rhs_h1, rhs_l2: rhs_h2)
-  double precision,intent(in)::jg  (  jg_l1:  jg_h1,  jg_l2:  jg_h2,0:ngroups-1)
-  double precision,intent(in)::mugT(mugT_l1:mugT_h1,mugT_l2:mugT_h2,0:ngroups-1)
-  double precision,intent(in)::mugY(mugY_l1:mugY_h1,mugY_l2:mugY_h2,0:ngroups-1)
-  double precision,intent(in)::cpT ( cpT_l1: cpT_h1, cpT_l2: cpT_h2)
-  double precision,intent(in)::cpY ( cpY_l1: cpY_h1, cpY_l2: cpY_h2)
-  double precision,intent(in)::etaT(etaT_l1:etaT_h1,etaT_l2:etaT_h2)
-  double precision,intent(in)::etaY(etaY_l1:etaY_h1,etaY_l2:etaY_h2)
-  double precision,intent(in)::theT(theT_l1:theT_h1,theT_l2:theT_h2)
-  double precision,intent(in)::theY(theY_l1:theY_h1,theY_l2:theY_h2)
-  double precision,intent(in)::Er2 ( Er2_l1: Er2_h1, Er2_l2: Er2_h2,0:ngroups-1)
-  double precision,intent(in)::re2 ( re2_l1: re2_h1, re2_l2: re2_h2)
-  double precision,intent(in)::rY2 ( rY2_l1: rY2_h1, rY2_l2: rY2_h2)
-  double precision,intent(in)::Ers ( Ers_l1: Ers_h1, Ers_l2: Ers_h2,0:ngroups-1)
-  double precision,intent(in)::res ( res_l1: res_h1, res_l2: res_h2)
-  double precision,intent(in)::rYs ( rYs_l1: rYs_h1, rYs_l2: rYs_h2)
-  double precision,intent(in) ::   r(lo(1):hi(1))
-  double precision,intent(in) :: dt, tau             
+  real(rt)                   ::rhs ( rhs_l1: rhs_h1, rhs_l2: rhs_h2)
+  real(rt)        ,intent(in)::jg  (  jg_l1:  jg_h1,  jg_l2:  jg_h2,0:ngroups-1)
+  real(rt)        ,intent(in)::mugT(mugT_l1:mugT_h1,mugT_l2:mugT_h2,0:ngroups-1)
+  real(rt)        ,intent(in)::mugY(mugY_l1:mugY_h1,mugY_l2:mugY_h2,0:ngroups-1)
+  real(rt)        ,intent(in)::cpT ( cpT_l1: cpT_h1, cpT_l2: cpT_h2)
+  real(rt)        ,intent(in)::cpY ( cpY_l1: cpY_h1, cpY_l2: cpY_h2)
+  real(rt)        ,intent(in)::etaT(etaT_l1:etaT_h1,etaT_l2:etaT_h2)
+  real(rt)        ,intent(in)::etaY(etaY_l1:etaY_h1,etaY_l2:etaY_h2)
+  real(rt)        ,intent(in)::theT(theT_l1:theT_h1,theT_l2:theT_h2)
+  real(rt)        ,intent(in)::theY(theY_l1:theY_h1,theY_l2:theY_h2)
+  real(rt)        ,intent(in)::Er2 ( Er2_l1: Er2_h1, Er2_l2: Er2_h2,0:ngroups-1)
+  real(rt)        ,intent(in)::re2 ( re2_l1: re2_h1, re2_l2: re2_h2)
+  real(rt)        ,intent(in)::rY2 ( rY2_l1: rY2_h1, rY2_l2: rY2_h2)
+  real(rt)        ,intent(in)::Ers ( Ers_l1: Ers_h1, Ers_l2: Ers_h2,0:ngroups-1)
+  real(rt)        ,intent(in)::res ( res_l1: res_h1, res_l2: res_h2)
+  real(rt)        ,intent(in)::rYs ( rYs_l1: rYs_h1, rYs_l2: rYs_h2)
+  real(rt)        ,intent(in) ::   r(lo(1):hi(1))
+  real(rt)        ,intent(in) :: dt, tau             
   integer, intent(in) :: igroup
 
   integer :: i, j
-  double precision :: Hg, thetag, dt1
+  real(rt)         :: Hg, thetag, dt1
 
-  dt1 = 1.d0/dt
+  dt1 = 1.e0_rt/dt
   do j=lo(2), hi(2)
   do i=lo(1), hi(1)
      Hg = mugT(i,j,igroup)*etaT(i,j) - mugY(i,j,igroup)*etaY(i,j)
@@ -710,6 +719,7 @@ subroutine ca_local_accel_neut( lo, hi,  &
 
   use rad_params_module, only : ngroups, clight, erg2rhoYe
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer,intent(in):: lo(2), hi(2)
@@ -722,22 +732,22 @@ subroutine ca_local_accel_neut( lo, hi,  &
   integer,intent(in)::theY_l1,theY_h1,theY_l2,theY_h2
   integer,intent(in)::mugT_l1,mugT_h1,mugT_l2,mugT_h2
   integer,intent(in)::mugY_l1,mugY_h1,mugY_l2,mugY_h2
-  double precision           ::Ern ( Ern_l1: Ern_h1, Ern_l2: Ern_h2,0:ngroups-1)
-  double precision,intent(in)::Erl ( Erl_l1: Erl_h1, Erl_l2: Erl_h2,0:ngroups-1)
-  double precision,intent(in)::kap ( kap_l1: kap_h1, kap_l2: kap_h2,0:ngroups-1)
-  double precision,intent(in)::etaT(etaT_l1:etaT_h1,etaT_l2:etaT_h2)
-  double precision,intent(in)::etaY(etaY_l1:etaY_h1,etaY_l2:etaY_h2)
-  double precision,intent(in)::theT(theT_l1:theT_h1,theT_l2:theT_h2)
-  double precision,intent(in)::theY(theY_l1:theY_h1,theY_l2:theY_h2)
-  double precision,intent(in)::mugT(mugT_l1:mugT_h1,mugT_l2:mugT_h2,0:ngroups-1)
-  double precision,intent(in)::mugY(mugY_l1:mugY_h1,mugY_l2:mugY_h2,0:ngroups-1)
-  double precision,intent(in) :: dt, tau
+  real(rt)                   ::Ern ( Ern_l1: Ern_h1, Ern_l2: Ern_h2,0:ngroups-1)
+  real(rt)        ,intent(in)::Erl ( Erl_l1: Erl_h1, Erl_l2: Erl_h2,0:ngroups-1)
+  real(rt)        ,intent(in)::kap ( kap_l1: kap_h1, kap_l2: kap_h2,0:ngroups-1)
+  real(rt)        ,intent(in)::etaT(etaT_l1:etaT_h1,etaT_l2:etaT_h2)
+  real(rt)        ,intent(in)::etaY(etaY_l1:etaY_h1,etaY_l2:etaY_h2)
+  real(rt)        ,intent(in)::theT(theT_l1:theT_h1,theT_l2:theT_h2)
+  real(rt)        ,intent(in)::theY(theY_l1:theY_h1,theY_l2:theY_h2)
+  real(rt)        ,intent(in)::mugT(mugT_l1:mugT_h1,mugT_l2:mugT_h2,0:ngroups-1)
+  real(rt)        ,intent(in)::mugY(mugY_l1:mugY_h1,mugY_l2:mugY_h2,0:ngroups-1)
+  real(rt)        ,intent(in) :: dt, tau
 
   integer :: i, j
-  double precision :: cdt1, rt, ry, p, q, r, s 
-  double precision,dimension(0:ngroups-1)::Hg, Tg, epsilon, kapt, kk
+  real(rt)         :: cdt1, rt, ry, p, q, r, s 
+  real(rt)        ,dimension(0:ngroups-1)::Hg, Tg, epsilon, kapt, kk
 
-  cdt1 = 1.d0/(clight*dt)
+  cdt1 = 1.e0_rt/(clight*dt)
 
   do j = lo(2), hi(2)
   do i = lo(1), hi(1)
@@ -747,16 +757,16 @@ subroutine ca_local_accel_neut( lo, hi,  &
      Hg = mugT(i,j,:)*etaT(i,j) - mugY(i,j,:)*etaY(i,j)
      Tg = -mugT(i,j,:)*theT(i,j) + mugY(i,j,:)*theY(i,j)
 
-     kapt = kap(i,j,:) + (1.d0+tau)*cdt1
+     kapt = kap(i,j,:) + (1.e0_rt+tau)*cdt1
      kk = kap(i,j,:) / kapt
 
-     p = 1.d0-sum(Hg*kk)
-     q = 1.d0-sum(Tg*erg2rhoYe*kk)
+     p = 1.e0_rt-sum(Hg*kk)
+     q = 1.e0_rt-sum(Tg*erg2rhoYe*kk)
      r = sum(Hg*erg2rhoYe*kk)
      s = sum(Tg*kk)
 
      epsilon = ((r*Tg + q*Hg) * rt + (s*Hg + p*Tg) * ry)  &
-          / (kapt*(p*q-r*s) + 1.d-50)
+          / (kapt*(p*q-r*s) + 1.e-50_rt)
 
      Ern(i,j,:) = Ern(i,j,:) + epsilon
   end do
@@ -784,6 +794,7 @@ subroutine ca_opac_emis_neut( lo, hi,  &
   use opacity_table_module, only : prep_opacity, get_opacity_emissivity
   use meth_params_module, only : NVAR, URHO
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: lo(2), hi(2)
@@ -799,28 +810,28 @@ subroutine ca_opac_emis_neut( lo, hi,  &
   integer, intent(in) :: djdY_l1, djdY_h1, djdY_l2, djdY_h2
   integer, intent(in) :: dkdT_l1, dkdT_h1, dkdT_l2, dkdT_h2
   integer, intent(in) :: dkdY_l1, dkdY_h1, dkdY_l2, dkdY_h2
-  double precision, intent(in) :: Snew(Snew_l1:Snew_h1,Snew_l2:Snew_h2,NVAR)
-  double precision, intent(in) :: T   (   T_l1:   T_h1,   T_l2:   T_h2)
-  double precision, intent(in) :: Ye  (  Ye_l1:  Ye_h1,  Ye_l2:  Ye_h2)
-  double precision, intent(in) :: Ts  (  Ts_l1:  Ts_h1,  Ts_l2:  Ts_h2)
-  double precision, intent(in) :: Yes ( Yes_l1: Yes_h1, Yes_l2: Yes_h2)
-  double precision             :: kpp ( kpp_l1: kpp_h1, kpp_l2: kpp_h2,0:ngroups-1)
-  double precision             :: kpr ( kpr_l1: kpr_h1, kpr_l2: kpr_h2,0:ngroups-1)
-  double precision             :: jg  (   j_l1:   j_h1,   j_l2:   j_h2,0:ngroups-1)
-  double precision             :: djdT(djdT_l1:djdT_h1,djdT_l2:djdT_h2,0:ngroups-1)
-  double precision             :: djdY(djdY_l1:djdY_h1,djdY_l2:djdY_h2,0:ngroups-1)
-  double precision             :: dkdT(dkdT_l1:dkdT_h1,dkdT_l2:dkdT_h2,0:ngroups-1)
-  double precision             :: dkdY(dkdY_l1:dkdY_h1,dkdY_l2:dkdY_h2,0:ngroups-1)
+  real(rt)        , intent(in) :: Snew(Snew_l1:Snew_h1,Snew_l2:Snew_h2,NVAR)
+  real(rt)        , intent(in) :: T   (   T_l1:   T_h1,   T_l2:   T_h2)
+  real(rt)        , intent(in) :: Ye  (  Ye_l1:  Ye_h1,  Ye_l2:  Ye_h2)
+  real(rt)        , intent(in) :: Ts  (  Ts_l1:  Ts_h1,  Ts_l2:  Ts_h2)
+  real(rt)        , intent(in) :: Yes ( Yes_l1: Yes_h1, Yes_l2: Yes_h2)
+  real(rt)                     :: kpp ( kpp_l1: kpp_h1, kpp_l2: kpp_h2,0:ngroups-1)
+  real(rt)                     :: kpr ( kpr_l1: kpr_h1, kpr_l2: kpr_h2,0:ngroups-1)
+  real(rt)                     :: jg  (   j_l1:   j_h1,   j_l2:   j_h2,0:ngroups-1)
+  real(rt)                     :: djdT(djdT_l1:djdT_h1,djdT_l2:djdT_h2,0:ngroups-1)
+  real(rt)                     :: djdY(djdY_l1:djdY_h1,djdY_l2:djdY_h2,0:ngroups-1)
+  real(rt)                     :: dkdT(dkdT_l1:dkdT_h1,dkdT_l2:dkdT_h2,0:ngroups-1)
+  real(rt)                     :: dkdY(dkdY_l1:dkdY_h1,dkdY_l2:dkdY_h2,0:ngroups-1)
   integer, intent(in) :: use_dkdT, validStar, lag_opac
 
   integer :: i, j, g, inu
-  double precision :: ab, sc, delta, eta, er, der, rho, temp
-  double precision :: ab1, sc1, delta1, eta1
-  double precision :: ab2, sc2, delta2, eta2 
-  double precision :: dT, dYe
-  double precision :: Bg, Bg1, Bg2
+  real(rt)         :: ab, sc, delta, eta, er, der, rho, temp
+  real(rt)         :: ab1, sc1, delta1, eta1
+  real(rt)         :: ab2, sc2, delta2, eta2 
+  real(rt)         :: dT, dYe
+  real(rt)         :: Bg, Bg1, Bg2
   logical :: comp_ab, comp_sc, comp_eta
-  double precision, parameter :: fac = 0.5d0, minfrac = 1.d-8
+  real(rt)        , parameter :: fac = 0.5e0_rt, minfrac = 1.e-8_rt
 
   do j=lo(2), hi(2)
   do i=lo(1), hi(1)
@@ -834,8 +845,8 @@ subroutine ca_opac_emis_neut( lo, hi,  &
         dYe = fac*abs(Yes(i,j) - Ye(i,j))
         dYe = max(dYe, minfrac*Ye(i,j))
      else
-        dT = T(i,j) * 1.d-3 + 1.d-50
-        dYe = 1.d-4
+        dT = T(i,j) * 1.e-3_rt + 1.e-50_rt
+        dYe = 1.e-4_rt
      end if
 
      do g=0, ngroups-1
@@ -844,8 +855,8 @@ subroutine ca_opac_emis_neut( lo, hi,  &
 
         if (lag_opac .eq. 1) then
 
-           dkdT(i,j,g) = 0.d0
-           dkdY(i,j,g) = 0.d0              
+           dkdT(i,j,g) = 0.e0_rt
+           dkdY(i,j,g) = 0.e0_rt              
 
            comp_ab = .true.
            comp_sc = .false.
@@ -864,7 +875,7 @@ subroutine ca_opac_emis_neut( lo, hi,  &
                 rho, Ye(i,j)+dye, temp, er, inu, comp_ab, comp_sc, comp_eta)
            Bg2 = eta2 * der / ab2
 
-           djdY(i,j,g) = (Bg2-Bg1)*kpp(i,j,g)/(2.d0*dye)
+           djdY(i,j,g) = (Bg2-Bg1)*kpp(i,j,g)/(2.e0_rt*dye)
 
            call get_opacity_emissivity(ab1, sc1, delta1, eta1, &
                 rho, Ye(i,j), temp-dT, er, inu, comp_ab, comp_sc, comp_eta)
@@ -874,7 +885,7 @@ subroutine ca_opac_emis_neut( lo, hi,  &
                 rho, Ye(i,j), temp+dT, er, inu, comp_ab, comp_sc, comp_eta)
            Bg2 = eta2 * der / ab2
 
-           djdT(i,j,g) = (Bg2-Bg1)*kpp(i,j,g)/(2.d0*dT)
+           djdT(i,j,g) = (Bg2-Bg1)*kpp(i,j,g)/(2.e0_rt*dT)
            
         else
 
@@ -885,7 +896,7 @@ subroutine ca_opac_emis_neut( lo, hi,  &
            call get_opacity_emissivity(ab, sc, delta, eta, &
                 rho, Ye(i,j), temp, er, inu, comp_ab, comp_sc, comp_eta)
            kpp(i,j,g) = ab
-           kpr(i,j,g) = ab + sc * (1.d0 - delta/3.d0)
+           kpr(i,j,g) = ab + sc * (1.e0_rt - delta/3.e0_rt)
            jg(i,j,g) = eta * der 
            
            comp_ab = .true.
@@ -896,22 +907,22 @@ subroutine ca_opac_emis_neut( lo, hi,  &
                 rho, Ye(i,j)-dye, temp, er, inu, comp_ab, comp_sc, comp_eta)
            call get_opacity_emissivity(ab2, sc2, delta2, eta2, &
                 rho, Ye(i,j)+dye, temp, er, inu, comp_ab, comp_sc, comp_eta)
-           djdY(i,j,g) = (eta2-eta1)*der/(2.d0*dye)
-           dkdY(i,j,g) = (ab2-ab1)/(2.d0*dye)
+           djdY(i,j,g) = (eta2-eta1)*der/(2.e0_rt*dye)
+           dkdY(i,j,g) = (ab2-ab1)/(2.e0_rt*dye)
            if (use_dkdT .eq. 0) then
-              djdY(i,j,g) = (eta2/ab2 - eta1/ab1)*der/(2.d0*dye) * ab
-              dkdY(i,j,g) = 0.d0
+              djdY(i,j,g) = (eta2/ab2 - eta1/ab1)*der/(2.e0_rt*dye) * ab
+              dkdY(i,j,g) = 0.e0_rt
            end if
            
            call get_opacity_emissivity(ab1, sc1, delta1, eta1, &
                 rho, Ye(i,j), temp-dT, er, inu, comp_ab, comp_sc, comp_eta)
            call get_opacity_emissivity(ab2, sc2, delta2, eta2, &
                 rho, Ye(i,j), temp+dT, er, inu, comp_ab, comp_sc, comp_eta)
-           djdT(i,j,g) = (eta2-eta1)*der/(2.d0*dT)
-           dkdT(i,j,g) = (ab2-ab1)/(2.d0*dT)
+           djdT(i,j,g) = (eta2-eta1)*der/(2.e0_rt*dT)
+           dkdT(i,j,g) = (ab2-ab1)/(2.e0_rt*dT)
            if (use_dkdT .eq. 0) then        
-              djdT(i,j,g) = (eta2/ab2 - eta1/ab1)*der/(2.d0*dT) * ab
-              dkdT(i,j,g) = 0.d0
+              djdT(i,j,g) = (eta2/ab2 - eta1/ab1)*der/(2.e0_rt*dT) * ab
+              dkdT(i,j,g) = 0.e0_rt
            end if
 
         end if
@@ -933,6 +944,7 @@ subroutine ca_state_update_neut( lo, hi, &
 
   use meth_params_module, only : NVAR, URHO, UEDEN, UEINT, UTEMP, UFX
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: lo(2), hi(2) 
@@ -941,26 +953,26 @@ subroutine ca_state_update_neut( lo, hi, &
   integer, intent(in) ::    Ye_l1,    Ye_h1,    Ye_l2,    Ye_h2
   integer, intent(in) ::  temp_l1,  temp_h1,  temp_l2,  temp_h2
   integer, intent(in) ::   msk_l1,   msk_h1,   msk_l2,   msk_h2
-  double precision, intent(in) :: rhoe( rhoe_l1: rhoe_h1, rhoe_l2: rhoe_h2)
-  double precision, intent(in) ::   Ye(   Ye_l1:   Ye_h1,   Ye_l2:   Ye_h2)
-  double precision, intent(in) :: temp( temp_l1: temp_h1, temp_l2: temp_h2)
-  double precision, intent(in) ::  msk(  msk_l1:  msk_h1,  msk_l2:  msk_h2)
-  double precision             ::state(state_l1:state_h1,state_l2:state_h2,NVAR)
-  double precision, intent(inout) :: derat, dTrat, dye
+  real(rt)        , intent(in) :: rhoe( rhoe_l1: rhoe_h1, rhoe_l2: rhoe_h2)
+  real(rt)        , intent(in) ::   Ye(   Ye_l1:   Ye_h1,   Ye_l2:   Ye_h2)
+  real(rt)        , intent(in) :: temp( temp_l1: temp_h1, temp_l2: temp_h2)
+  real(rt)        , intent(in) ::  msk(  msk_l1:  msk_h1,  msk_l2:  msk_h2)
+  real(rt)                     ::state(state_l1:state_h1,state_l2:state_h2,NVAR)
+  real(rt)        , intent(inout) :: derat, dTrat, dye
 
   integer :: i, j
-  double precision :: ei, ek, Told, Yeold
+  real(rt)         :: ei, ek, Told, Yeold
 
   do j=lo(2), hi(2)
   do i=lo(1), hi(1)
      ei = state(i,j,UEINT)
-     derat = max(derat, abs((rhoe(i,j) - ei)*msk(i,j)/ max(ei, 1.d-50)))
+     derat = max(derat, abs((rhoe(i,j) - ei)*msk(i,j)/ max(ei, 1.e-50_rt)))
      ek = state(i,j,UEDEN) - state(i,j,UEINT)
      state(i,j,UEINT) = rhoe(i,j)
      state(i,j,UEDEN) = rhoe(i,j) + ek
 
      Told = state(i,j,UTEMP);
-     dTrat = max(dTrat, abs((temp(i,j)-Told)*msk(i,j)/ max(Told, 1.d-50)))
+     dTrat = max(dTrat, abs((temp(i,j)-Told)*msk(i,j)/ max(Told, 1.e-50_rt)))
      state(i,j,UTEMP) = temp(i,j)
 
      Yeold = state(i,j,UFX) / state(i,j,URHO)
@@ -999,6 +1011,7 @@ subroutine ca_update_matter_neut( lo, hi,  &
   use rad_params_module, only : ngroups, erg2rhoYe, clight
   use meth_params_module, only : NVAR, URHO
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer,intent(in)::lo(2),hi(2)
@@ -1023,32 +1036,32 @@ subroutine ca_update_matter_neut( lo, hi,  &
   integer,intent(in)::mugT_l1, mugT_h1, mugT_l2, mugT_h2
   integer,intent(in)::mugY_l1, mugY_h1, mugY_l2, mugY_h2
   integer,intent(in)::Snew_l1, Snew_h1, Snew_l2, Snew_h2
-  double precision           ::re_n(re_n_l1:re_n_h1,re_n_l2:re_n_h2)
-  double precision           ::rY_n(rY_n_l1:rY_n_h1,rY_n_l2:rY_n_h2)
-  double precision           ::Ye_n(Ye_n_l1:Ye_n_h1,Ye_n_l2:Ye_n_h2)
-  double precision,intent(in)::Er_n(Er_n_l1:Er_n_h1,Er_n_l2:Er_n_h2,0:ngroups-1)
-  double precision,intent(in)::Er_l(Er_l_l1:Er_l_h1,Er_l_l2:Er_l_h2,0:ngroups-1)
-  double precision,intent(in)::re_s(re_s_l1:re_s_h1,re_s_l2:re_s_h2)
-  double precision,intent(in)::rY_s(rY_s_l1:rY_s_h1,rY_s_l2:rY_s_h2)
-  double precision,intent(in)::re_2(re_2_l1:re_2_h1,re_2_l2:re_2_h2)
-  double precision,intent(in)::rY_2(rY_2_l1:rY_2_h1,rY_2_l2:rY_2_h2)
-  double precision,intent(in)::etaT(etaT_l1:etaT_h1,etaT_l2:etaT_h2)
-  double precision,intent(in)::etaY(etaY_l1:etaY_h1,etaY_l2:etaY_h2)
-  double precision,intent(in)::eta1(eta1_l1:eta1_h1,eta1_l2:eta1_h2)
-  double precision,intent(in)::theT(theT_l1:theT_h1,theT_l2:theT_h2)
-  double precision,intent(in)::theY(theY_l1:theY_h1,theY_l2:theY_h2)
-  double precision,intent(in)::the1(the1_l1:the1_h1,the1_l2:the1_h2)
-  double precision,intent(in):: cpt( cpt_l1: cpt_h1, cpt_l2: cpt_h2)
-  double precision,intent(in):: cpy( cpy_l1: cpy_h1, cpy_l2: cpy_h2)
-  double precision,intent(in):: kpp( kpp_l1: kpp_h1, kpp_l2: kpp_h2,0:ngroups-1)
-  double precision,intent(in)::mugT(mugT_l1:mugT_h1,mugT_l2:mugT_h2,0:ngroups-1)
-  double precision,intent(in)::mugY(mugY_l1:mugY_h1,mugY_l2:mugY_h2,0:ngroups-1)
-  double precision,intent(in)::Snew(Snew_l1:Snew_h1,Snew_l2:Snew_h2,NVAR)
-  double precision,intent(in) :: dt, tau
+  real(rt)                   ::re_n(re_n_l1:re_n_h1,re_n_l2:re_n_h2)
+  real(rt)                   ::rY_n(rY_n_l1:rY_n_h1,rY_n_l2:rY_n_h2)
+  real(rt)                   ::Ye_n(Ye_n_l1:Ye_n_h1,Ye_n_l2:Ye_n_h2)
+  real(rt)        ,intent(in)::Er_n(Er_n_l1:Er_n_h1,Er_n_l2:Er_n_h2,0:ngroups-1)
+  real(rt)        ,intent(in)::Er_l(Er_l_l1:Er_l_h1,Er_l_l2:Er_l_h2,0:ngroups-1)
+  real(rt)        ,intent(in)::re_s(re_s_l1:re_s_h1,re_s_l2:re_s_h2)
+  real(rt)        ,intent(in)::rY_s(rY_s_l1:rY_s_h1,rY_s_l2:rY_s_h2)
+  real(rt)        ,intent(in)::re_2(re_2_l1:re_2_h1,re_2_l2:re_2_h2)
+  real(rt)        ,intent(in)::rY_2(rY_2_l1:rY_2_h1,rY_2_l2:rY_2_h2)
+  real(rt)        ,intent(in)::etaT(etaT_l1:etaT_h1,etaT_l2:etaT_h2)
+  real(rt)        ,intent(in)::etaY(etaY_l1:etaY_h1,etaY_l2:etaY_h2)
+  real(rt)        ,intent(in)::eta1(eta1_l1:eta1_h1,eta1_l2:eta1_h2)
+  real(rt)        ,intent(in)::theT(theT_l1:theT_h1,theT_l2:theT_h2)
+  real(rt)        ,intent(in)::theY(theY_l1:theY_h1,theY_l2:theY_h2)
+  real(rt)        ,intent(in)::the1(the1_l1:the1_h1,the1_l2:the1_h2)
+  real(rt)        ,intent(in):: cpt( cpt_l1: cpt_h1, cpt_l2: cpt_h2)
+  real(rt)        ,intent(in):: cpy( cpy_l1: cpy_h1, cpy_l2: cpy_h2)
+  real(rt)        ,intent(in):: kpp( kpp_l1: kpp_h1, kpp_l2: kpp_h2,0:ngroups-1)
+  real(rt)        ,intent(in)::mugT(mugT_l1:mugT_h1,mugT_l2:mugT_h2,0:ngroups-1)
+  real(rt)        ,intent(in)::mugY(mugY_l1:mugY_h1,mugY_l2:mugY_h2,0:ngroups-1)
+  real(rt)        ,intent(in)::Snew(Snew_l1:Snew_h1,Snew_l2:Snew_h2,NVAR)
+  real(rt)        ,intent(in) :: dt, tau
 
   integer :: i,j,g
-  double precision :: cdt, H1, Theta, Thbar1, Hbar 
-  double precision :: dkEE, dkEEY, foo, chg, chgY
+  real(rt)         :: cdt, H1, Theta, Thbar1, Hbar 
+  real(rt)         :: dkEE, dkEEY, foo, chg, chgY
 
   cdt = clight * dt
   do j = lo(2), hi(2)
@@ -1060,8 +1073,8 @@ subroutine ca_update_matter_neut( lo, hi,  &
      Theta = theY(i,j) - theT(i,j)
      Hbar = sum(erg2rhoYe*(mugT(i,j,:)*etaT(i,j) - mugY(i,j,:)*etaY(i,j)))
 
-     dkEE = 0.d0
-     dkEEY = 0.d0
+     dkEE = 0.e0_rt
+     dkEEY = 0.e0_rt
      do g=0, ngroups-1
         foo = kpp(i,j,g)*(Er_n(i,j,g)-Er_l(i,j,g))
         dkEE = dkEE + foo
@@ -1077,8 +1090,8 @@ subroutine ca_update_matter_neut( lo, hi,  &
      re_n(i,j) = re_s(i,j) + chg
      rY_n(i,j) = rY_s(i,j) + chgY
 
-     re_n(i,j) = (re_n(i,j) + tau*re_s(i,j)) / (1.d0+tau)
-     rY_n(i,j) = (rY_n(i,j) + tau*rY_s(i,j)) / (1.d0+tau)
+     re_n(i,j) = (re_n(i,j) + tau*re_s(i,j)) / (1.e0_rt+tau)
+     rY_n(i,j) = (rY_n(i,j) + tau*rY_s(i,j)) / (1.e0_rt+tau)
 
      Ye_n(i,j) = rY_n(i,j) / Snew(i,j,URHO)
 
@@ -1107,6 +1120,7 @@ subroutine ca_ncupdate_matter_neut( lo, hi,  &
 
   use rad_params_module, only : ngroups, erg2rhoYe, clight
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer,intent(in)::lo(2),hi(2)
@@ -1123,32 +1137,32 @@ subroutine ca_ncupdate_matter_neut( lo, hi,  &
   integer,intent(in)::thYz_l1, thYz_h1, thYz_l2, thYz_h2
   integer,intent(in):: kpp_l1,  kpp_h1,  kpp_l2,  kpp_h2
   integer,intent(in)::  jg_l1,   jg_h1,   jg_l2,   jg_h2
-  double precision           ::Tp_n(Tp_n_l1:Tp_n_h1,Tp_n_l2:Tp_n_h2)
-  double precision           ::Ye_n(Ye_n_l1:Ye_n_h1,Ye_n_l2:Ye_n_h2)
-  double precision,intent(in)::Er_n(Er_n_l1:Er_n_h1,Er_n_l2:Er_n_h2,0:ngroups-1)
-  double precision,intent(in)::re_s(re_s_l1:re_s_h1,re_s_l2:re_s_h2)
-  double precision,intent(in)::rY_s(rY_s_l1:rY_s_h1,rY_s_l2:rY_s_h2)
-  double precision,intent(in)::re_2(re_2_l1:re_2_h1,re_2_l2:re_2_h2)
-  double precision,intent(in)::rY_2(rY_2_l1:rY_2_h1,rY_2_l2:rY_2_h2)
-  double precision,intent(in)::etTz(etTz_l1:etTz_h1,etTz_l2:etTz_h2)
-  double precision,intent(in)::etYz(etYz_l1:etYz_h1,etYz_l2:etYz_h2)
-  double precision,intent(in)::thTz(thTz_l1:thTz_h1,thTz_l2:thTz_h2)
-  double precision,intent(in)::thYz(thYz_l1:thYz_h1,thYz_l2:thYz_h2)
-  double precision,intent(in):: kpp( kpp_l1: kpp_h1, kpp_l2: kpp_h2,0:ngroups-1)
-  double precision,intent(in)::  jg(  jg_l1:  jg_h1,  jg_l2:  jg_h2,0:ngroups-1)
-  double precision,intent(in) :: dt
+  real(rt)                   ::Tp_n(Tp_n_l1:Tp_n_h1,Tp_n_l2:Tp_n_h2)
+  real(rt)                   ::Ye_n(Ye_n_l1:Ye_n_h1,Ye_n_l2:Ye_n_h2)
+  real(rt)        ,intent(in)::Er_n(Er_n_l1:Er_n_h1,Er_n_l2:Er_n_h2,0:ngroups-1)
+  real(rt)        ,intent(in)::re_s(re_s_l1:re_s_h1,re_s_l2:re_s_h2)
+  real(rt)        ,intent(in)::rY_s(rY_s_l1:rY_s_h1,rY_s_l2:rY_s_h2)
+  real(rt)        ,intent(in)::re_2(re_2_l1:re_2_h1,re_2_l2:re_2_h2)
+  real(rt)        ,intent(in)::rY_2(rY_2_l1:rY_2_h1,rY_2_l2:rY_2_h2)
+  real(rt)        ,intent(in)::etTz(etTz_l1:etTz_h1,etTz_l2:etTz_h2)
+  real(rt)        ,intent(in)::etYz(etYz_l1:etYz_h1,etYz_l2:etYz_h2)
+  real(rt)        ,intent(in)::thTz(thTz_l1:thTz_h1,thTz_l2:thTz_h2)
+  real(rt)        ,intent(in)::thYz(thYz_l1:thYz_h1,thYz_l2:thYz_h2)
+  real(rt)        ,intent(in):: kpp( kpp_l1: kpp_h1, kpp_l2: kpp_h2,0:ngroups-1)
+  real(rt)        ,intent(in)::  jg(  jg_l1:  jg_h1,  jg_l2:  jg_h2,0:ngroups-1)
+  real(rt)        ,intent(in) :: dt
 
    integer :: i,j,g
-   double precision :: cdt1, cpT, cpY, foo, scrch_re, scrch_rY
-   double precision :: dTemp, dYe
-   double precision, parameter :: fac = 0.01d0
+   real(rt)         :: cdt1, cpT, cpY, foo, scrch_re, scrch_rY
+   real(rt)         :: dTemp, dYe
+   real(rt)        , parameter :: fac = 0.01e0_rt
 
-   cdt1 = 1.d0 / (clight * dt)
+   cdt1 = 1.e0_rt / (clight * dt)
    do j = lo(2), hi(2)
    do i = lo(1), hi(1)
 
-      cpT = 0.d0
-      cpY = 0.d0
+      cpT = 0.e0_rt
+      cpY = 0.e0_rt
       do g = 0, ngroups-1
          foo = kpp(i,j,g)*Er_n(i,j,g) - jg(i,j,g)
          cpT = cpT + foo
@@ -1161,11 +1175,11 @@ subroutine ca_ncupdate_matter_neut( lo, hi,  &
       dTemp = etTz(i,j)*scrch_re - thTz(i,j)*scrch_rY
       dYe   = -etYz(i,j)*scrch_re + thYz(i,j)*scrch_rY
 
-      if (abs(dTemp/(Tp_n(i,j)+1.d-50)) > fac) then
+      if (abs(dTemp/(Tp_n(i,j)+1.e-50_rt)) > fac) then
          dTemp = sign(fac*Tp_n(i,j), dTemp)
       end if
 
-      if (abs(dYe/(Ye_n(i,j)+1.d-50)) > fac) then
+      if (abs(dYe/(Ye_n(i,j)+1.e-50_rt)) > fac) then
          dYe = sign(fac*Ye_n(i,j), dYe)
       end if
 
@@ -1186,16 +1200,17 @@ subroutine ca_compute_rosseland_neut( lo, hi,  &
   use opacity_table_module, only : prep_opacity, get_opacity_emissivity
   use meth_params_module, only : NVAR, URHO, UTEMP, UFX
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: lo(2), hi(2)
   integer, intent(in) ::  kpr_l1,  kpr_h1,  kpr_l2,  kpr_h2
   integer, intent(in) :: stat_l1, stat_h1, stat_l2, stat_h2 
-  double precision             :: kpr ( kpr_l1: kpr_h1, kpr_l2: kpr_h2,0:ngroups-1)
-  double precision, intent(in) :: stat(stat_l1:stat_h1,stat_l2:stat_h2,NVAR)
+  real(rt)                     :: kpr ( kpr_l1: kpr_h1, kpr_l2: kpr_h2,0:ngroups-1)
+  real(rt)        , intent(in) :: stat(stat_l1:stat_h1,stat_l2:stat_h2,NVAR)
 
   integer :: i, j, g, inu
-  double precision :: ab, sc, delta, eta, er, der, rho, temp, Ye
+  real(rt)         :: ab, sc, delta, eta, er, der, rho, temp, Ye
   logical :: comp_ab, comp_sc, comp_eta
 
   comp_ab = .true.
@@ -1216,7 +1231,7 @@ subroutine ca_compute_rosseland_neut( lo, hi,  &
         call get_opacity_emissivity(ab, sc, delta, eta, &
              rho, Ye, temp, er, inu, comp_ab, comp_sc, comp_eta)
 
-        kpr(i,j,g) = ab + sc * (1.d0 - delta/3.d0)
+        kpr(i,j,g) = ab + sc * (1.e0_rt - delta/3.e0_rt)
 
      end do
      end do
@@ -1233,16 +1248,17 @@ subroutine ca_compute_planck_neut( lo, hi,  &
   use opacity_table_module, only : prep_opacity, get_opacity_emissivity
   use meth_params_module, only : NVAR, URHO, UTEMP, UFX
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: lo(2), hi(2)
   integer, intent(in) ::  kpp_l1,  kpp_h1,  kpp_l2,  kpp_h2
   integer, intent(in) :: stat_l1, stat_h1, stat_l2, stat_h2 
-  double precision             :: kpp ( kpp_l1: kpp_h1, kpp_l2: kpp_h2,0:ngroups-1)
-  double precision, intent(in) :: stat(stat_l1:stat_h1,stat_l2:stat_h2,NVAR)
+  real(rt)                     :: kpp ( kpp_l1: kpp_h1, kpp_l2: kpp_h2,0:ngroups-1)
+  real(rt)        , intent(in) :: stat(stat_l1:stat_h1,stat_l2:stat_h2,NVAR)
 
   integer :: i, j, g, inu
-  double precision :: ab, sc, delta, eta, er, der, rho, temp, Ye
+  real(rt)         :: ab, sc, delta, eta, er, der, rho, temp, Ye
   logical :: comp_ab, comp_sc, comp_eta
 
   comp_ab = .true.

--- a/Source/Radiation/RadSrc_2d/RAD_2D.F90
+++ b/Source/Radiation/RadSrc_2d/RAD_2D.F90
@@ -9,10 +9,11 @@ module rad_module
 
   use rad_util_module, only : FLDlambda
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
-  double precision, parameter :: tiny = 1.e-50_dp_t
-  double precision, parameter :: BIGKR = 1.e25_dp_t
+  real(rt)        , parameter :: tiny = 1.e-50_rt
+  real(rt)        , parameter :: BIGKR = 1.e25_rt
 
 contains
 
@@ -20,12 +21,13 @@ subroutine multrs(d, &
                   DIMS(dbox), &
                   DIMS(reg), &
                   r, s) bind(C, name="multrs")
+  use bl_fort_module, only : rt => c_real
   implicit none
   integer :: DIMDEC(dbox)
   integer :: DIMDEC(reg)
-  real*8 :: d(DIMV(dbox))
-  real*8 :: r(reg_l1:reg_h1)
-  real*8 :: s(reg_l2:reg_h2)
+  real(rt)         :: d(DIMV(dbox))
+  real(rt)         :: r(reg_l1:reg_h1)
+  real(rt)         :: s(reg_l2:reg_h2)
   integer :: i, j
   do j = reg_l2, reg_h2
      do i = reg_l1, reg_h1
@@ -37,16 +39,17 @@ end subroutine multrs
 subroutine sphc(r, s, &
                 DIMS(reg), dx) bind(C, name="sphc")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(reg)
-  real*8 :: r(reg_l1:reg_h1)
-  real*8 :: s(reg_l2:reg_h2)
-  real*8 :: dx(2)
-  real*8 :: h1, h2, d1, d2
+  real(rt)         :: r(reg_l1:reg_h1)
+  real(rt)         :: s(reg_l2:reg_h2)
+  real(rt)         :: dx(2)
+  real(rt)         :: h1, h2, d1, d2
   integer :: i, j
-  h1 = 0.5d0 * dx(1)
-  h2 = 0.5d0 * dx(2)
-  d1 = 1.d0 / (3.d0 * dx(1))
-  d2 = 1.d0 / dx(2)
+  h1 = 0.5e0_rt * dx(1)
+  h2 = 0.5e0_rt * dx(2)
+  d1 = 1.e0_rt / (3.e0_rt * dx(1))
+  d2 = 1.e0_rt / dx(2)
   do i = reg_l1, reg_h1
      r(i) = d1 * ((r(i) + h1)**3 - (r(i) - h1)**3)
   enddo
@@ -58,25 +61,26 @@ end subroutine sphc
 subroutine sphe(r, s, n, &
                 DIMS(reg), dx) bind(C, name="sphe")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(reg)
-  real*8 :: r(reg_l1:reg_h1)
-  real*8 :: s(reg_l2:reg_h2)
+  real(rt)         :: r(reg_l1:reg_h1)
+  real(rt)         :: s(reg_l2:reg_h2)
   integer :: n
-  real*8 :: dx(2)
-  real*8 :: h1, h2, d1, d2
+  real(rt)         :: dx(2)
+  real(rt)         :: h1, h2, d1, d2
   integer :: i, j
   if (n == 0) then
      do i = reg_l1, reg_h1
         r(i) = r(i)**2
      enddo
-     h2 = 0.5d0 * dx(2)
-     d2 = 1.d0 / dx(2)
+     h2 = 0.5e0_rt * dx(2)
+     d2 = 1.e0_rt / dx(2)
      do j = reg_l2, reg_h2
         s(j) = d2 * (cos(s(j) - h2) - cos(s(j) + h2))
      enddo
   else
-     h1 = 0.5d0 * dx(1)
-     d1 = 1.d0 / (3.d0 * dx(1))
+     h1 = 0.5e0_rt * dx(1)
+     d1 = 1.e0_rt / (3.e0_rt * dx(1))
      do i = reg_l1, reg_h1
         r(i) = d1 * ((r(i) + h1)**3 - (r(i) - h1)**3)
      enddo
@@ -91,23 +95,24 @@ subroutine lacoef(a, &
                   DIMS(reg), &
                   fkp, eta, etainv, r, s, c, dt, theta) bind(C, name="lacoef")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(abox)
   integer :: DIMDEC(reg)
-  real*8 :: a(DIMV(abox))
-  real*8 :: fkp(DIMV(abox))
-  real*8 :: eta(DIMV(abox))
-  real*8 :: etainv(DIMV(abox))
-  real*8 :: r(reg_l1:reg_h1)
-  real*8 :: s(reg_l2:reg_h2)
-  real*8 :: c, dt, theta
+  real(rt)         :: a(DIMV(abox))
+  real(rt)         :: fkp(DIMV(abox))
+  real(rt)         :: eta(DIMV(abox))
+  real(rt)         :: etainv(DIMV(abox))
+  real(rt)         :: r(reg_l1:reg_h1)
+  real(rt)         :: s(reg_l2:reg_h2)
+  real(rt)         :: c, dt, theta
   integer :: i, j
-  real*8 :: dtm
-  dtm = 1.d0 / dt
+  real(rt)         :: dtm
+  dtm = 1.e0_rt / dt
   do j = reg_l2, reg_h2
      do i = reg_l1, reg_h1
         a(i,j) = r(i) * s(j) * &
              (fkp(i,j) * etainv(i,j) * c + dtm) / &
-             (1.d0 - (1.d0 - theta) * eta(i,j))
+             (1.e0_rt - (1.e0_rt - theta) * eta(i,j))
      enddo
   enddo
 end subroutine lacoef
@@ -118,19 +123,20 @@ subroutine bclim(b, &
                  n, kappar, DIMS(kbox), &
                  r, s, c, dx) bind(C, name="bclim")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(bbox)
   integer :: DIMDEC(reg)
   integer :: DIMDEC(kbox)
   integer :: n
-  real*8 :: b(DIMV(bbox))
-  real*8 :: lambda(DIMV(bbox))
-  real*8 :: kappar(DIMV(kbox))
-  real*8 :: r(reg_l1:reg_h1+1)
-  real*8 :: s(reg_l2:reg_h2+1)
-  real*8 :: c, dx(2)
-  real*8 :: kavg
+  real(rt)         :: b(DIMV(bbox))
+  real(rt)         :: lambda(DIMV(bbox))
+  real(rt)         :: kappar(DIMV(kbox))
+  real(rt)         :: r(reg_l1:reg_h1+1)
+  real(rt)         :: s(reg_l2:reg_h2+1)
+  real(rt)         :: c, dx(2)
+  real(rt)         :: kavg
   integer :: i, j
-  real*8 :: kap
+  real(rt)         :: kap
   if (n == 0) then
      do j = reg_l2, reg_h2
         do i = reg_l1, reg_h1 + 1
@@ -152,10 +158,11 @@ subroutine flxlim(lambda, &
                   DIMS(rbox), &
                   DIMS(reg), limiter) bind(C, name="flxlim")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(rbox)
   integer :: DIMDEC(reg)
   integer :: limiter
-  real*8 :: lambda(DIMV(rbox))
+  real(rt)         :: lambda(DIMV(rbox))
   integer :: i, j
   do j = reg_l2, reg_h2
      do i = reg_l1, reg_h1
@@ -168,12 +175,13 @@ subroutine eddfac(efact, &
                   DIMS(rbox), &
                   DIMS(reg), limiter, n) bind(C, name="eddfac")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(rbox)
   integer :: DIMDEC(reg)
   integer :: n, limiter
-  real*8 :: efact(DIMV(rbox))
+  real(rt)         :: efact(DIMV(rbox))
   integer :: i, j
-  real*8 :: r, lambda
+  real(rt)         :: r, lambda
   if (n == 0) then
      do j = reg_l2, reg_h2
         do i = reg_l1, reg_h1 + 1
@@ -199,17 +207,18 @@ subroutine scgrd1(r, &
                   n, kappar, DIMS(kbox), &
                   er, dx) bind(C, name="scgrd1")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(rbox)
   integer :: DIMDEC(reg)
   integer :: DIMDEC(kbox)
   integer :: n
-  real*8 :: r(DIMV(rbox))
-  real*8 :: kappar(DIMV(kbox))
-  real*8 :: er(DIMV(kbox))
-  real*8 :: dx(2)
-  real*8 :: kavg
+  real(rt)         :: r(DIMV(rbox))
+  real(rt)         :: kappar(DIMV(kbox))
+  real(rt)         :: er(DIMV(kbox))
+  real(rt)         :: dx(2)
+  real(rt)         :: kavg
   integer :: i, j
-  real*8 :: kap
+  real(rt)         :: kap
   if (n == 0) then
      do j = reg_l2, reg_h2
         ! x derivatives, gradient assembly:
@@ -217,11 +226,11 @@ subroutine scgrd1(r, &
            r(i,j) = abs(er(i,j) - er(i-1,j)) / dx(1)
         enddo
         i = reg_l1
-        if (er(i-1,j) == -1.d0) then
+        if (er(i-1,j) == -1.e0_rt) then
            r(i,j) = abs(er(i+1,j) - er(i,j)) / dx(1)
         endif
         i = reg_h1 + 1
-        if (er(i,j) == -1.d0) then
+        if (er(i,j) == -1.e0_rt) then
            r(i,j) = abs(er(i-1,j) - er(i-2,j)) / dx(1)
         endif
         ! construct coefficients:
@@ -240,11 +249,11 @@ subroutine scgrd1(r, &
      enddo
      do i = reg_l1, reg_h1
         j = reg_l2
-        if (er(i,j-1) == -1.d0) then
+        if (er(i,j-1) == -1.e0_rt) then
            r(i,j) = abs(er(i,j+1) - er(i,j)) / dx(2)
         endif
         j = reg_h2 + 1
-        if (er(i,j) == -1.d0) then
+        if (er(i,j) == -1.e0_rt) then
            r(i,j) = abs(er(i,j-1) - er(i,j-2)) / dx(2)
         endif
      enddo
@@ -265,19 +274,20 @@ subroutine scgrd2(r, &
                   n, kappar, DIMS(kbox), er, &
                   DIMS(dbox), d, dx) bind(C, name="scgrd2")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(rbox)
   integer :: DIMDEC(reg)
   integer :: DIMDEC(kbox)
   integer :: DIMDEC(dbox)
   integer :: n
-  real*8 :: r(DIMV(rbox))
-  real*8 :: kappar(DIMV(kbox))
-  real*8 :: er(DIMV(kbox))
-  real*8 :: d(DIMV(dbox))
-  real*8 :: dx(2)
-  real*8 :: kavg
+  real(rt)         :: r(DIMV(rbox))
+  real(rt)         :: kappar(DIMV(kbox))
+  real(rt)         :: er(DIMV(kbox))
+  real(rt)         :: d(DIMV(dbox))
+  real(rt)         :: dx(2)
+  real(rt)         :: kavg
   integer :: i, j
-  real*8 :: kap
+  real(rt)         :: kap
   if (n == 0) then
      ! y derivatives:
      do j = reg_l2, reg_h2
@@ -288,46 +298,46 @@ subroutine scgrd2(r, &
      ! check y derivatives at reg_l2 - 1 and reg_h2 + 1:
      do i = reg_l1 - 1, reg_h1 + 1
         j = reg_l2
-        if (er(i,j-1) == -1.d0) then
-           d(i,j) = 2.d0 * (er(i,j+1) - er(i,j))
+        if (er(i,j-1) == -1.e0_rt) then
+           d(i,j) = 2.e0_rt * (er(i,j+1) - er(i,j))
         endif
         j = reg_h2
-        if (er(i,j+1) == -1.d0) then
-           d(i,j) = 2.d0 * (er(i,j) - er(i,j-1))
+        if (er(i,j+1) == -1.e0_rt) then
+           d(i,j) = 2.e0_rt * (er(i,j) - er(i,j-1))
         endif
      enddo
      do j = reg_l2, reg_h2
         ! check y derivatives at reg_l1 - 1 and reg_h1 + 1:
         ! (check at j-1 and j+1.  if value at j is bad it will not be used at all.)
         i = reg_l1 - 1
-        if (er(i,j-1) == -1.d0) then
-           d(i,j) = 2.d0 * (er(i,j+1) - er(i,j))
-        else if (er(i,j+1) == -1.d0) then
-           d(i,j) = 2.d0 * (er(i,j) - er(i,j-1))
+        if (er(i,j-1) == -1.e0_rt) then
+           d(i,j) = 2.e0_rt * (er(i,j+1) - er(i,j))
+        else if (er(i,j+1) == -1.e0_rt) then
+           d(i,j) = 2.e0_rt * (er(i,j) - er(i,j-1))
         endif
         i = reg_h1 + 1
-        if (er(i,j-1) == -1.d0) then
-           d(i,j) = 2.d0 * (er(i,j+1) - er(i,j))
-        else if (er(i,j+1) == -1.d0) then
-           d(i,j) = 2.d0 * (er(i,j) - er(i,j-1))
+        if (er(i,j-1) == -1.e0_rt) then
+           d(i,j) = 2.e0_rt * (er(i,j+1) - er(i,j))
+        else if (er(i,j+1) == -1.e0_rt) then
+           d(i,j) = 2.e0_rt * (er(i,j) - er(i,j-1))
         endif
         ! x derivatives, gradient assembly:
         do i = reg_l1, reg_h1 + 1
            r(i,j) = ((er(i,j) - er(i-1,j)) / dx(1)) ** 2 + &
                 ((d(i-1,j) + d(i,j)) / &
-                (4.d0 * dx(2))) ** 2
+                (4.e0_rt * dx(2))) ** 2
         enddo
         i = reg_l1
-        if (er(i-1,j) == -1.d0) then
+        if (er(i-1,j) == -1.e0_rt) then
            r(i,j) = ((er(i+1,j) - er(i,j)) / dx(1)) ** 2 + &
                 (d(i,j) / &
-                (2.d0 * dx(2))) ** 2
+                (2.e0_rt * dx(2))) ** 2
         endif
         i = reg_h1 + 1
-        if (er(i,j) == -1.d0) then
+        if (er(i,j) == -1.e0_rt) then
            r(i,j) = ((er(i-1,j) - er(i-2,j)) / dx(1)) ** 2 + &
                 (d(i-1,j) / &
-                (2.d0 * dx(2))) ** 2
+                (2.e0_rt * dx(2))) ** 2
         endif
         ! construct scaled gradient:
         do i = reg_l1, reg_h1 + 1
@@ -344,28 +354,28 @@ subroutine scgrd2(r, &
         enddo
         ! check x derivatives at reg_l1 - 1 and reg_h1 + 1:
         i = reg_l1
-        if (er(i-1,j) == -1.d0) then
-           d(i,j) = 2.d0 * (er(i+1,j) - er(i,j))
+        if (er(i-1,j) == -1.e0_rt) then
+           d(i,j) = 2.e0_rt * (er(i+1,j) - er(i,j))
         endif
         i = reg_h1
-        if (er(i+1,j) == -1.d0) then
-           d(i,j) = 2.d0 * (er(i,j) - er(i-1,j))
+        if (er(i+1,j) == -1.e0_rt) then
+           d(i,j) = 2.e0_rt * (er(i,j) - er(i-1,j))
         endif
      enddo
      do i = reg_l1, reg_h1
         ! check x derivatives at reg_l2 - 1 and reg_h2 + 1:
         ! (check at i-1 and i+1.  if value at i is bad it will not be used at all.)
         j = reg_l2 - 1
-        if (er(i-1,j) == -1.d0) then
-           d(i,j) = 2.d0 * (er(i+1,j) - er(i,j))
-        else if (er(i+1,j) == -1.d0) then
-           d(i,j) = 2.d0 * (er(i,j) - er(i-1,j))
+        if (er(i-1,j) == -1.e0_rt) then
+           d(i,j) = 2.e0_rt * (er(i+1,j) - er(i,j))
+        else if (er(i+1,j) == -1.e0_rt) then
+           d(i,j) = 2.e0_rt * (er(i,j) - er(i-1,j))
         endif
         j = reg_h2 + 1
-        if (er(i-1,j) == -1.d0) then
-           d(i,j) = 2.d0 * (er(i+1,j) - er(i,j))
-        else if (er(i+1,j) == -1.d0) then
-           d(i,j) = 2.d0 * (er(i,j) - er(i-1,j))
+        if (er(i-1,j) == -1.e0_rt) then
+           d(i,j) = 2.e0_rt * (er(i+1,j) - er(i,j))
+        else if (er(i+1,j) == -1.e0_rt) then
+           d(i,j) = 2.e0_rt * (er(i,j) - er(i-1,j))
         endif
      enddo
      ! y derivatives, gradient assembly:
@@ -373,21 +383,21 @@ subroutine scgrd2(r, &
         do i = reg_l1, reg_h1
            r(i,j) = ((er(i,j) - er(i,j-1)) / dx(2)) ** 2 + &
                 ((d(i,j-1) + d(i,j)) / &
-                (4.d0 * dx(1))) ** 2
+                (4.e0_rt * dx(1))) ** 2
         enddo
      enddo
      do i = reg_l1, reg_h1
         j = reg_l2
-        if (er(i,j-1) == -1.d0) then
+        if (er(i,j-1) == -1.e0_rt) then
            r(i,j) = ((er(i,j+1) - er(i,j)) / dx(2)) ** 2 + &
                 (d(i,j) / &
-                (2.d0 * dx(1))) ** 2
+                (2.e0_rt * dx(1))) ** 2
         endif
         j = reg_h2 + 1
-        if (er(i,j) == -1.d0) then
+        if (er(i,j) == -1.e0_rt) then
            r(i,j) = ((er(i,j-1) - er(i,j-2)) / dx(2)) ** 2 + &
                 (d(i,j-1) / &
-                (2.d0 * dx(1))) ** 2
+                (2.e0_rt * dx(1))) ** 2
         endif
      enddo
      ! construct coefficients:
@@ -407,19 +417,20 @@ subroutine scgrd3(r, &
                   n, kappar, DIMS(kbox), er, &
                   DIMS(dbox), d, dx) bind(C, name="scgrd3")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(rbox)
   integer :: DIMDEC(reg)
   integer :: DIMDEC(kbox)
   integer :: DIMDEC(dbox)
   integer :: n
-  real*8 :: r(DIMV(rbox))
-  real*8 :: kappar(DIMV(kbox))
-  real*8 :: er(DIMV(kbox))
-  real*8 :: d(DIMV(dbox))
-  real*8 :: dx(2)
-  real*8 :: kavg
+  real(rt)         :: r(DIMV(rbox))
+  real(rt)         :: kappar(DIMV(kbox))
+  real(rt)         :: er(DIMV(kbox))
+  real(rt)         :: d(DIMV(dbox))
+  real(rt)         :: dx(2)
+  real(rt)         :: kavg
   integer :: i, j
-  real*8 :: kap
+  real(rt)         :: kap
   if (n == 0) then
      ! y derivatives:
      do j = reg_l2, reg_h2
@@ -430,46 +441,46 @@ subroutine scgrd3(r, &
      ! check y derivatives at reg_l2 - 1 and reg_h2 + 1:
      do i = reg_l1 - 1, reg_h1 + 1
         j = reg_l2
-        if (er(i,j-1) == -1.d0) then
-           d(i,j) = 2.d0 * (er(i,j+1) - er(i,j))
+        if (er(i,j-1) == -1.e0_rt) then
+           d(i,j) = 2.e0_rt * (er(i,j+1) - er(i,j))
         endif
         j = reg_h2
-        if (er(i,j+1) == -1.d0) then
-           d(i,j) = 2.d0 * (er(i,j) - er(i,j-1))
+        if (er(i,j+1) == -1.e0_rt) then
+           d(i,j) = 2.e0_rt * (er(i,j) - er(i,j-1))
         endif
      enddo
      do j = reg_l2, reg_h2
         ! check y derivatives at reg_l1 - 1 and reg_h1 + 1:
         ! (check at j-1 and j+1.  if value at j is bad it will not be used at all.)
         i = reg_l1 - 1
-        if (er(i,j-1) == -1.d0) then
-           d(i,j) = 2.d0 * (er(i,j+1) - er(i,j))
-        else if (er(i,j+1) == -1.d0) then
-           d(i,j) = 2.d0 * (er(i,j) - er(i,j-1))
+        if (er(i,j-1) == -1.e0_rt) then
+           d(i,j) = 2.e0_rt * (er(i,j+1) - er(i,j))
+        else if (er(i,j+1) == -1.e0_rt) then
+           d(i,j) = 2.e0_rt * (er(i,j) - er(i,j-1))
         endif
         i = reg_h1 + 1
-        if (er(i,j-1) == -1.d0) then
-           d(i,j) = 2.d0 * (er(i,j+1) - er(i,j))
-        else if (er(i,j+1) == -1.d0) then
-           d(i,j) = 2.d0 * (er(i,j) - er(i,j-1))
+        if (er(i,j-1) == -1.e0_rt) then
+           d(i,j) = 2.e0_rt * (er(i,j+1) - er(i,j))
+        else if (er(i,j+1) == -1.e0_rt) then
+           d(i,j) = 2.e0_rt * (er(i,j) - er(i,j-1))
         endif
         ! x derivatives, gradient assembly:
         do i = reg_l1, reg_h1 + 1
            r(i,j) = ((er(i,j) - er(i-1,j)) / dx(1)) ** 2 + &
                 ((d(i-1,j) + d(i,j)) / &
-                (4.d0 * dx(2))) ** 2
+                (4.e0_rt * dx(2))) ** 2
         enddo
         i = reg_l1
-        if (er(i-1,j) == -1.d0) then
+        if (er(i-1,j) == -1.e0_rt) then
            r(i,j) = ((er(i+1,j) - er(i,j)) / dx(1)) ** 2 + &
                 (d(i,j) / &
-                (2.d0 * dx(2))) ** 2
+                (2.e0_rt * dx(2))) ** 2
         endif
         i = reg_h1 + 1
-        if (er(i,j) == -1.d0) then
+        if (er(i,j) == -1.e0_rt) then
            r(i,j) = ((er(i-1,j) - er(i-2,j)) / dx(1)) ** 2 + &
                 (d(i-1,j) / &
-                (2.d0 * dx(2))) ** 2
+                (2.e0_rt * dx(2))) ** 2
         endif
         ! construct scaled gradient:
         do i = reg_l1, reg_h1 + 1
@@ -488,28 +499,28 @@ subroutine scgrd3(r, &
         enddo
         ! check x derivatives at reg_l1 - 1 and reg_h1 + 1:
         i = reg_l1
-        if (er(i-1,j) == -1.d0) then
-           d(i,j) = 2.d0 * (er(i+1,j) - er(i,j))
+        if (er(i-1,j) == -1.e0_rt) then
+           d(i,j) = 2.e0_rt * (er(i+1,j) - er(i,j))
         endif
         i = reg_h1
-        if (er(i+1,j) == -1.d0) then
-           d(i,j) = 2.d0 * (er(i,j) - er(i-1,j))
+        if (er(i+1,j) == -1.e0_rt) then
+           d(i,j) = 2.e0_rt * (er(i,j) - er(i-1,j))
         endif
      enddo
      do i = reg_l1, reg_h1
         ! check x derivatives at reg_l2 - 1 and reg_h2 + 1:
         ! (check at i-1 and i+1.  if value at i is bad it will not be used at all.)
         j = reg_l2 - 1
-        if (er(i-1,j) == -1.d0) then
-           d(i,j) = 2.d0 * (er(i+1,j) - er(i,j))
-        else if (er(i+1,j) == -1.d0) then
-           d(i,j) = 2.d0 * (er(i,j) - er(i-1,j))
+        if (er(i-1,j) == -1.e0_rt) then
+           d(i,j) = 2.e0_rt * (er(i+1,j) - er(i,j))
+        else if (er(i+1,j) == -1.e0_rt) then
+           d(i,j) = 2.e0_rt * (er(i,j) - er(i-1,j))
         endif
         j = reg_h2 + 1
-        if (er(i-1,j) == -1.d0) then
-           d(i,j) = 2.d0 * (er(i+1,j) - er(i,j))
-        else if (er(i+1,j) == -1.d0) then
-           d(i,j) = 2.d0 * (er(i,j) - er(i-1,j))
+        if (er(i-1,j) == -1.e0_rt) then
+           d(i,j) = 2.e0_rt * (er(i+1,j) - er(i,j))
+        else if (er(i+1,j) == -1.e0_rt) then
+           d(i,j) = 2.e0_rt * (er(i,j) - er(i-1,j))
         endif
      enddo
      ! y derivatives, gradient assembly:
@@ -517,21 +528,21 @@ subroutine scgrd3(r, &
         do i = reg_l1, reg_h1
            r(i,j) = ((er(i,j) - er(i,j-1)) / dx(2)) ** 2 + &
                 ((d(i,j-1) + d(i,j)) / &
-                (4.d0 * dx(1))) ** 2
+                (4.e0_rt * dx(1))) ** 2
         enddo
      enddo
      do i = reg_l1, reg_h1
         j = reg_l2
-        if (er(i,j-1) == -1.d0) then
+        if (er(i,j-1) == -1.e0_rt) then
            r(i,j) = ((er(i,j+1) - er(i,j)) / dx(2)) ** 2 + &
                 (d(i,j) / &
-                (2.d0 * dx(1))) ** 2
+                (2.e0_rt * dx(1))) ** 2
         endif
         j = reg_h2 + 1
-        if (er(i,j) == -1.d0) then
+        if (er(i,j) == -1.e0_rt) then
            r(i,j) = ((er(i,j-1) - er(i,j-2)) / dx(2)) ** 2 + &
                 (d(i,j-1) / &
-                (2.d0 * dx(1))) ** 2
+                (2.e0_rt * dx(1))) ** 2
         endif
      enddo
      ! construct coefficients:
@@ -554,37 +565,38 @@ subroutine lrhs(rhs, &
                 ero, DIMS(ebox), edot, &
                 r, s, dt, sigma, c, theta) bind(C, name="lrhs")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(rbox)
   integer :: DIMDEC(ebox)
   integer :: DIMDEC(reg)
-  real*8 :: rhs(DIMV(rbox))
-  real*8 :: temp(DIMV(rbox))
-  real*8 :: fkp(DIMV(rbox))
-  real*8 :: eta(DIMV(rbox))
-  real*8 :: etainv(DIMV(rbox))
-  real*8 :: frhoem(DIMV(rbox))
-  real*8 :: frhoes(DIMV(rbox))
-  real*8 :: dfo(DIMV(rbox))
-  real*8 :: ero(DIMV(ebox))
-  real*8 :: edot(DIMV(rbox))
-  real*8 :: r(reg_l1:reg_h1)
-  real*8 :: s(reg_l2:reg_h2)
-  real*8 :: dt, sigma, c, theta
+  real(rt)         :: rhs(DIMV(rbox))
+  real(rt)         :: temp(DIMV(rbox))
+  real(rt)         :: fkp(DIMV(rbox))
+  real(rt)         :: eta(DIMV(rbox))
+  real(rt)         :: etainv(DIMV(rbox))
+  real(rt)         :: frhoem(DIMV(rbox))
+  real(rt)         :: frhoes(DIMV(rbox))
+  real(rt)         :: dfo(DIMV(rbox))
+  real(rt)         :: ero(DIMV(ebox))
+  real(rt)         :: edot(DIMV(rbox))
+  real(rt)         :: r(reg_l1:reg_h1)
+  real(rt)         :: s(reg_l2:reg_h2)
+  real(rt)         :: dt, sigma, c, theta
   integer :: i, j
-  real*8 :: dtm, ek, bs, es, ekt
-  dtm = 1.d0 / dt
+  real(rt)         :: dtm, ek, bs, es, ekt
+  dtm = 1.e0_rt / dt
   do j = reg_l2, reg_h2
      do i = reg_l1, reg_h1
         ek = fkp(i,j) * eta(i,j)
         bs = etainv(i,j) * &
-             &            4.d0 * sigma * fkp(i,j) * temp(i,j)**4
+             &            4.e0_rt * sigma * fkp(i,j) * temp(i,j)**4
         es = eta(i,j) * (frhoem(i,j) - frhoes(i,j))
-        ekt = (1.d0 - theta) * eta(i,j)
+        ekt = (1.e0_rt - theta) * eta(i,j)
         rhs(i,j) = (rhs(i,j) + r(i) * s(j) * &
              (bs + dtm * (ero(i,j) + es) + &
              ek * c * edot(i,j) - &
              ekt * dfo(i,j))) / &
-             (1.d0 - ekt)
+             (1.e0_rt - ekt)
      enddo
   enddo
 end subroutine lrhs
@@ -593,19 +605,20 @@ subroutine anatw2(test, &
                   DIMS(reg), &
                   temp, p, xf, Tc, dx, xlo, lo) bind(C, name="anatw2")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(reg)
-  real*8 :: test(DIMV(reg), 0:1)
-  real*8 :: temp(DIMV(reg))
-  real*8 :: p, xf, Tc, dx(2), xlo(2)
+  real(rt)         :: test(DIMV(reg), 0:1)
+  real(rt)         :: temp(DIMV(reg))
+  real(rt)         :: p, xf, Tc, dx(2), xlo(2)
   integer :: lo(2)
   integer :: i, j
-  real*8 :: x, y, r2
+  real(rt)         :: x, y, r2
   do j = reg_l2, reg_h2
-     y = xlo(2) + dx(2) * ((j-lo(2)) + 0.5d0)
+     y = xlo(2) + dx(2) * ((j-lo(2)) + 0.5e0_rt)
      do i = reg_l1, reg_h1
-        x  = xlo(1) + dx(1) * ((i-lo(1)) + 0.5d0)
+        x  = xlo(1) + dx(1) * ((i-lo(1)) + 0.5e0_rt)
         r2 = x*x + y*y
-        test(i,j,0) = Tc * max((1.d0-r2/xf**2), 0.d0)**(1.d0/p)
+        test(i,j,0) = Tc * max((1.e0_rt-r2/xf**2), 0.e0_rt)**(1.e0_rt/p)
         test(i,j,1) = temp(i,j) - test(i,j,0)
      enddo
   enddo
@@ -617,16 +630,17 @@ subroutine cfrhoe(DIMS(reg), &
                   state, &
                   DIMS(sb)) bind(C, name="cfrhoe")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(reg)
   integer :: DIMDEC(fb)
   integer :: DIMDEC(sb)
-  real*8 :: frhoe(DIMV(fb))
-  real*8 :: state(DIMV(sb), NVAR)
-  !      real*8 kin
+  real(rt)         :: frhoe(DIMV(fb))
+  real(rt)         :: state(DIMV(sb), NVAR)
+  !      real(rt)         kin
   integer :: i, j
   do j = reg_l2, reg_h2
      do i = reg_l1, reg_h1
-        !            kin = 0.5d0 * (state(i,j,XMOM)   ** 2 +
+        !            kin = 0.5e0_rt * (state(i,j,XMOM)   ** 2 +
         !     @                     state(i,j,XMOM+1) ** 2) /
         !     @                    state(i,j,DEN)
         !            frhoe(i,j) = state(i,j,EDEN) - kin
@@ -642,32 +656,33 @@ subroutine gtemp(DIMS(reg), &
                  const, em, en, &
                  state, DIMS(sb)) bind(C, name="gtemp")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(reg)
   integer :: DIMDEC(tb)
   integer :: DIMDEC(sb)
-  real*8 :: temp(DIMV(tb))
-  real*8 :: const(0:1), em(0:1), en(0:1)
-  real*8 :: state(DIMV(sb),  NVAR)
-  real*8 :: alpha, teff, ex, frhoal
+  real(rt)         :: temp(DIMV(tb))
+  real(rt)         :: const(0:1), em(0:1), en(0:1)
+  real(rt)         :: state(DIMV(sb),  NVAR)
+  real(rt)         :: alpha, teff, ex, frhoal
   integer :: i, j
-  if (en(0) >= 1.d0) then
+  if (en(0) >= 1.e0_rt) then
      print *, "Bad exponent for cv calculation"
      stop
   endif
-  ex = 1.d0 / (1.d0 - en(0))
+  ex = 1.e0_rt / (1.e0_rt - en(0))
   do j = reg_l2, reg_h2
      do i = reg_l1, reg_h1
-        if (em(0) == 0.d0) then
+        if (em(0) == 0.e0_rt) then
            alpha = const(0)
         else
            alpha = const(0) * state(i,j, URHO) ** em(0)
         endif
         frhoal = state(i,j, URHO) * alpha + tiny
-        if (en(0) == 0.d0) then
+        if (en(0) == 0.e0_rt) then
            temp(i,j) = temp(i,j) / frhoal
         else
            teff = max(temp(i,j), tiny)
-           temp(i,j) = ((1.d0 - en(0)) * teff / frhoal) ** ex
+           temp(i,j) = ((1.e0_rt - en(0)) * teff / frhoal) ** ex
         endif
      enddo
   enddo
@@ -681,25 +696,26 @@ subroutine gcv(DIMS(reg), &
      const, em, en, tf, &
      state, DIMS(sbox)) bind(C, name="gcv")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(reg)
   integer :: DIMDEC(cbox)
   integer :: DIMDEC(tbox)
   integer :: DIMDEC(sbox)
-  real*8 :: cv(DIMV(cbox))
-  real*8 :: temp(DIMV(tbox))
-  real*8 :: const(0:1), em(0:1), en(0:1), tf(0:1)
-  real*8 :: state(DIMV(sbox), NVAR)
-  real*8 :: alpha, teff, frhoal
+  real(rt)         :: cv(DIMV(cbox))
+  real(rt)         :: temp(DIMV(tbox))
+  real(rt)         :: const(0:1), em(0:1), en(0:1), tf(0:1)
+  real(rt)         :: state(DIMV(sbox), NVAR)
+  real(rt)         :: alpha, teff, frhoal
   integer :: i, j
   do j = reg_l2, reg_h2
      do i = reg_l1, reg_h1
-        if (em(0) == 0.d0) then
+        if (em(0) == 0.e0_rt) then
            alpha = const(0)
         else
            alpha = const(0) * state(i,j, URHO) ** em(0)
         endif
         frhoal = state(i,j, URHO) * alpha + tiny
-        if (en(0) == 0.d0) then
+        if (en(0) == 0.e0_rt) then
            cv(i,j) = alpha
         else
            teff = max(temp(i,j), tiny)
@@ -718,19 +734,20 @@ subroutine cexch( DIMS(reg), &
      fkp , DIMS(kbox), &
      sigma, c) bind(C, name="cexch")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(reg)
   integer :: DIMDEC(xbox)
   integer :: DIMDEC(ebox)
   integer :: DIMDEC(kbox)
-  real*8 :: exch(DIMV(xbox))
-  real*8 :: er  (DIMV(ebox))
-  real*8 :: fkp (DIMV(kbox))
-  real*8 :: sigma, c
+  real(rt)         :: exch(DIMV(xbox))
+  real(rt)         :: er  (DIMV(ebox))
+  real(rt)         :: fkp (DIMV(kbox))
+  real(rt)         :: sigma, c
   integer :: i, j
   do j = reg_l2, reg_h2
      do i = reg_l1, reg_h1
         exch(i,j) = fkp(i,j) * &
-             (4.d0 * sigma * exch(i,j)**4 &
+             (4.e0_rt * sigma * exch(i,j)**4 &
              - c * er(i,j))
      enddo
   enddo
@@ -745,6 +762,7 @@ subroutine ceta2(DIMS(reg), &
                  er, DIMS(ebox), &
                  dtemp, dtime, sigma, c, underr, lagpla) bind(C, name="ceta2")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(reg)
   integer :: DIMDEC(etab)
   integer :: DIMDEC(sb)
@@ -752,20 +770,20 @@ subroutine ceta2(DIMS(reg), &
   integer :: DIMDEC(cb)
   integer :: DIMDEC(fb)
   integer :: DIMDEC(ebox)
-  real*8 :: eta(DIMV(etab))
-  real*8 :: etainv(DIMV(etab))
-  real*8 :: frho(DIMV(sb))
-  real*8 :: temp(DIMV(tb))
-  real*8 :: cv(DIMV(cb))
-  real*8 :: fkp(DIMV(fb))
-  real*8 :: er(DIMV(ebox))
-  real*8 :: dtemp, dtime, sigma, c, underr
+  real(rt)         :: eta(DIMV(etab))
+  real(rt)         :: etainv(DIMV(etab))
+  real(rt)         :: frho(DIMV(sb))
+  real(rt)         :: temp(DIMV(tb))
+  real(rt)         :: cv(DIMV(cb))
+  real(rt)         :: fkp(DIMV(fb))
+  real(rt)         :: er(DIMV(ebox))
+  real(rt)         :: dtemp, dtime, sigma, c, underr
   integer :: lagpla
-  real*8 :: d, frc, fac0, fac1, fac2
+  real(rt)         :: d, frc, fac0, fac1, fac2
   integer :: i, j
-  fac1 = 16.d0 * sigma * dtime
+  fac1 = 16.e0_rt * sigma * dtime
   if (lagpla == 0) then
-     fac0 = 0.25d0 * fac1 / dtemp
+     fac0 = 0.25e0_rt * fac1 / dtemp
      fac2 = dtime * c / dtemp
   endif
   do j = reg_l2, reg_h2
@@ -782,8 +800,8 @@ subroutine ceta2(DIMS(reg), &
            !     @             fac0 * (eta(i,j) - fkp(i,j)) * temp(i,j) ** 4 -
            !     @             fac2 * (eta(i,j) - fkp(i,j)) * er(i,j)
            ! analytic derivatives for specific test problem:
-           !               d = (1.2d+6 * sigma * temp(i,j) ** 2 +
-           !     @              1.d+5 * c * er(i,j) * (temp(i,j) + tiny) ** (-2)) * dtime
+           !               d = (1.2e+6_rt * sigma * temp(i,j) ** 2 +
+           !     @              1.e+5_rt * c * er(i,j) * (temp(i,j) + tiny) ** (-2)) * dtime
            ! another alternate form (much worse):
            !               d = fac1 * fkp(i,j) * (temp(i,j) + dtemp) ** 3 +
            !     @             fac0 * (eta(i,j) - fkp(i,j)) * (temp(i,j) + dtemp) ** 4 -
@@ -792,8 +810,8 @@ subroutine ceta2(DIMS(reg), &
         frc = frho(i,j) * cv(i,j) + tiny
         eta(i,j) = d / (d + frc)
         etainv(i,j) = underr * frc / (d + frc)
-        eta(i,j) = 1.d0 - etainv(i,j)
-        !            eta(i,j) = 1.d0 - underr * (1.d0 - eta(i,j))
+        eta(i,j) = 1.e0_rt - etainv(i,j)
+        !            eta(i,j) = 1.e0_rt - underr * (1.e0_rt - eta(i,j))
      enddo
   enddo
 end subroutine ceta2
@@ -803,26 +821,27 @@ subroutine ceup(DIMS(reg), relres, absres, &
                 frhoem, eta, etainv, dfo, dfn, exch, &
                 dt, theta) bind(C, name="ceup")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(reg)
   integer :: DIMDEC(grd)
-  real*8 :: frhoes(DIMV(grd))
-  real*8 :: frhoem(DIMV(grd))
-  real*8 :: eta(DIMV(grd))
-  real*8 :: etainv(DIMV(grd))
-  real*8 :: dfo(DIMV(grd))
-  real*8 :: dfn(DIMV(grd))
-  real*8 :: exch(DIMV(grd))
-  real*8 :: dt, theta, relres, absres
-  real*8 :: tmp, chg, tot
+  real(rt)         :: frhoes(DIMV(grd))
+  real(rt)         :: frhoem(DIMV(grd))
+  real(rt)         :: eta(DIMV(grd))
+  real(rt)         :: etainv(DIMV(grd))
+  real(rt)         :: dfo(DIMV(grd))
+  real(rt)         :: dfn(DIMV(grd))
+  real(rt)         :: exch(DIMV(grd))
+  real(rt)         :: dt, theta, relres, absres
+  real(rt)         :: tmp, chg, tot
   integer :: i, j
   do j = reg_l2, reg_h2
      do i = reg_l1, reg_h1
-        chg = 0.d0
-        tot = 0.d0
+        chg = 0.e0_rt
+        tot = 0.e0_rt
         tmp = eta(i,j) * frhoes(i,j) + &
              etainv(i,j) * &
              (frhoem(i,j) - &
-             dt * ((1.d0 - theta) * &
+             dt * ((1.e0_rt - theta) * &
              (dfo(i,j) - dfn(i,j)) + &
              exch(i,j)))
         chg = abs(tmp - frhoes(i,j))
@@ -839,27 +858,28 @@ subroutine ceupdterm( DIMS(reg), relres, absres, &
      frhoem, eta, etainv, dfo, dfn, exch, dterm, &
      dt, theta) bind(C, name="ceupdterm")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(reg)
   integer :: DIMDEC(grd)
-  real*8 :: frhoes(DIMV(grd))
-  real*8 :: frhoem(DIMV(grd))
-  real*8 :: eta(DIMV(grd))
-  real*8 :: etainv(DIMV(grd))
-  real*8 :: dfo(DIMV(grd))
-  real*8 :: dfn(DIMV(grd))
-  real*8 :: exch(DIMV(grd))
-  real*8 :: dterm(DIMV(grd))
-  real*8 :: dt, theta, relres, absres
-  real*8 :: tmp, chg, tot
+  real(rt)         :: frhoes(DIMV(grd))
+  real(rt)         :: frhoem(DIMV(grd))
+  real(rt)         :: eta(DIMV(grd))
+  real(rt)         :: etainv(DIMV(grd))
+  real(rt)         :: dfo(DIMV(grd))
+  real(rt)         :: dfn(DIMV(grd))
+  real(rt)         :: exch(DIMV(grd))
+  real(rt)         :: dterm(DIMV(grd))
+  real(rt)         :: dt, theta, relres, absres
+  real(rt)         :: tmp, chg, tot
   integer :: i, j
   do j = reg_l2, reg_h2
      do i = reg_l1, reg_h1
-        chg = 0.d0
-        tot = 0.d0
+        chg = 0.e0_rt
+        tot = 0.e0_rt
         tmp = eta(i,j) * frhoes(i,j) + &
              etainv(i,j) * &
              (frhoem(i,j) - &
-             dt * ((1.d0 - theta) * &
+             dt * ((1.e0_rt - theta) * &
              (dfo(i,j) - dfn(i,j)) + &
              exch(i,j))) &
              + dt * dterm(i,j)
@@ -881,44 +901,45 @@ subroutine nceup(DIMS(reg), relres, absres, &
                  state, DIMS(sb), &
                  sigma, c, dt, theta) bind(C, name="nceup")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(reg)
   integer :: DIMDEC(grd)
   integer :: DIMDEC(sb)
   integer :: DIMDEC(ebox)
-  real*8 :: frhoes(DIMV(grd))
-  real*8 :: frhoem(DIMV(grd))
-  real*8 :: eta(DIMV(grd))
-  real*8 :: etainv(DIMV(grd))
-  real*8 :: er(DIMV(ebox))
-  real*8 :: dfo(DIMV(grd))
-  real*8 :: dfn(DIMV(grd))
-  real*8 :: temp(DIMV(grd))
-  real*8 :: fkp(DIMV(grd))
-  real*8 :: cv(DIMV(reg))
-  real*8 :: state(DIMV(sb), NVAR)
-  real*8 :: sigma, c, dt, theta, relres, absres
-  real*8 :: tmp, chg, tot, exch, b, db, dbdt, frhocv
+  real(rt)         :: frhoes(DIMV(grd))
+  real(rt)         :: frhoem(DIMV(grd))
+  real(rt)         :: eta(DIMV(grd))
+  real(rt)         :: etainv(DIMV(grd))
+  real(rt)         :: er(DIMV(ebox))
+  real(rt)         :: dfo(DIMV(grd))
+  real(rt)         :: dfn(DIMV(grd))
+  real(rt)         :: temp(DIMV(grd))
+  real(rt)         :: fkp(DIMV(grd))
+  real(rt)         :: cv(DIMV(reg))
+  real(rt)         :: state(DIMV(sb), NVAR)
+  real(rt)         :: sigma, c, dt, theta, relres, absres
+  real(rt)         :: tmp, chg, tot, exch, b, db, dbdt, frhocv
   integer :: i, j
   do j = reg_l2, reg_h2
      do i = reg_l1, reg_h1
-        chg = 0.d0
-        tot = 0.d0
+        chg = 0.e0_rt
+        tot = 0.e0_rt
         frhocv = state(i,j, URHO) * cv(i,j)
-        dbdt = 16.d0 * sigma * temp(i,j)**3
-        b = 4.d0 * sigma * temp(i,j)**4
+        dbdt = 16.e0_rt * sigma * temp(i,j)**3
+        b = 4.e0_rt * sigma * temp(i,j)**4
         exch = fkp(i,j) * (b - c * er(i,j))
         tmp = eta(i,j) * frhoes(i,j) + etainv(i,j) * &
              (frhoem(i,j) - &
-             dt * ((1.d0 - theta) * &
+             dt * ((1.e0_rt - theta) * &
              (dfo(i,j) - dfn(i,j)) + &
              exch))
 #if 1
         if (frhocv > tiny .AND. tmp > frhoes(i,j)) then
            db = (tmp - frhoes(i,j)) * dbdt / frhocv
-           if (b + db <= 0.d0) then
+           if (b + db <= 0.e0_rt) then
               print *, i, j, b, db, b+db
            endif
-           tmp = ((b + db) / (4.d0 * sigma))**0.25d0
+           tmp = ((b + db) / (4.e0_rt * sigma))**0.25e0_rt
            tmp = frhoes(i,j) + frhocv * (tmp - temp(i,j))
         endif
 #endif
@@ -935,16 +956,17 @@ subroutine cetot(DIMS(reg), &
                  state, DIMS(sb), &
                  frhoe, DIMS(fb)) bind(C, name="cetot")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(reg)
   integer :: DIMDEC(sb)
   integer :: DIMDEC(fb)
-  real*8 :: state(DIMV(sb), NVAR)
-  real*8 :: frhoe(DIMV(fb))
-  real*8 :: kin
+  real(rt)         :: state(DIMV(sb), NVAR)
+  real(rt)         :: frhoe(DIMV(fb))
+  real(rt)         :: kin
   integer :: i, j
   do j = reg_l2, reg_h2
      do i = reg_l1, reg_h1
-        !            kin = 0.5d0 * (state(i,j,XMOM)   ** 2 +
+        !            kin = 0.5e0_rt * (state(i,j,XMOM)   ** 2 +
         !     @                     state(i,j,XMOM+1) ** 2) /
         !     @                    state(i,j,DEN)
         kin = state(i,j, UEDEN) - state(i,j, UEINT)
@@ -961,16 +983,17 @@ subroutine fkpn( DIMS(reg), &
      temp, DIMS(tb), &
      state, DIMS(sb)) bind(C, name="fkpn")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(reg)
   integer :: DIMDEC(fb)
   integer :: DIMDEC(tb)
   integer :: DIMDEC(sb)
-  real*8 :: fkp(DIMV(fb))
-  real*8 :: const(0:1), em(0:1), en(0:1), tf(0:1)
-  real*8 :: ep(0:1), nu
-  real*8 :: temp(DIMV(tb))
-  real*8 :: state(DIMV(sb), NVAR)
-  real*8 :: teff
+  real(rt)         :: fkp(DIMV(fb))
+  real(rt)         :: const(0:1), em(0:1), en(0:1), tf(0:1)
+  real(rt)         :: ep(0:1), nu
+  real(rt)         :: temp(DIMV(tb))
+  real(rt)         :: state(DIMV(sb), NVAR)
+  real(rt)         :: teff
   integer :: i, j
   do j = reg_l2, reg_h2
      do i = reg_l1, reg_h1
@@ -992,17 +1015,18 @@ subroutine rosse1(DIMS(reg), &
                   temp, DIMS(tb), &
                   state, DIMS(sb)) bind(C, name="rosse1")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(reg)
   integer :: DIMDEC(kbox)
   integer :: DIMDEC(tb)
   integer :: DIMDEC(sb)
-  real*8 :: kappar(DIMV(kbox))
-  real*8 :: const(0:1), em(0:1), en(0:1), tf(0:1)
-  real*8 :: ep(0:1), nu
-  real*8 :: temp(DIMV(tb))
-  real*8 :: state(DIMV(sb), NVAR)
-  real*8 :: kfloor
-  real*8 :: kf, teff
+  real(rt)         :: kappar(DIMV(kbox))
+  real(rt)         :: const(0:1), em(0:1), en(0:1), tf(0:1)
+  real(rt)         :: ep(0:1), nu
+  real(rt)         :: temp(DIMV(tb))
+  real(rt)         :: state(DIMV(sb), NVAR)
+  real(rt)         :: kfloor
+  real(rt)         :: kf, teff
   integer :: i, j
   do j = reg_l2, reg_h2
      do i = reg_l1, reg_h1
@@ -1028,18 +1052,19 @@ subroutine rosse1s(DIMS(reg), &
                    temp, DIMS(tb), &
                    state, DIMS(sb)) bind(C, name="rosse1s")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(reg)
   integer :: DIMDEC(kbox)
   integer :: DIMDEC(tb)
   integer :: DIMDEC(sb)
-  real*8 :: kappar(DIMV(kbox))
-  real*8 :: const(0:1), em(0:1), en(0:1), tf(0:1)
-  real*8 :: ep(0:1), nu
-  real*8 :: sconst(0:1), sem(0:1), sen(0:1), sep(0:1)
-  real*8 :: temp(DIMV(tb))
-  real*8 :: state(DIMV(sb), NVAR)
-  real*8 :: kfloor
-  real*8 :: kf, teff, sct
+  real(rt)         :: kappar(DIMV(kbox))
+  real(rt)         :: const(0:1), em(0:1), en(0:1), tf(0:1)
+  real(rt)         :: ep(0:1), nu
+  real(rt)         :: sconst(0:1), sem(0:1), sen(0:1), sep(0:1)
+  real(rt)         :: temp(DIMV(tb))
+  real(rt)         :: state(DIMV(sb), NVAR)
+  real(rt)         :: kfloor
+  real(rt)         :: kf, teff, sct
   integer :: i, j
   do j = reg_l2, reg_h2
      do i = reg_l1, reg_h1
@@ -1063,11 +1088,12 @@ subroutine nfloor(dest, &
                   DIMS(reg), &
                   nflr, flr, nvar) bind(C, name="nfloor")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(dbox)
   integer :: DIMDEC(reg)
   integer :: nvar, nflr
-  real*8 :: dest(DIMV(dbox), 0:nvar-1)
-  real*8 :: flr
+  real(rt)         :: dest(DIMV(dbox), 0:nvar-1)
+  real(rt)         :: flr
   integer :: i, j, n
   nflr = 0
   do n = 0, nvar-1
@@ -1094,22 +1120,23 @@ subroutine lacoefmgfld(a, &
                        r, s, &
                        dt, c) bind(C, name="lacoefmgfld")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(abox)
   integer :: DIMDEC(reg)
   integer :: DIMDEC(kbox)
 
-  real*8 :: a(DIMV(abox))
-  real*8 :: kappa(DIMV(kbox))
-  real*8 :: r(reg_l1:reg_h1)
-  real*8 :: s(reg_l2:reg_h2)
-  real*8 :: dt, c
+  real(rt)         :: a(DIMV(abox))
+  real(rt)         :: kappa(DIMV(kbox))
+  real(rt)         :: r(reg_l1:reg_h1)
+  real(rt)         :: s(reg_l2:reg_h2)
+  real(rt)         :: dt, c
 
   integer :: i, j
 
   do j = reg_l2, reg_h2
      do i = reg_l1, reg_h1
 
-        a(i,j) = c*kappa(i,j) + 1.d0/dt
+        a(i,j) = c*kappa(i,j) + 1.e0_rt/dt
         a(i,j) = r(i) * s(j) * a(i,j)
 
      enddo
@@ -1126,10 +1153,11 @@ subroutine rfface(fine, &
                   DIMS(cbox), &
                   idim, irat) bind(C, name="rfface")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(fbox)
   integer :: DIMDEC(cbox)
-  real*8 :: fine(DIMV(fbox))
-  real*8 :: crse(DIMV(cbox))
+  real(rt)         :: fine(DIMV(fbox))
+  real(rt)         :: crse(DIMV(cbox))
   integer :: idim, irat(0:1)
   integer :: i, j
   if (idim == 0) then
@@ -1147,25 +1175,26 @@ end subroutine rfface
 subroutine bextrp(f, fbox_l1, fbox_l2, fbox_h1, fbox_h2, &
                   reg_l1, reg_l2, reg_h1, reg_h2) bind(C, name="bextrp")
 
+  use bl_fort_module, only : rt => c_real
   integer :: fbox_l1, fbox_l2, fbox_h1, fbox_h2
   integer ::  reg_l1,  reg_l2,  reg_h1,  reg_h2
-  real*8 :: f(fbox_l1:fbox_h1,fbox_l2:fbox_h2)
+  real(rt)         :: f(fbox_l1:fbox_h1,fbox_l2:fbox_h2)
   integer :: i, j
 
   !     i direction first:
   do j = reg_l2, reg_h2
      i = reg_l1
-     f(i-1,j) = 2.d0 * f(i,j) - f(i+1,j)
+     f(i-1,j) = 2.e0_rt * f(i,j) - f(i+1,j)
      i = reg_h1
-     f(i+1,j) = 2.d0 * f(i,j) - f(i-1,j)
+     f(i+1,j) = 2.e0_rt * f(i,j) - f(i-1,j)
   enddo
 
   !     j direction second, including corners:
   do i = reg_l1 - 1, reg_h1 + 1
      j = reg_l2
-     f(i,j-1) = 2.d0 * f(i,j) - f(i,j+1)
+     f(i,j-1) = 2.e0_rt * f(i,j) - f(i,j+1)
      j = reg_h2
-     f(i,j+1) = 2.d0 * f(i,j) - f(i,j-1)
+     f(i,j+1) = 2.e0_rt * f(i,j) - f(i,j-1)
   enddo
 
   !  corner results are the same whichever direction we extrapolate first
@@ -1178,27 +1207,28 @@ subroutine lbcoefna(bcoef, &
                     spec, sboxl0, sboxl1, sboxh0, sboxh1, &
                     idim) bind(C, name="lbcoefna")
 
+  use bl_fort_module, only : rt => c_real
   implicit none
   integer :: idim
   integer ::  reg_l1,  reg_l2,  reg_h1,  reg_h2
   integer :: bboxl0, bboxl1, bboxh0, bboxh1
   integer :: sboxl0, sboxl1, sboxh0, sboxh1
-  real*8 :: bcoef(bboxl0:bboxh0,bboxl1:bboxh1)
-  real*8 :: bcgrp(bboxl0:bboxh0,bboxl1:bboxh1)
-  real*8 :: spec(sboxl0:sboxh0,sboxl1:sboxh1)
+  real(rt)         :: bcoef(bboxl0:bboxh0,bboxl1:bboxh1)
+  real(rt)         :: bcgrp(bboxl0:bboxh0,bboxl1:bboxh1)
+  real(rt)         :: spec(sboxl0:sboxh0,sboxl1:sboxh1)
   integer :: i, j
   if (idim == 0) then
      do j = reg_l2, reg_h2
         do i = reg_l1, reg_h1
            bcoef(i,j) = bcoef(i,j) &
-                + 0.5d0 * (spec(i-1,j) + spec(i,j)) * bcgrp(i,j)
+                + 0.5e0_rt * (spec(i-1,j) + spec(i,j)) * bcgrp(i,j)
         enddo
      enddo
   else
      do j = reg_l2, reg_h2
         do i = reg_l1, reg_h1
            bcoef(i,j) = bcoef(i,j) &
-                + 0.5d0 * (spec(i,j-1) + spec(i,j)) * bcgrp(i,j)
+                + 0.5e0_rt * (spec(i,j-1) + spec(i,j)) * bcgrp(i,j)
         enddo
      enddo
   endif
@@ -1212,14 +1242,15 @@ subroutine ljupna(jnew, jboxl0, jboxl1, jboxh0, jboxh1, &
                   accel, aboxl0, aboxl1, aboxh0, aboxh1, &
                   nTotal) bind(C, name="ljupna")
 
+  use bl_fort_module, only : rt => c_real
   integer :: nTotal
   integer ::  reg_l1,  reg_l2,  reg_h1, reg_h2
   integer :: jboxl0, jboxl1, jboxh0, jboxh1
   integer :: sboxl0, sboxl1, sboxh0, sboxh1
   integer :: aboxl0, aboxl1, aboxh0, aboxh1
-  real*8 :: jnew(jboxl0:jboxh0,jboxl1:jboxh1,0:nTotal-1)
-  real*8 :: spec(sboxl0:sboxh0,sboxl1:sboxh1,0:nTotal-1)
-  real*8 :: accel(aboxl0:aboxh0,aboxl1:aboxh1)
+  real(rt)         :: jnew(jboxl0:jboxh0,jboxl1:jboxh1,0:nTotal-1)
+  real(rt)         :: spec(sboxl0:sboxh0,sboxl1:sboxh1,0:nTotal-1)
+  real(rt)         :: accel(aboxl0:aboxh0,aboxl1:aboxh1)
 
   integer :: i, j, n
 

--- a/Source/Radiation/RadSrc_2d/RadBndry_2d.f90
+++ b/Source/Radiation/RadSrc_2d/RadBndry_2d.f90
@@ -14,15 +14,16 @@ subroutine rbndry(  &
 
   use rad_params_module, only : ngroups
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: b_l1,b_l2,b_h1,b_h2
   integer, intent(in) :: d_l1,d_l2,d_h1,d_h2 ! computational domain index
   integer, intent(in) :: dir         ! 0: x    1: y-direction
   integer, intent(in) :: face        ! 0: low  1: high
-  double precision, intent(out) :: bf(b_l1:b_h1,b_l2:b_h2,0:ngroups-1)
-  double precision, intent(in) :: dx(2), xlo(2), t
+  real(rt)        , intent(out) :: bf(b_l1:b_h1,b_l2:b_h2,0:ngroups-1)
+  real(rt)        , intent(in) :: dx(2), xlo(2), t
 
-  bf = 0.5d0
+  bf = 0.5e0_rt
 
 end subroutine rbndry

--- a/Source/Radiation/RadSrc_2d/RadEOS_2d.f90
+++ b/Source/Radiation/RadSrc_2d/RadEOS_2d.f90
@@ -9,23 +9,24 @@ subroutine ca_compute_c_v(lo, hi, &
   use network, only : nspec, naux
   use meth_params_module, only : NVAR, URHO, UFS, UFX
 
+  use bl_fort_module, only : rt => c_real
   implicit none
   integer, intent(in)          :: lo(2), hi(2)
   integer, intent(in)          :: cv_l1, cv_l2, cv_h1, cv_h2
   integer, intent(in)          :: temp_l1, temp_l2, temp_h1, temp_h2
   integer, intent(in)          :: state_l1, state_l2, state_h1, state_h2
-  double precision             :: cv(cv_l1:cv_h1,cv_l2:cv_h2)
-  double precision, intent(in) :: temp(temp_l1:temp_h1,temp_l2:temp_h2)
-  double precision, intent(in) :: state(state_l1:state_h1,state_l2:state_h2,NVAR)
+  real(rt)                     :: cv(cv_l1:cv_h1,cv_l2:cv_h2)
+  real(rt)        , intent(in) :: temp(temp_l1:temp_h1,temp_l2:temp_h2)
+  real(rt)        , intent(in) :: state(state_l1:state_h1,state_l2:state_h2,NVAR)
 
   integer           :: i, j
-  double precision :: rhoInv
+  real(rt)         :: rhoInv
   type(eos_t) :: eos_state
 
   do j = lo(2), hi(2)
      do i = lo(1), hi(1)
 
-        rhoInv = 1.d0 / state(i,j,URHO)
+        rhoInv = 1.e0_rt / state(i,j,URHO)
         eos_state % rho = state(i,j,URHO)
         eos_state % T   =  temp(i,j)
         eos_state % xn  = state(i,j,UFS:UFS+nspec-1) * rhoInv
@@ -51,23 +52,24 @@ subroutine ca_get_rhoe(lo, hi, &
   use network, only : nspec, naux
   use meth_params_module, only : NVAR, URHO, UFS, UFX
 
+  use bl_fort_module, only : rt => c_real
   implicit none
   integer         , intent(in) :: lo(2), hi(2)
   integer         , intent(in) :: rhoe_l1, rhoe_l2, rhoe_h1, rhoe_h2
   integer         , intent(in) :: temp_l1, temp_l2, temp_h1, temp_h2
   integer         , intent(in) :: state_l1, state_l2, state_h1, state_h2
-  double precision, intent(in) :: temp(temp_l1:temp_h1,temp_l2:temp_h2)
-  double precision, intent(in) :: state(state_l1:state_h1,state_l2:state_h2,NVAR)
-  double precision             :: rhoe(rhoe_l1:rhoe_h1,rhoe_l2:rhoe_h2)
+  real(rt)        , intent(in) :: temp(temp_l1:temp_h1,temp_l2:temp_h2)
+  real(rt)        , intent(in) :: state(state_l1:state_h1,state_l2:state_h2,NVAR)
+  real(rt)                     :: rhoe(rhoe_l1:rhoe_h1,rhoe_l2:rhoe_h2)
 
   integer          :: i, j
-  double precision :: rhoInv
+  real(rt)         :: rhoInv
   type(eos_t) :: eos_state  
 
   do j = lo(2), hi(2)
      do i = lo(1), hi(1)
 
-        rhoInv = 1.d0 / state(i,j,URHO)
+        rhoInv = 1.e0_rt / state(i,j,URHO)
         eos_state % rho = state(i,j,URHO)
         eos_state % T   =  temp(i,j)
         eos_state % xn  = state(i,j,UFS:UFS+nspec-1) * rhoInv
@@ -92,23 +94,24 @@ subroutine ca_compute_temp_given_rhoe(lo,hi,  &
   use meth_params_module, only : NVAR, URHO, UTEMP, UFS, UFX, &
                                  small_temp, allow_negative_energy
 
+  use bl_fort_module, only : rt => c_real
   implicit none
   integer         , intent(in) :: lo(2),hi(2)
   integer         , intent(in) :: temp_l1, temp_l2, temp_h1, temp_h2, &
        state_l1,state_l2,state_h1,state_h2
-  double precision, intent(in) :: state(state_l1:state_h1,state_l2:state_h2,NVAR)
-  double precision :: temp(temp_l1:temp_h1,temp_l2:temp_h2) ! temp contains rhoe as input
+  real(rt)        , intent(in) :: state(state_l1:state_h1,state_l2:state_h2,NVAR)
+  real(rt)         :: temp(temp_l1:temp_h1,temp_l2:temp_h2) ! temp contains rhoe as input
 
   integer :: i, j
-  double precision :: rhoInv
+  real(rt)         :: rhoInv
   type (eos_t) :: eos_state
 
   do j = lo(2),hi(2)
      do i = lo(1),hi(1)
-        if (allow_negative_energy.eq.0 .and. temp(i,j).le.0.d0) then
+        if (allow_negative_energy.eq.0 .and. temp(i,j).le.0.e0_rt) then
            temp(i,j) = small_temp
         else
-           rhoInv = 1.d0 / state(i,j,URHO)
+           rhoInv = 1.e0_rt / state(i,j,URHO)
            eos_state % rho = state(i,j,URHO)
            eos_state % T   = state(i,j,UTEMP)
            eos_state % e   =  temp(i,j)*rhoInv 
@@ -132,32 +135,33 @@ subroutine ca_compute_temp_given_cv(lo,hi,  &
 
   use meth_params_module, only : NVAR, URHO
 
+  use bl_fort_module, only : rt => c_real
   implicit none
   integer         , intent(in) :: lo(2),hi(2)
   integer         , intent(in) :: temp_l1, temp_l2, temp_h1, temp_h2, &
        state_l1,state_l2,state_h1,state_h2
-  double precision, intent(in) :: state(state_l1:state_h1,state_l2:state_h2,NVAR)
-  double precision :: temp(temp_l1:temp_h1,temp_l2:temp_h2) ! temp contains rhoe
-  double precision, intent(in) :: const_c_v, c_v_exp_m, c_v_exp_n
+  real(rt)        , intent(in) :: state(state_l1:state_h1,state_l2:state_h2,NVAR)
+  real(rt)         :: temp(temp_l1:temp_h1,temp_l2:temp_h2) ! temp contains rhoe
+  real(rt)        , intent(in) :: const_c_v, c_v_exp_m, c_v_exp_n
 
   integer :: i, j
-  double precision :: ex, alpha, rhoal, teff
+  real(rt)         :: ex, alpha, rhoal, teff
 
-  ex = 1.d0 / (1.d0 - c_v_exp_n)
+  ex = 1.e0_rt / (1.e0_rt - c_v_exp_n)
 
   do j=lo(2), hi(2)
      do i=lo(1), hi(1)
-        if (c_v_exp_m .eq. 0.d0) then
+        if (c_v_exp_m .eq. 0.e0_rt) then
            alpha = const_c_v
         else
            alpha = const_c_v * state(i,j,URHO) ** c_v_exp_m
         endif
-        rhoal = state(i,j,URHO) * alpha + 1.d-50
-        if (c_v_exp_n .eq. 0.d0) then
+        rhoal = state(i,j,URHO) * alpha + 1.e-50_rt
+        if (c_v_exp_n .eq. 0.e0_rt) then
            temp(i,j) = temp(i,j) / rhoal
         else
-           teff = max(temp(i,j), 1.d-50)
-           temp(i,j) = ((1.d0 - c_v_exp_n) * teff / rhoal) ** ex
+           teff = max(temp(i,j), 1.e-50_rt)
+           temp(i,j) = ((1.e0_rt - c_v_exp_n) * teff / rhoal) ** ex
         endif
      end do
   end do
@@ -181,29 +185,30 @@ subroutine ca_compute_temp_given_reye(lo, hi, &
   use meth_params_module, only : NVAR, URHO, UMX, UMY, UFS, UFX, &
        small_temp, allow_negative_energy
 
+  use bl_fort_module, only : rt => c_real
   implicit none
   integer         , intent(in) :: lo(2), hi(2)
   integer         , intent(in) ::  temp_l1, temp_l2, temp_h1, temp_h2
   integer         , intent(in) ::    re_l1,   re_l2,   re_h1,   re_h2
   integer         , intent(in) ::    ye_l1,   ye_l2,   ye_h1,   ye_h2
   integer         , intent(in) :: state_l1,state_l2,state_h1,state_h2
-  double precision, intent(in) :: state(state_l1:state_h1,state_l2:state_h2,NVAR)
-  double precision, intent(in) ::  rhoe(   re_l1:   re_h1,   re_l2:   re_h2)
-  double precision, intent(in) ::    ye(   ye_l1:   ye_h1,   ye_l2:   ye_h2)
-  double precision             ::  temp( temp_l1: temp_h1, temp_l2: temp_h2)
+  real(rt)        , intent(in) :: state(state_l1:state_h1,state_l2:state_h2,NVAR)
+  real(rt)        , intent(in) ::  rhoe(   re_l1:   re_h1,   re_l2:   re_h2)
+  real(rt)        , intent(in) ::    ye(   ye_l1:   ye_h1,   ye_l2:   ye_h2)
+  real(rt)                     ::  temp( temp_l1: temp_h1, temp_l2: temp_h2)
 
   integer          :: i, j
-  double precision :: rhoInv
+  real(rt)         :: rhoInv
   type (eos_t) :: eos_state
 
   do j = lo(2), hi(2)
      do i = lo(1), hi(1)
 
-        if(allow_negative_energy.eq.0 .and. rhoe(i,j).le.0.d0) then
+        if(allow_negative_energy.eq.0 .and. rhoe(i,j).le.0.e0_rt) then
            temp(i,j) = small_temp
         else
 
-           rhoInv = 1.d0 / state(i,j,URHO)
+           rhoInv = 1.e0_rt / state(i,j,URHO)
            eos_state % rho = state(i,j,URHO)
            ! set initial guess of temperature
            eos_state % T = temp(i,j)
@@ -217,7 +222,7 @@ subroutine ca_compute_temp_given_reye(lo, hi, &
 
            temp(i,j) = eos_state % T
 
-           if(temp(i,j).lt.0.d0) then
+           if(temp(i,j).lt.0.e0_rt) then
               print*,'negative temp in compute_temp_given_reye ', temp(i,j)
               call bl_error("Error :: ca_compute_temp_given_reye")
            endif
@@ -240,6 +245,7 @@ subroutine ca_compute_reye_given_ty(lo, hi, &
   use eos_module
   use meth_params_module, only : NVAR, URHO, UFS, UFX
 
+  use bl_fort_module, only : rt => c_real
   implicit none
   integer         , intent(in) :: lo(2), hi(2)
   integer         , intent(in) :: re_l1, re_h1, re_l2, re_h2
@@ -247,20 +253,20 @@ subroutine ca_compute_reye_given_ty(lo, hi, &
   integer         , intent(in) :: temp_l1, temp_h1, temp_l2, temp_h2
   integer         , intent(in) :: ye_l1, ye_h1, ye_l2, ye_h2
   integer         , intent(in) :: state_l1, state_h1, state_l2, state_h2
-  double precision, intent(in) :: state(state_l1:state_h1,state_l2:state_h2,NVAR)
-  double precision             :: rhoe(re_l1:re_h1,re_l2:re_h2)
-  double precision             :: rhoY(rY_l1:rY_h1,rY_l2:rY_h2)
-  double precision, intent(in) :: ye(ye_l1:ye_h1,ye_l2:ye_h2)
-  double precision, intent(in) :: temp(temp_l1:temp_h1,temp_l2:temp_h2)
+  real(rt)        , intent(in) :: state(state_l1:state_h1,state_l2:state_h2,NVAR)
+  real(rt)                     :: rhoe(re_l1:re_h1,re_l2:re_h2)
+  real(rt)                     :: rhoY(rY_l1:rY_h1,rY_l2:rY_h2)
+  real(rt)        , intent(in) :: ye(ye_l1:ye_h1,ye_l2:ye_h2)
+  real(rt)        , intent(in) :: temp(temp_l1:temp_h1,temp_l2:temp_h2)
 
   integer          :: i, j
-  double precision :: rhoInv
+  real(rt)         :: rhoInv
   type (eos_t) :: eos_state
 
   do j = lo(2), hi(2)
      do i = lo(1), hi(1)
 
-        rhoInv = 1.d0 / state(i,j,URHO)
+        rhoInv = 1.e0_rt / state(i,j,URHO)
         eos_state % rho = state(i,j,URHO)
         eos_state % T   =  temp(i,j)
         eos_state % xn  = state(i,j,UFS:UFS+nspec-1) * rhoInv

--- a/Source/Radiation/RadSrc_2d/RadPlotvar_2d.f90
+++ b/Source/Radiation/RadSrc_2d/RadPlotvar_2d.f90
@@ -6,6 +6,7 @@ subroutine ca_er_com2lab(lo, hi, &
      Elab, El_l1, El_l2, El_h1, El_h2, ier, npv)
   use meth_params_module, only : NVAR, URHO, UMX, UMY
   use rad_params_module, only : ngroups, clight, nnuspec, ng0, ng1, dlognu
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: lo(2), hi(2)
@@ -13,31 +14,31 @@ subroutine ca_er_com2lab(lo, hi, &
   integer, intent(in) :: Ec_l1, Ec_l2, Ec_h1, Ec_h2
   integer, intent(in) ::  F_l1,  F_l2,  F_h1,  F_h2, iflx, nflx
   integer, intent(in) :: El_l1, El_l2, El_h1, El_h2, ier, npv
-  double precision,intent(in)   ::Snew( S_l1: S_h1, S_l2: S_h2,NVAR)
-  double precision,intent(in)   ::Ecom(Ec_l1:Ec_h1,Ec_l2:Ec_h2,0:ngroups-1)
-  double precision,intent(in)   ::F   ( F_l1: F_h1, F_l2: F_h2,0:nflx-1)
-  double precision,intent(inout)::Elab(El_l1:El_h1,El_l2:El_h2,0:npv-1)
+  real(rt)        ,intent(in)   ::Snew( S_l1: S_h1, S_l2: S_h2,NVAR)
+  real(rt)        ,intent(in)   ::Ecom(Ec_l1:Ec_h1,Ec_l2:Ec_h2,0:ngroups-1)
+  real(rt)        ,intent(in)   ::F   ( F_l1: F_h1, F_l2: F_h2,0:nflx-1)
+  real(rt)        ,intent(inout)::Elab(El_l1:El_h1,El_l2:El_h2,0:npv-1)
 
   integer :: i, j, g, ifx, ify
-  double precision :: rhoInv, c2, vxc2, vyc2
-  double precision :: nufnux(-1:ngroups), nufnuy(-1:ngroups)
-  double precision :: dlognuInv(0:ngroups-1)
+  real(rt)         :: rhoInv, c2, vxc2, vyc2
+  real(rt)         :: nufnux(-1:ngroups), nufnuy(-1:ngroups)
+  real(rt)         :: dlognuInv(0:ngroups-1)
 
   ifx = iflx
   ify = iflx + ngroups
 
-  c2 = 1.d0/clight**2
+  c2 = 1.e0_rt/clight**2
 
-  if (ngroups > 1) dlognuInv = 1.d0/dlognu
+  if (ngroups > 1) dlognuInv = 1.e0_rt/dlognu
 
   do j = lo(2), hi(2)
   do i = lo(1), hi(1)
-     rhoInv = 1.d0/Snew(i,j,URHO)
+     rhoInv = 1.e0_rt/Snew(i,j,URHO)
      vxc2 = Snew(i,j,UMX)*rhoInv*c2
      vyc2 = Snew(i,j,UMY)*rhoInv*c2
      
      do g = 0, ngroups-1
-        Elab(i,j,g+ier) = Ecom(i,j,g) + 2.d0*(vxc2*F(i,j,ifx+g) &
+        Elab(i,j,g+ier) = Ecom(i,j,g) + 2.e0_rt*(vxc2*F(i,j,ifx+g) &
              &                              + vyc2*F(i,j,ify+g))
      end do
      
@@ -53,8 +54,8 @@ subroutine ca_er_com2lab(lo, hi, &
            nufnux(ngroups) = -nufnux(ngroups-1)
            nufnuy(ngroups) = -nufnuy(ngroups-1)              
            do g=0,ngroups-1
-              Elab(i,j,g+ier) = Elab(i,j,g+ier) - vxc2*0.5d0*(nufnux(g+1)-nufnux(g-1)) &
-                   &                    - vyc2*0.5d0*(nufnuy(g+1)-nufnuy(g-1))
+              Elab(i,j,g+ier) = Elab(i,j,g+ier) - vxc2*0.5e0_rt*(nufnux(g+1)-nufnux(g-1)) &
+                   &                    - vyc2*0.5e0_rt*(nufnuy(g+1)-nufnuy(g-1))
            end do
            
         else
@@ -68,8 +69,8 @@ subroutine ca_er_com2lab(lo, hi, &
            nufnux(ng0) = -nufnux(ng0-1)
            nufnuy(ng0) = -nufnuy(ng0-1)              
            do g=0,ng0-1
-              Elab(i,j,g+ier) = Elab(i,j,g+ier) - vxc2*0.5d0*(nufnux(g+1)-nufnux(g-1)) &
-                   &                            - vyc2*0.5d0*(nufnuy(g+1)-nufnuy(g-1))
+              Elab(i,j,g+ier) = Elab(i,j,g+ier) - vxc2*0.5e0_rt*(nufnux(g+1)-nufnux(g-1)) &
+                   &                            - vyc2*0.5e0_rt*(nufnuy(g+1)-nufnuy(g-1))
            end do
            
            if (nnuspec >= 2) then
@@ -83,8 +84,8 @@ subroutine ca_er_com2lab(lo, hi, &
               nufnux(ng0+ng1) = -nufnux(ng0+ng1-1)
               nufnuy(ng0+ng1) = -nufnuy(ng0+ng1-1)              
               do g=ng0,ng0+ng1-1
-                 Elab(i,j,g+ier) = Elab(i,j,g+ier) - vxc2*0.5d0*(nufnux(g+1)-nufnux(g-1)) &
-                      &                            - vyc2*0.5d0*(nufnuy(g+1)-nufnuy(g-1))
+                 Elab(i,j,g+ier) = Elab(i,j,g+ier) - vxc2*0.5e0_rt*(nufnux(g+1)-nufnux(g-1)) &
+                      &                            - vyc2*0.5e0_rt*(nufnuy(g+1)-nufnuy(g-1))
               end do
               
            end if
@@ -100,8 +101,8 @@ subroutine ca_er_com2lab(lo, hi, &
               nufnux(ngroups) = -nufnux(ngroups-1)
               nufnuy(ngroups) = -nufnuy(ngroups-1)              
               do g=ng0+ng1,ngroups-1
-                 Elab(i,j,g+ier) = Elab(i,j,g+ier) - vxc2*0.5d0*(nufnux(g+1)-nufnux(g-1)) &
-                      &                            - vyc2*0.5d0*(nufnuy(g+1)-nufnuy(g-1))
+                 Elab(i,j,g+ier) = Elab(i,j,g+ier) - vxc2*0.5e0_rt*(nufnux(g+1)-nufnux(g-1)) &
+                      &                            - vyc2*0.5e0_rt*(nufnuy(g+1)-nufnuy(g-1))
               end do
               
            end if
@@ -120,23 +121,24 @@ subroutine ca_compute_fcc(lo, hi, &
      Eddf, Eddf_l1, Eddf_l2, Eddf_h1, Eddf_h2)
   use rad_params_module, only : ngroups
   use fluxlimiter_module, only : Edd_factor
+  use bl_fort_module, only : rt => c_real
   implicit none
   integer, intent(in) :: lo(2), hi(2)
   integer, intent(in) :: lamx_l1, lamx_l2, lamx_h1, lamx_h2
   integer, intent(in) :: lamy_l1, lamy_l2, lamy_h1, lamy_h2, nlam
   integer, intent(in) :: Eddf_l1, Eddf_l2, Eddf_h1, Eddf_h2
-  double precision,intent(in   )::lamx(lamx_l1:lamx_h1,lamx_l2:lamx_h2,0:nlam-1)
-  double precision,intent(in   )::lamy(lamy_l1:lamy_h1,lamy_l2:lamy_h2,0:nlam-1)
-  double precision,intent(inout)::Eddf(Eddf_l1:Eddf_h1,Eddf_l2:Eddf_h2,0:ngroups-1)
+  real(rt)        ,intent(in   )::lamx(lamx_l1:lamx_h1,lamx_l2:lamx_h2,0:nlam-1)
+  real(rt)        ,intent(in   )::lamy(lamy_l1:lamy_h1,lamy_l2:lamy_h2,0:nlam-1)
+  real(rt)        ,intent(inout)::Eddf(Eddf_l1:Eddf_h1,Eddf_l2:Eddf_h2,0:ngroups-1)
 
   integer :: i, j, g, ilam
-  double precision :: lamcc
+  real(rt)         :: lamcc
 
   do g=0,ngroups-1
      ilam = min(g,nlam-1)
      do j = lo(2), hi(2)
         do i = lo(1), hi(1)
-           lamcc = 0.25d0*(lamx(i,j,ilam)+lamx(i+1,j,ilam)+lamy(i,j,ilam)+lamy(i,j+1,ilam))
+           lamcc = 0.25e0_rt*(lamx(i,j,ilam)+lamx(i+1,j,ilam)+lamy(i,j,ilam)+lamy(i,j+1,ilam))
            Eddf(i,j,g) = Edd_factor(lamcc)
         end do
      end do
@@ -152,26 +154,27 @@ subroutine ca_transform_flux (lo, hi, flag, &
      Fo,   Fo_l1, Fo_l2, Fo_h1, Fo_h2, ifo, nfo)
   use meth_params_module, only : NVAR, URHO, UMX, UMY
   use rad_params_module, only : ngroups, nnuspec, ng0, ng1, dlognu
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: lo(2), hi(2)
-  double precision, intent(in) :: flag
+  real(rt)        , intent(in) :: flag
   integer, intent(in) ::  S_l1,  S_l2,  S_h1,  S_h2
   integer, intent(in) ::  f_l1,  f_l2,  f_h1,  f_h2
   integer, intent(in) :: Er_l1, Er_l2, Er_h1, Er_h2
   integer, intent(in) :: Fi_l1, Fi_l2, Fi_h1, Fi_h2, ifi, nfi
   integer, intent(in) :: Fo_l1, Fo_l2, Fo_h1, Fo_h2, ifo, nfo
-  double precision,intent(in   )::Snew( S_l1: S_h1, S_l2: S_h2,NVAR)
-  double precision,intent(in   )::   f( f_l1: f_h1, f_l2: f_h2,0:ngroups-1)
-  double precision,intent(in   )::  Er(Er_l1:Er_h1,Er_l2:Er_h2,0:ngroups-1)
-  double precision,intent(in   )::  Fi(Fi_l1:Fi_h1,Fi_l2:Fi_h2,0:nfi-1)
-  double precision,intent(inout)::  Fo(Fo_l1:Fo_h1,Fo_l2:Fo_h2,0:nfo-1)
+  real(rt)        ,intent(in   )::Snew( S_l1: S_h1, S_l2: S_h2,NVAR)
+  real(rt)        ,intent(in   )::   f( f_l1: f_h1, f_l2: f_h2,0:ngroups-1)
+  real(rt)        ,intent(in   )::  Er(Er_l1:Er_h1,Er_l2:Er_h2,0:ngroups-1)
+  real(rt)        ,intent(in   )::  Fi(Fi_l1:Fi_h1,Fi_l2:Fi_h2,0:nfi-1)
+  real(rt)        ,intent(inout)::  Fo(Fo_l1:Fo_h1,Fo_l2:Fo_h2,0:nfo-1)
 
   integer :: i, j, g, ifix, ifiy, ifox, ifoy
-  double precision :: rhoInv,  vx, vy, f1, f2, nx, ny, foo, vdotn
-  double precision :: nuvpnux(-1:ngroups), nuvpnuy(-1:ngroups)
-  double precision :: dlognuInv(0:ngroups-1)
-  double precision :: vdotpx(0:ngroups-1), vdotpy(0:ngroups-1)
+  real(rt)         :: rhoInv,  vx, vy, f1, f2, nx, ny, foo, vdotn
+  real(rt)         :: nuvpnux(-1:ngroups), nuvpnuy(-1:ngroups)
+  real(rt)         :: dlognuInv(0:ngroups-1)
+  real(rt)         :: vdotpx(0:ngroups-1), vdotpy(0:ngroups-1)
 
   ifix = ifi
   ifiy = ifi + ngroups
@@ -179,23 +182,23 @@ subroutine ca_transform_flux (lo, hi, flag, &
   ifox = ifo
   ifoy = ifo + ngroups
 
-  if (ngroups > 1) dlognuInv = 1.d0/dlognu
+  if (ngroups > 1) dlognuInv = 1.e0_rt/dlognu
 
   do j = lo(2), hi(2)
   do i = lo(1), hi(1)
-     rhoInv = 1.d0/Snew(i,j,URHO)
+     rhoInv = 1.e0_rt/Snew(i,j,URHO)
      vx = Snew(i,j,UMX)*rhoInv*flag
      vy = Snew(i,j,UMY)*rhoInv*flag
 
      do g = 0, ngroups-1
-        f1 = (1.d0-f(i,j,g))
-        f2 = (3.d0*f(i,j,g)-1.d0)
-        foo = 1.d0/sqrt(Fi(i,j,ifix+g)**2+Fi(i,j,ifiy+g)**2+1.d-50)
+        f1 = (1.e0_rt-f(i,j,g))
+        f2 = (3.e0_rt*f(i,j,g)-1.e0_rt)
+        foo = 1.e0_rt/sqrt(Fi(i,j,ifix+g)**2+Fi(i,j,ifiy+g)**2+1.e-50_rt)
         nx = Fi(i,j,ifix+g)*foo
         ny = Fi(i,j,ifiy+g)*foo
         vdotn = vx*nx+vy*ny
-        vdotpx(g) = 0.5d0*Er(i,j,g)*(f1*vx + f2*vdotn*nx)
-        vdotpy(g) = 0.5d0*Er(i,j,g)*(f1*vy + f2*vdotn*ny)
+        vdotpx(g) = 0.5e0_rt*Er(i,j,g)*(f1*vx + f2*vdotn*nx)
+        vdotpy(g) = 0.5e0_rt*Er(i,j,g)*(f1*vy + f2*vdotn*ny)
         Fo(i,j,ifox+g) = Fi(i,j,ifix+g) + vx*Er(i,j,g) + vdotpx(g)
         Fo(i,j,ifoy+g) = Fi(i,j,ifiy+g) + vy*Er(i,j,g) + vdotpy(g)
      end do
@@ -212,8 +215,8 @@ subroutine ca_transform_flux (lo, hi, flag, &
            nuvpnux(ngroups) = -nuvpnux(ngroups-1)
            nuvpnuy(ngroups) = -nuvpnuy(ngroups-1)              
            do g=0,ngroups-1
-              Fo(i,j,ifox+g) = Fo(i,j,ifox+g) - 0.5d0*(nuvpnux(g+1)-nuvpnux(g-1))
-              Fo(i,j,ifoy+g) = Fo(i,j,ifoy+g) - 0.5d0*(nuvpnuy(g+1)-nuvpnuy(g-1))
+              Fo(i,j,ifox+g) = Fo(i,j,ifox+g) - 0.5e0_rt*(nuvpnux(g+1)-nuvpnux(g-1))
+              Fo(i,j,ifoy+g) = Fo(i,j,ifoy+g) - 0.5e0_rt*(nuvpnuy(g+1)-nuvpnuy(g-1))
            end do
 
         else
@@ -227,8 +230,8 @@ subroutine ca_transform_flux (lo, hi, flag, &
            nuvpnux(ng0) = -nuvpnux(ng0-1)
            nuvpnuy(ng0) = -nuvpnuy(ng0-1)              
            do g=0,ng0-1
-              Fo(i,j,ifox+g) = Fo(i,j,ifox+g) - 0.5d0*(nuvpnux(g+1)-nuvpnux(g-1))
-              Fo(i,j,ifoy+g) = Fo(i,j,ifoy+g) - 0.5d0*(nuvpnuy(g+1)-nuvpnuy(g-1))
+              Fo(i,j,ifox+g) = Fo(i,j,ifox+g) - 0.5e0_rt*(nuvpnux(g+1)-nuvpnux(g-1))
+              Fo(i,j,ifoy+g) = Fo(i,j,ifoy+g) - 0.5e0_rt*(nuvpnuy(g+1)-nuvpnuy(g-1))
            end do
 
            if (nnuspec >= 2) then
@@ -242,8 +245,8 @@ subroutine ca_transform_flux (lo, hi, flag, &
               nuvpnux(ng0+ng1) = -nuvpnux(ng0+ng1-1)
               nuvpnuy(ng0+ng1) = -nuvpnuy(ng0+ng1-1)              
               do g=ng0,ng0+ng1-1
-                 Fo(i,j,ifox+g) = Fo(i,j,ifox+g) - 0.5d0*(nuvpnux(g+1)-nuvpnux(g-1))
-                 Fo(i,j,ifoy+g) = Fo(i,j,ifoy+g) - 0.5d0*(nuvpnuy(g+1)-nuvpnuy(g-1))
+                 Fo(i,j,ifox+g) = Fo(i,j,ifox+g) - 0.5e0_rt*(nuvpnux(g+1)-nuvpnux(g-1))
+                 Fo(i,j,ifoy+g) = Fo(i,j,ifoy+g) - 0.5e0_rt*(nuvpnuy(g+1)-nuvpnuy(g-1))
               end do
 
            end if
@@ -259,8 +262,8 @@ subroutine ca_transform_flux (lo, hi, flag, &
               nuvpnux(ngroups) = -nuvpnux(ngroups-1)
               nuvpnuy(ngroups) = -nuvpnuy(ngroups-1)              
               do g=ng0+ng1,ngroups-1
-                 Fo(i,j,ifox+g) = Fo(i,j,ifox+g) - 0.5d0*(nuvpnux(g+1)-nuvpnux(g-1))
-                 Fo(i,j,ifoy+g) = Fo(i,j,ifoy+g) - 0.5d0*(nuvpnuy(g+1)-nuvpnuy(g-1))
+                 Fo(i,j,ifox+g) = Fo(i,j,ifox+g) - 0.5e0_rt*(nuvpnux(g+1)-nuvpnux(g-1))
+                 Fo(i,j,ifoy+g) = Fo(i,j,ifoy+g) - 0.5e0_rt*(nuvpnuy(g+1)-nuvpnuy(g-1))
               end do
 
            end if

--- a/Source/Radiation/RadSrc_2d/filt_prim_2d.f90
+++ b/Source/Radiation/RadSrc_2d/filt_prim_2d.f90
@@ -11,26 +11,27 @@ subroutine ca_filt_prim(lo, hi, &
        small_temp, small_dens, nadv
   use filter_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: lo(2), hi(2), domlo(2), domhi(2), level
   integer, intent(in) :: filt_T, S
-  double precision, intent(in) :: delta(2), xlo(2), problo(2), time
+  real(rt)        , intent(in) :: delta(2), xlo(2), problo(2), time
   integer, intent(in) ::   Stmp_l1,Stmp_h1,Stmp_l2,Stmp_h2
   integer, intent(in) ::   Snew_l1,Snew_h1,Snew_l2,Snew_h2
   integer, intent(in) ::   mask_l1,mask_h1,mask_l2,mask_h2
-  double precision :: Stmp(Stmp_l1:Stmp_h1,Stmp_l2:Stmp_h2,NVAR)
-  double precision :: Snew(Snew_l1:Snew_h1,Snew_l2:Snew_h2,NVAR)
-  double precision :: mask(mask_l1:mask_h1,mask_l2:mask_h2)
-  ! mask has three possible values: -1.d0, 0.d0, and 1.d0.
-  ! -1.d0 appears only in cells that are covered by neither this level nor the finer level.
+  real(rt)         :: Stmp(Stmp_l1:Stmp_h1,Stmp_l2:Stmp_h2,NVAR)
+  real(rt)         :: Snew(Snew_l1:Snew_h1,Snew_l2:Snew_h2,NVAR)
+  real(rt)         :: mask(mask_l1:mask_h1,mask_l2:mask_h2)
+  ! mask has three possible values: -1.e0_rt, 0.e0_rt, and 1.e0_rt.
+  ! -1.e0_rt appears only in cells that are covered by neither this level nor the finer level.
   !       It can only appear in ghost cells. 
-  !  0.d0 appears only in cells that are covered by only this level, but not the finer level.
-  !  1.d0 appears only in cells that are covered by the finer level.
+  !  0.e0_rt appears only in cells that are covered by only this level, but not the finer level.
+  !  1.e0_rt appears only in cells that are covered by the finer level.
   !       It can appear in either valid cells or ghost cells. 
 
   integer :: i,j
-  double precision :: p, e, X(nspec+naux)
+  real(rt)         :: p, e, X(nspec+naux)
 
   ! this is a stub -- a problem can override this in its own directory
   ! to implement filtering

--- a/Source/Radiation/RadSrc_2d/trace_ppm_rad_2d.f90
+++ b/Source/Radiation/RadSrc_2d/trace_ppm_rad_2d.f90
@@ -3,6 +3,7 @@
 
 module trace_ppm_rad_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   private
@@ -30,6 +31,7 @@ contains
     use rad_params_module, only : ngroups
     use ppm_module, only : ppm
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer ilo1,ilo2,ihi1,ihi2
@@ -39,24 +41,24 @@ contains
     integer src_l1,src_l2,src_h1,src_h2
     integer gc_l1,gc_l2,gc_h1,gc_h2
 
-    double precision     q(qd_l1:qd_h1,qd_l2:qd_h2,NQ)
-    double precision :: qaux(qd_l1:qd_h1,qd_l2:qd_h2, NQAUX)
-    double precision flatn(qd_l1:qd_h1,qd_l2:qd_h2)
-    double precision srcQ(src_l1:src_h1,src_l2:src_h2,QVAR)
-    double precision dloga(dloga_l1:dloga_h1,dloga_l2:dloga_h2)
+    real(rt)             q(qd_l1:qd_h1,qd_l2:qd_h2,NQ)
+    real(rt)         :: qaux(qd_l1:qd_h1,qd_l2:qd_h2, NQAUX)
+    real(rt)         flatn(qd_l1:qd_h1,qd_l2:qd_h2)
+    real(rt)         srcQ(src_l1:src_h1,src_l2:src_h2,QVAR)
+    real(rt)         dloga(dloga_l1:dloga_h1,dloga_l2:dloga_h2)
 
-    double precision qxm(qpd_l1:qpd_h1,qpd_l2:qpd_h2,NQ)
-    double precision qxp(qpd_l1:qpd_h1,qpd_l2:qpd_h2,NQ)
-    double precision qym(qpd_l1:qpd_h1,qpd_l2:qpd_h2,NQ)
-    double precision qyp(qpd_l1:qpd_h1,qpd_l2:qpd_h2,NQ)
+    real(rt)         qxm(qpd_l1:qpd_h1,qpd_l2:qpd_h2,NQ)
+    real(rt)         qxp(qpd_l1:qpd_h1,qpd_l2:qpd_h2,NQ)
+    real(rt)         qym(qpd_l1:qpd_h1,qpd_l2:qpd_h2,NQ)
+    real(rt)         qyp(qpd_l1:qpd_h1,qpd_l2:qpd_h2,NQ)
 
-    double precision dx, dy, dt
+    real(rt)         dx, dy, dt
 
     ! Local variables
     integer :: i, j, g
     integer :: n, ipassive
 
-    double precision :: hdt, dtdx, dtdy
+    real(rt)         :: hdt, dtdx, dtdy
 
     ! To allow for easy integration of radiation, we adopt the
     ! following conventions:
@@ -76,39 +78,39 @@ contains
     ! for pure hydro, we will only consider:
     !   rho, u, v, w, ptot, rhoe_g, cc, h_g
 
-    double precision :: cc, csq, cgassq, Clag
-    double precision :: rho, u, v, p, rhoe_g, h_g, tau
-    double precision :: ptot, gam_g, game
+    real(rt)         :: cc, csq, cgassq, Clag
+    real(rt)         :: rho, u, v, p, rhoe_g, h_g, tau
+    real(rt)         :: ptot, gam_g, game
 
-    double precision :: drho, dptot, drhoe_g
-    double precision :: dge, dtau
-    double precision :: dup, dvp, dptotp
-    double precision :: dum, dvm, dptotm
+    real(rt)         :: drho, dptot, drhoe_g
+    real(rt)         :: dge, dtau
+    real(rt)         :: dup, dvp, dptotp
+    real(rt)         :: dum, dvm, dptotm
 
-    double precision :: rho_ref, u_ref, v_ref, p_ref, rhoe_g_ref, h_g_ref
-    double precision :: ptot_ref
-    double precision :: tau_ref
+    real(rt)         :: rho_ref, u_ref, v_ref, p_ref, rhoe_g_ref, h_g_ref
+    real(rt)         :: ptot_ref
+    real(rt)         :: tau_ref
 
-    double precision :: cc_ref, csq_ref, Clag_ref, gam_g_ref, game_ref, gfactor
+    real(rt)         :: cc_ref, csq_ref, Clag_ref, gam_g_ref, game_ref, gfactor
 
-    double precision :: alpham, alphap, alpha0r, alpha0e_g
-    double precision :: sourcr,sourcp,source,courn,eta,dlogatmp
+    real(rt)         :: alpham, alphap, alpha0r, alpha0e_g
+    real(rt)         :: sourcr,sourcp,source,courn,eta,dlogatmp
 
-    double precision :: tau_s
+    real(rt)         :: tau_s
 
-    double precision, dimension(0:ngroups-1) :: er, der, alphar, sourcer, qrtmp,hr
-    double precision, dimension(0:ngroups-1) :: lam0, lamp, lamm
+    real(rt)        , dimension(0:ngroups-1) :: er, der, alphar, sourcer, qrtmp,hr
+    real(rt)        , dimension(0:ngroups-1) :: lam0, lamp, lamm
 
-    double precision, dimension(0:ngroups-1) :: er_ref
+    real(rt)        , dimension(0:ngroups-1) :: er_ref
 
 
-    double precision, allocatable :: Ip(:,:,:,:,:)
-    double precision, allocatable :: Im(:,:,:,:,:)
+    real(rt)        , allocatable :: Ip(:,:,:,:,:)
+    real(rt)        , allocatable :: Im(:,:,:,:,:)
 
-    double precision, allocatable :: Ip_src(:,:,:,:,:)
-    double precision, allocatable :: Im_src(:,:,:,:,:)
+    real(rt)        , allocatable :: Ip_src(:,:,:,:,:)
+    real(rt)        , allocatable :: Im_src(:,:,:,:,:)
 
-    double precision :: er_foo
+    real(rt)         :: er_foo
 
     if (ppm_type == 0) then
        print *,'Oops -- shouldnt be in trace_ppm with ppm_type = 0'

--- a/Source/Radiation/RadSrc_3d/CastroRad_3d.f90
+++ b/Source/Radiation/RadSrc_3d/CastroRad_3d.f90
@@ -8,21 +8,22 @@ subroutine ca_compute_lamborder(Er, Er_l1, Er_l2, Er_l3, Er_h1, Er_h2, Er_h3, &
   use fluxlimiter_module, only : FLDlambda
   use filter_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: Er_l1, Er_l2, Er_l3, Er_h1, Er_h2, Er_h3, &
        kap_l1, kap_l2, kap_l3, kap_h1, kap_h2, kap_h3, &
        lam_l1, lam_l2, lam_l3, lam_h1, lam_h2, lam_h3
   integer, intent(in) :: ngrow, limiter, filter_T, S
-  double precision, intent(in) :: dx(3)
-  double precision, intent(in) :: kap(kap_l1:kap_h1, kap_l2:kap_h2, kap_l3:kap_h3, 0:ngroups-1)
-  double precision, intent(in) :: Er(Er_l1:Er_h1, Er_l2:Er_h2, Er_l3:Er_h3, 0:ngroups-1)
-  double precision, intent(out) :: lam(lam_l1:lam_h1, lam_l2:lam_h2, lam_l3:lam_h3, 0:ngroups-1)
+  real(rt)        , intent(in) :: dx(3)
+  real(rt)        , intent(in) :: kap(kap_l1:kap_h1, kap_l2:kap_h2, kap_l3:kap_h3, 0:ngroups-1)
+  real(rt)        , intent(in) :: Er(Er_l1:Er_h1, Er_l2:Er_h2, Er_l3:Er_h3, 0:ngroups-1)
+  real(rt)        , intent(out) :: lam(lam_l1:lam_h1, lam_l2:lam_h2, lam_l3:lam_h3, 0:ngroups-1)
 
   integer :: i, j, k, reg_l1, reg_l2, reg_l3, reg_h1, reg_h2, reg_h3, g
-  double precision :: r, r1, r2, r3
+  real(rt)         :: r, r1, r2, r3
 
-  double precision, allocatable :: lamfil(:,:,:)
+  real(rt)        , allocatable :: lamfil(:,:,:)
 
   reg_l1 = lam_l1 + ngrow
   reg_l2 = lam_l2 + ngrow
@@ -41,38 +42,38 @@ subroutine ca_compute_lamborder(Er, Er_l1, Er_l2, Er_l3, Er_h1, Er_h2, Er_h3, &
      do j=lam_l2, lam_h2
         do i=lam_l1, lam_h1
 
-           lam(i,j,k,g) = -1.d50
+           lam(i,j,k,g) = -1.e50_rt
 
-           if (Er(i,j,k,g) .eq. -1.d0) then
+           if (Er(i,j,k,g) .eq. -1.e0_rt) then
               cycle
            end if
 
-           if (Er(i-1,j,k,g) .eq. -1.d0) then
+           if (Er(i-1,j,k,g) .eq. -1.e0_rt) then
               r1 = (Er(i+1,j,k,g) - Er(i,j,k,g)) / (dx(1))
-           else if (Er(i+1,j,k,g) .eq. -1.d0) then
+           else if (Er(i+1,j,k,g) .eq. -1.e0_rt) then
               r1 = (Er(i,j,k,g) - Er(i-1,j,k,g)) / (dx(1))
            else
-              r1 = (Er(i+1,j,k,g) - Er(i-1,j,k,g)) / (2.d0*dx(1))
+              r1 = (Er(i+1,j,k,g) - Er(i-1,j,k,g)) / (2.e0_rt*dx(1))
            end if
 
-           if (Er(i,j-1,k,g) .eq. -1.d0) then
+           if (Er(i,j-1,k,g) .eq. -1.e0_rt) then
               r2 = (Er(i,j+1,k,g) - Er(i,j,k,g)) / (dx(2))
-           else if (Er(i,j+1,k,g) .eq. -1.d0) then
+           else if (Er(i,j+1,k,g) .eq. -1.e0_rt) then
               r2 = (Er(i,j,k,g) - Er(i,j-1,k,g)) / (dx(2))
            else
-              r2 = (Er(i,j+1,k,g) - Er(i,j-1,k,g)) / (2.d0*dx(2))
+              r2 = (Er(i,j+1,k,g) - Er(i,j-1,k,g)) / (2.e0_rt*dx(2))
            end if
 
-           if (Er(i,j,k-1,g) .eq. -1.d0) then
+           if (Er(i,j,k-1,g) .eq. -1.e0_rt) then
               r3 = (Er(i,j,k+1,g) - Er(i,j,k,g)) / dx(3)
-           else if (Er(i,j,k+1,g) .eq. -1.d0) then
+           else if (Er(i,j,k+1,g) .eq. -1.e0_rt) then
               r3 = (Er(i,j,k,g) - Er(i,j,k-1,g)) / dx(3)
            else
-              r3 = (Er(i,j,k+1,g) - Er(i,j,k-1,g)) / (2.d0*dx(3))
+              r3 = (Er(i,j,k+1,g) - Er(i,j,k-1,g)) / (2.e0_rt*dx(3))
            end if
 
            r = sqrt(r1**2 + r2**2 + r3**2)
-           r = r / (kap(i,j,k,g) * max(Er(i,j,k,g), 1.d-50))
+           r = r / (kap(i,j,k,g) * max(Er(i,j,k,g), 1.e-50_rt))
 
            lam(i,j,k,g) = FLDlambda(r, limiter)
         end do
@@ -83,8 +84,8 @@ subroutine ca_compute_lamborder(Er, Er_l1, Er_l2, Er_l3, Er_h1, Er_h2, Er_h3, &
   if (filter_T .eq. 1) then
      do k=lam_l3, lam_h3
         do j=lam_l2, lam_h2
-           if (Er(reg_l1,j,k,g) .eq. -1.d0) then
-              lamfil(:,j,k) = -1.d-50
+           if (Er(reg_l1,j,k,g) .eq. -1.e0_rt) then
+              lamfil(:,j,k) = -1.e-50_rt
               cycle
            end if
 
@@ -93,12 +94,12 @@ subroutine ca_compute_lamborder(Er, Er_l1, Er_l2, Er_l3, Er_h1, Er_h2, Er_h3, &
                    &        + ff1(1) * (lam(i-1,j,k,g)+lam(i+1,j,k,g))
            end do
 
-           if (Er(reg_l1-1,j,k,g) .eq. -1.d0) then
+           if (Er(reg_l1-1,j,k,g) .eq. -1.e0_rt) then
               i = reg_l1
               lamfil(i,j,k) = dot_product(ff1b, lam(i:i+1,j,k,g))
            end if
 
-           if (Er(reg_h1+1,j,k,g) .eq. -1.d0) then
+           if (Er(reg_h1+1,j,k,g) .eq. -1.e0_rt) then
               i = reg_h1
               lamfil(i,j,k) = dot_product(ff1b(1:0:-1), lam(i-1:i,j,k,g))
            end if
@@ -106,7 +107,7 @@ subroutine ca_compute_lamborder(Er, Er_l1, Er_l2, Er_l3, Er_h1, Er_h2, Er_h3, &
      end do
 
      do k=lam_l3, lam_h3
-        if (Er(reg_l1,reg_l2,k,g) .eq. -1.d0) then
+        if (Er(reg_l1,reg_l2,k,g) .eq. -1.e0_rt) then
            cycle
         end if
 
@@ -117,14 +118,14 @@ subroutine ca_compute_lamborder(Er, Er_l1, Er_l2, Er_l3, Er_h1, Er_h2, Er_h3, &
            end do
         end do
 
-        if (Er(reg_l1,reg_l2-1,k,g) .eq. -1.d0) then
+        if (Er(reg_l1,reg_l2-1,k,g) .eq. -1.e0_rt) then
            j = reg_l2
            do i=reg_l1,reg_h1
               lam(i,j,k,g) = dot_product(ff1b, lamfil(i,j:j+1,k))
            end do
         end if
 
-        if (Er(reg_l1,reg_h2+1,k,g) .eq. -1.d0) then
+        if (Er(reg_l1,reg_h2+1,k,g) .eq. -1.e0_rt) then
            j = reg_h2
            do i=reg_l1,reg_h1
               lam(i,j,k,g) = dot_product(ff1b(1:0:-1), lamfil(i,j-1:j,k))
@@ -137,27 +138,27 @@ subroutine ca_compute_lamborder(Er, Er_l1, Er_l2, Er_l3, Er_h1, Er_h2, Er_h3, &
            do i=reg_l1, reg_h1
               lamfil(i,j,k) = ff1(0) * lam(i,j,k,g) &
                    &        + ff1(1) * (lam(i,j,k-1,g)+lam(i,j,k+1,g))
-              lamfil(i,j,k) = min(1.d0/3.d0, max(1.d-25, lamfil(i,j,k)))
+              lamfil(i,j,k) = min(1.e0_rt/3.e0_rt, max(1.e-25_rt, lamfil(i,j,k)))
            end do
         end do
      end do
 
-     if (Er(reg_l1,reg_l2,reg_l3-1,g) .eq. -1.d0) then
+     if (Er(reg_l1,reg_l2,reg_l3-1,g) .eq. -1.e0_rt) then
         k = reg_l3
         do j=reg_l2, reg_h2
            do i=reg_l1, reg_h1
               lamfil(i,j,k) = dot_product(ff1b, lam(i,j,k:k+1,g))
-              lamfil(i,j,k) = min(1.d0/3.d0, max(1.d-25, lamfil(i,j,k)))
+              lamfil(i,j,k) = min(1.e0_rt/3.e0_rt, max(1.e-25_rt, lamfil(i,j,k)))
            end do
         end do
      end if
 
-     if (Er(reg_l1,reg_l2,reg_h3+1,g) .eq. -1.d0) then
+     if (Er(reg_l1,reg_l2,reg_h3+1,g) .eq. -1.e0_rt) then
         k = reg_h3
         do j=reg_l2, reg_h2
            do i=reg_l1, reg_h1
               lamfil(i,j,k) = dot_product(ff1b(1:0:-1), lam(i,j,k-1:k,g))
-              lamfil(i,j,k) = min(1.d0/3.d0, max(1.d-25, lamfil(i,j,k)))
+              lamfil(i,j,k) = min(1.e0_rt/3.e0_rt, max(1.e-25_rt, lamfil(i,j,k)))
            end do
         end do
      end if
@@ -169,8 +170,8 @@ subroutine ca_compute_lamborder(Er, Er_l1, Er_l2, Er_l3, Er_h1, Er_h2, Er_h3, &
 
      do k=lam_l3, lam_h3
         do j=lam_l2, lam_h2
-           if (Er(reg_l1,j,k,g) .eq. -1.d0) then
-              lamfil(:,j,k) = -1.d-50
+           if (Er(reg_l1,j,k,g) .eq. -1.e0_rt) then
+              lamfil(:,j,k) = -1.e-50_rt
               cycle
            end if
 
@@ -180,7 +181,7 @@ subroutine ca_compute_lamborder(Er, Er_l1, Er_l2, Er_l3, Er_h1, Er_h2, Er_h3, &
                    &        + ff2(2,S) * (lam(i-2,j,k,g)+lam(i+2,j,k,g))
            end do
 
-           if (Er(reg_l1-1,j,k,g) .eq. -1.d0) then
+           if (Er(reg_l1-1,j,k,g) .eq. -1.e0_rt) then
               i = reg_l1
               lamfil(i,j,k) = dot_product(ff2b0, lam(i:i+2,j,k,g))
 
@@ -188,7 +189,7 @@ subroutine ca_compute_lamborder(Er, Er_l1, Er_l2, Er_l3, Er_h1, Er_h2, Er_h3, &
               lamfil(i,j,k) = dot_product(ff2b1, lam(i-1:i+2,j,k,g))
            end if
 
-           if (Er(reg_h1+1,j,k,g) .eq. -1.d0) then
+           if (Er(reg_h1+1,j,k,g) .eq. -1.e0_rt) then
               i = reg_h1 - 1
               lamfil(i,j,k) = dot_product(ff2b1(2:-1:-1), lam(i-2:i+1,j,k,g))
 
@@ -199,7 +200,7 @@ subroutine ca_compute_lamborder(Er, Er_l1, Er_l2, Er_l3, Er_h1, Er_h2, Er_h3, &
      end do
 
      do k=lam_l3, lam_h3
-        if (Er(reg_l1,reg_l2,k,g) .eq. -1.d0) then
+        if (Er(reg_l1,reg_l2,k,g) .eq. -1.e0_rt) then
            cycle
         end if
 
@@ -211,7 +212,7 @@ subroutine ca_compute_lamborder(Er, Er_l1, Er_l2, Er_l3, Er_h1, Er_h2, Er_h3, &
            end do
         end do
 
-        if (Er(reg_l1,reg_l2-1,k,g) .eq. -1.d0) then
+        if (Er(reg_l1,reg_l2-1,k,g) .eq. -1.e0_rt) then
            j = reg_l2
            do i=reg_l1,reg_h1
               lam(i,j,k,g) = dot_product(ff2b0, lamfil(i,j:j+2,k))
@@ -223,7 +224,7 @@ subroutine ca_compute_lamborder(Er, Er_l1, Er_l2, Er_l3, Er_h1, Er_h2, Er_h3, &
            end do
         end if
 
-        if (Er(reg_l1,reg_h2+1,k,g) .eq. -1.d0) then
+        if (Er(reg_l1,reg_h2+1,k,g) .eq. -1.e0_rt) then
            j = reg_h2 - 1
            do i=reg_l1,reg_h1
               lam(i,j,k,g) = dot_product(ff2b1(2:-1:-1), lamfil(i,j-2:j+1,k))
@@ -242,17 +243,17 @@ subroutine ca_compute_lamborder(Er, Er_l1, Er_l2, Er_l3, Er_h1, Er_h2, Er_h3, &
               lamfil(i,j,k) = ff2(0,S) * lam(i,j,k,g) &
                    &        + ff2(1,S) * (lam(i,j,k-1,g)+lam(i,j,k+1,g)) &
                    &        + ff2(2,S) * (lam(i,j,k-2,g)+lam(i,j,k+2,g))
-              lamfil(i,j,k) = min(1.d0/3.d0, max(1.d-25, lamfil(i,j,k)))
+              lamfil(i,j,k) = min(1.e0_rt/3.e0_rt, max(1.e-25_rt, lamfil(i,j,k)))
            end do
         end do
      end do
 
-     if (Er(reg_l1,reg_l2,reg_l3-1,g) .eq. -1.d0) then
+     if (Er(reg_l1,reg_l2,reg_l3-1,g) .eq. -1.e0_rt) then
         k = reg_l3
         do j=reg_l2, reg_h2
            do i=reg_l1, reg_h1
               lamfil(i,j,k) = dot_product(ff2b0, lam(i,j,k:k+2,g))
-              lamfil(i,j,k) = min(1.d0/3.d0, max(1.d-25, lamfil(i,j,k)))
+              lamfil(i,j,k) = min(1.e0_rt/3.e0_rt, max(1.e-25_rt, lamfil(i,j,k)))
            end do
         end do
 
@@ -260,17 +261,17 @@ subroutine ca_compute_lamborder(Er, Er_l1, Er_l2, Er_l3, Er_h1, Er_h2, Er_h3, &
         do j=reg_l2, reg_h2
            do i=reg_l1, reg_h1
               lamfil(i,j,k) = dot_product(ff2b1, lam(i,j,k-1:k+2,g))
-              lamfil(i,j,k) = min(1.d0/3.d0, max(1.d-25, lamfil(i,j,k)))
+              lamfil(i,j,k) = min(1.e0_rt/3.e0_rt, max(1.e-25_rt, lamfil(i,j,k)))
            end do
         end do
      end if
 
-     if (Er(reg_l1,reg_l2,reg_h3+1,g) .eq. -1.d0) then
+     if (Er(reg_l1,reg_l2,reg_h3+1,g) .eq. -1.e0_rt) then
         k = reg_h3 - 1
         do j=reg_l2, reg_h2
            do i=reg_l1, reg_h1
               lamfil(i,j,k) = dot_product(ff2b1(2:-1:-1), lam(i,j,k-2:k+1,g))
-              lamfil(i,j,k) = min(1.d0/3.d0, max(1.d-25, lamfil(i,j,k)))
+              lamfil(i,j,k) = min(1.e0_rt/3.e0_rt, max(1.e-25_rt, lamfil(i,j,k)))
            end do
         end do
 
@@ -278,7 +279,7 @@ subroutine ca_compute_lamborder(Er, Er_l1, Er_l2, Er_l3, Er_h1, Er_h2, Er_h3, &
         do j=reg_l2, reg_h2
            do i=reg_l1, reg_h1
               lamfil(i,j,k) = dot_product(ff2b0(2:0:-1), lam(i,j,k-2:k,g))
-              lamfil(i,j,k) = min(1.d0/3.d0, max(1.d-25, lamfil(i,j,k)))
+              lamfil(i,j,k) = min(1.e0_rt/3.e0_rt, max(1.e-25_rt, lamfil(i,j,k)))
            end do
         end do
      end if
@@ -290,8 +291,8 @@ subroutine ca_compute_lamborder(Er, Er_l1, Er_l2, Er_l3, Er_h1, Er_h2, Er_h3, &
 
      do k=lam_l3, lam_h3
         do j=lam_l2, lam_h2
-           if (Er(reg_l1,j,k,g) .eq. -1.d0) then
-              lamfil(:,j,k) = -1.d-50
+           if (Er(reg_l1,j,k,g) .eq. -1.e0_rt) then
+              lamfil(:,j,k) = -1.e-50_rt
               cycle
            end if
 
@@ -302,7 +303,7 @@ subroutine ca_compute_lamborder(Er, Er_l1, Er_l2, Er_l3, Er_h1, Er_h2, Er_h3, &
                    &        + ff3(3,S) * (lam(i-3,j,k,g)+lam(i+3,j,k,g))
            end do
 
-           if (Er(reg_l1-1,j,k,g) .eq. -1.d0) then
+           if (Er(reg_l1-1,j,k,g) .eq. -1.e0_rt) then
               i = reg_l1
               lamfil(i,j,k) = dot_product(ff3b0, lam(i:i+3,j,k,g))
 
@@ -313,7 +314,7 @@ subroutine ca_compute_lamborder(Er, Er_l1, Er_l2, Er_l3, Er_h1, Er_h2, Er_h3, &
               lamfil(i,j,k) = dot_product(ff3b2, lam(i-2:i+3,j,k,g))
            end if
 
-           if (Er(reg_h1+1,j,k,g) .eq. -1.d0) then
+           if (Er(reg_h1+1,j,k,g) .eq. -1.e0_rt) then
               i = reg_h1 - 2
               lamfil(i,j,k) = dot_product(ff3b2(3:-2:-1), lam(i-3:i+2,j,k,g))
 
@@ -327,7 +328,7 @@ subroutine ca_compute_lamborder(Er, Er_l1, Er_l2, Er_l3, Er_h1, Er_h2, Er_h3, &
      end do
 
      do k=lam_l3, lam_h3
-        if (Er(reg_l1,reg_l2,k,g) .eq. -1.d0) then
+        if (Er(reg_l1,reg_l2,k,g) .eq. -1.e0_rt) then
            cycle
         end if
 
@@ -340,7 +341,7 @@ subroutine ca_compute_lamborder(Er, Er_l1, Er_l2, Er_l3, Er_h1, Er_h2, Er_h3, &
            end do
         end do
 
-        if (Er(reg_l1,reg_l2-1,k,g) .eq. -1.d0) then
+        if (Er(reg_l1,reg_l2-1,k,g) .eq. -1.e0_rt) then
            j = reg_l2
            do i=reg_l1,reg_h1
               lam(i,j,k,g) = dot_product(ff3b0, lamfil(i,j:j+3,k))
@@ -357,7 +358,7 @@ subroutine ca_compute_lamborder(Er, Er_l1, Er_l2, Er_l3, Er_h1, Er_h2, Er_h3, &
            end do
         end if
 
-        if (Er(reg_l1,reg_h2+1,k,g) .eq. -1.d0) then
+        if (Er(reg_l1,reg_h2+1,k,g) .eq. -1.e0_rt) then
            j = reg_h2 - 2
            do i=reg_l1,reg_h1
               lam(i,j,k,g) = dot_product(ff3b2(3:-2:-1), lamfil(i,j-3:j+2,k))
@@ -382,17 +383,17 @@ subroutine ca_compute_lamborder(Er, Er_l1, Er_l2, Er_l3, Er_h1, Er_h2, Er_h3, &
                    &        + ff3(1,S) * (lam(i,j,k-1,g)+lam(i,j,k+1,g)) &
                    &        + ff3(2,S) * (lam(i,j,k-2,g)+lam(i,j,k+2,g)) &
                    &        + ff3(3,S) * (lam(i,j,k-3,g)+lam(i,j,k+3,g))
-              lamfil(i,j,k) = min(1.d0/3.d0, max(1.d-25, lamfil(i,j,k)))
+              lamfil(i,j,k) = min(1.e0_rt/3.e0_rt, max(1.e-25_rt, lamfil(i,j,k)))
            end do
         end do
      end do
 
-     if (Er(reg_l1,reg_l2,reg_l3-1,g) .eq. -1.d0) then
+     if (Er(reg_l1,reg_l2,reg_l3-1,g) .eq. -1.e0_rt) then
         k = reg_l3
         do j=reg_l2, reg_h2
            do i=reg_l1, reg_h1
               lamfil(i,j,k) = dot_product(ff3b0, lam(i,j,k:k+3,g))
-              lamfil(i,j,k) = min(1.d0/3.d0, max(1.d-25, lamfil(i,j,k)))
+              lamfil(i,j,k) = min(1.e0_rt/3.e0_rt, max(1.e-25_rt, lamfil(i,j,k)))
            end do
         end do
 
@@ -400,7 +401,7 @@ subroutine ca_compute_lamborder(Er, Er_l1, Er_l2, Er_l3, Er_h1, Er_h2, Er_h3, &
         do j=reg_l2, reg_h2
            do i=reg_l1, reg_h1
               lamfil(i,j,k) = dot_product(ff3b1, lam(i,j,k-1:k+3,g))
-              lamfil(i,j,k) = min(1.d0/3.d0, max(1.d-25, lamfil(i,j,k)))
+              lamfil(i,j,k) = min(1.e0_rt/3.e0_rt, max(1.e-25_rt, lamfil(i,j,k)))
            end do
         end do
 
@@ -408,17 +409,17 @@ subroutine ca_compute_lamborder(Er, Er_l1, Er_l2, Er_l3, Er_h1, Er_h2, Er_h3, &
         do j=reg_l2, reg_h2
            do i=reg_l1, reg_h1
               lamfil(i,j,k) = dot_product(ff3b2, lam(i,j,k-2:k+3,g))
-              lamfil(i,j,k) = min(1.d0/3.d0, max(1.d-25, lamfil(i,j,k)))
+              lamfil(i,j,k) = min(1.e0_rt/3.e0_rt, max(1.e-25_rt, lamfil(i,j,k)))
            end do
         end do
      end if
 
-     if (Er(reg_l1,reg_l2,reg_h3+1,g) .eq. -1.d0) then
+     if (Er(reg_l1,reg_l2,reg_h3+1,g) .eq. -1.e0_rt) then
         k = reg_h3 - 2
         do j=reg_l2, reg_h2
            do i=reg_l1, reg_h1
               lamfil(i,j,k) = dot_product(ff3b2(3:-2:-1), lam(i,j,k-3:k+2,g))
-              lamfil(i,j,k) = min(1.d0/3.d0, max(1.d-25, lamfil(i,j,k)))
+              lamfil(i,j,k) = min(1.e0_rt/3.e0_rt, max(1.e-25_rt, lamfil(i,j,k)))
            end do
         end do
 
@@ -426,7 +427,7 @@ subroutine ca_compute_lamborder(Er, Er_l1, Er_l2, Er_l3, Er_h1, Er_h2, Er_h3, &
         do j=reg_l2, reg_h2
            do i=reg_l1, reg_h1
               lamfil(i,j,k) = dot_product(ff3b1(3:-1:-1), lam(i,j,k-3:k+1,g))
-              lamfil(i,j,k) = min(1.d0/3.d0, max(1.d-25, lamfil(i,j,k)))
+              lamfil(i,j,k) = min(1.e0_rt/3.e0_rt, max(1.e-25_rt, lamfil(i,j,k)))
            end do
         end do
 
@@ -434,7 +435,7 @@ subroutine ca_compute_lamborder(Er, Er_l1, Er_l2, Er_l3, Er_h1, Er_h2, Er_h3, &
         do j=reg_l2, reg_h2
            do i=reg_l1, reg_h1
               lamfil(i,j,k) = dot_product(ff3b0(3:0:-1), lam(i,j,k-3:k,g))
-              lamfil(i,j,k) = min(1.d0/3.d0, max(1.d-25, lamfil(i,j,k)))
+              lamfil(i,j,k) = min(1.e0_rt/3.e0_rt, max(1.e-25_rt, lamfil(i,j,k)))
            end do
         end do
      end if
@@ -446,8 +447,8 @@ subroutine ca_compute_lamborder(Er, Er_l1, Er_l2, Er_l3, Er_h1, Er_h2, Er_h3, &
 
      do k=lam_l3, lam_h3
         do j=lam_l2, lam_h2
-           if (Er(reg_l1,j,k,g) .eq. -1.d0) then
-              lamfil(:,j,k) = -1.d-50
+           if (Er(reg_l1,j,k,g) .eq. -1.e0_rt) then
+              lamfil(:,j,k) = -1.e-50_rt
               cycle
            end if
 
@@ -459,7 +460,7 @@ subroutine ca_compute_lamborder(Er, Er_l1, Er_l2, Er_l3, Er_h1, Er_h2, Er_h3, &
                    &        + ff4(4,S) * (lam(i-4,j,k,g)+lam(i+4,j,k,g))
            end do
 
-           if (Er(reg_l1-1,j,k,g) .eq. -1.d0) then
+           if (Er(reg_l1-1,j,k,g) .eq. -1.e0_rt) then
               i = reg_l1
               lamfil(i,j,k) = dot_product(ff4b0, lam(i:i+4,j,k,g))
 
@@ -473,7 +474,7 @@ subroutine ca_compute_lamborder(Er, Er_l1, Er_l2, Er_l3, Er_h1, Er_h2, Er_h3, &
               lamfil(i,j,k) = dot_product(ff4b3, lam(i-3:i+4,j,k,g))
            end if
 
-           if (Er(reg_h1+1,j,k,g) .eq. -1.d0) then
+           if (Er(reg_h1+1,j,k,g) .eq. -1.e0_rt) then
               i = reg_h1 - 3
               lamfil(i,j,k) = dot_product(ff4b3(4:-3:-1), lam(i-4:i+3,j,k,g))
 
@@ -490,7 +491,7 @@ subroutine ca_compute_lamborder(Er, Er_l1, Er_l2, Er_l3, Er_h1, Er_h2, Er_h3, &
      end do
 
      do k=lam_l3, lam_h3
-        if (Er(reg_l1,reg_l2,k,g) .eq. -1.d0) then
+        if (Er(reg_l1,reg_l2,k,g) .eq. -1.e0_rt) then
            cycle
         end if
 
@@ -504,7 +505,7 @@ subroutine ca_compute_lamborder(Er, Er_l1, Er_l2, Er_l3, Er_h1, Er_h2, Er_h3, &
            end do
         end do
 
-        if (Er(reg_l1,reg_l2-1,k,g) .eq. -1.d0) then
+        if (Er(reg_l1,reg_l2-1,k,g) .eq. -1.e0_rt) then
            j = reg_l2
            do i=reg_l1,reg_h1
               lam(i,j,k,g) = dot_product(ff4b0, lamfil(i,j:j+4,k))
@@ -526,7 +527,7 @@ subroutine ca_compute_lamborder(Er, Er_l1, Er_l2, Er_l3, Er_h1, Er_h2, Er_h3, &
            end do
         end if
 
-        if (Er(reg_l1,reg_h2+1,k,g) .eq. -1.d0) then
+        if (Er(reg_l1,reg_h2+1,k,g) .eq. -1.e0_rt) then
            j = reg_h2 - 3
            do i=reg_l1,reg_h1
               lam(i,j,k,g) = dot_product(ff4b3(4:-3:-1), lamfil(i,j-4:j+3,k))
@@ -557,17 +558,17 @@ subroutine ca_compute_lamborder(Er, Er_l1, Er_l2, Er_l3, Er_h1, Er_h2, Er_h3, &
                    &        + ff4(2,S) * (lam(i,j,k-2,g)+lam(i,j,k+2,g)) &
                    &        + ff4(3,S) * (lam(i,j,k-3,g)+lam(i,j,k+3,g)) &
                    &        + ff4(4,S) * (lam(i,j,k-4,g)+lam(i,j,k+4,g))
-              lamfil(i,j,k) = min(1.d0/3.d0, max(1.d-25, lamfil(i,j,k)))
+              lamfil(i,j,k) = min(1.e0_rt/3.e0_rt, max(1.e-25_rt, lamfil(i,j,k)))
            end do
         end do
      end do
 
-     if (Er(reg_l1,reg_l2,reg_l3-1,g) .eq. -1.d0) then
+     if (Er(reg_l1,reg_l2,reg_l3-1,g) .eq. -1.e0_rt) then
         k = reg_l3
         do j=reg_l2, reg_h2
            do i=reg_l1, reg_h1
               lamfil(i,j,k) = dot_product(ff4b0, lam(i,j,k:k+4,g))
-              lamfil(i,j,k) = min(1.d0/3.d0, max(1.d-25, lamfil(i,j,k)))
+              lamfil(i,j,k) = min(1.e0_rt/3.e0_rt, max(1.e-25_rt, lamfil(i,j,k)))
            end do
         end do
 
@@ -575,7 +576,7 @@ subroutine ca_compute_lamborder(Er, Er_l1, Er_l2, Er_l3, Er_h1, Er_h2, Er_h3, &
         do j=reg_l2, reg_h2
            do i=reg_l1, reg_h1
               lamfil(i,j,k) = dot_product(ff4b1, lam(i,j,k-1:k+4,g))
-              lamfil(i,j,k) = min(1.d0/3.d0, max(1.d-25, lamfil(i,j,k)))
+              lamfil(i,j,k) = min(1.e0_rt/3.e0_rt, max(1.e-25_rt, lamfil(i,j,k)))
            end do
         end do
 
@@ -583,7 +584,7 @@ subroutine ca_compute_lamborder(Er, Er_l1, Er_l2, Er_l3, Er_h1, Er_h2, Er_h3, &
         do j=reg_l2, reg_h2
            do i=reg_l1, reg_h1
               lamfil(i,j,k) = dot_product(ff4b2, lam(i,j,k-2:k+4,g))
-              lamfil(i,j,k) = min(1.d0/3.d0, max(1.d-25, lamfil(i,j,k)))
+              lamfil(i,j,k) = min(1.e0_rt/3.e0_rt, max(1.e-25_rt, lamfil(i,j,k)))
            end do
         end do
 
@@ -591,17 +592,17 @@ subroutine ca_compute_lamborder(Er, Er_l1, Er_l2, Er_l3, Er_h1, Er_h2, Er_h3, &
         do j=reg_l2, reg_h2
            do i=reg_l1, reg_h1
               lamfil(i,j,k) = dot_product(ff4b3, lam(i,j,k-3:k+4,g))
-              lamfil(i,j,k) = min(1.d0/3.d0, max(1.d-25, lamfil(i,j,k)))
+              lamfil(i,j,k) = min(1.e0_rt/3.e0_rt, max(1.e-25_rt, lamfil(i,j,k)))
            end do
         end do
      end if
 
-     if (Er(reg_l1,reg_l2,reg_h3+1,g) .eq. -1.d0) then
+     if (Er(reg_l1,reg_l2,reg_h3+1,g) .eq. -1.e0_rt) then
         k = reg_h3 - 3
         do j=reg_l2, reg_h2
            do i=reg_l1, reg_h1
               lamfil(i,j,k) = dot_product(ff4b3(4:-3:-1), lam(i,j,k-4:k+3,g))
-              lamfil(i,j,k) = min(1.d0/3.d0, max(1.d-25, lamfil(i,j,k)))
+              lamfil(i,j,k) = min(1.e0_rt/3.e0_rt, max(1.e-25_rt, lamfil(i,j,k)))
            end do
         end do
 
@@ -609,7 +610,7 @@ subroutine ca_compute_lamborder(Er, Er_l1, Er_l2, Er_l3, Er_h1, Er_h2, Er_h3, &
         do j=reg_l2, reg_h2
            do i=reg_l1, reg_h1
               lamfil(i,j,k) = dot_product(ff4b2(4:-2:-1), lam(i,j,k-4:k+2,g))
-              lamfil(i,j,k) = min(1.d0/3.d0, max(1.d-25, lamfil(i,j,k)))
+              lamfil(i,j,k) = min(1.e0_rt/3.e0_rt, max(1.e-25_rt, lamfil(i,j,k)))
            end do
         end do
 
@@ -617,7 +618,7 @@ subroutine ca_compute_lamborder(Er, Er_l1, Er_l2, Er_l3, Er_h1, Er_h2, Er_h3, &
         do j=reg_l2, reg_h2
            do i=reg_l1, reg_h1
               lamfil(i,j,k) = dot_product(ff4b1(4:-1:-1), lam(i,j,k-4:k+1,g))
-              lamfil(i,j,k) = min(1.d0/3.d0, max(1.d-25, lamfil(i,j,k)))
+              lamfil(i,j,k) = min(1.e0_rt/3.e0_rt, max(1.e-25_rt, lamfil(i,j,k)))
            end do
         end do
 
@@ -625,7 +626,7 @@ subroutine ca_compute_lamborder(Er, Er_l1, Er_l2, Er_l3, Er_h1, Er_h2, Er_h3, &
         do j=reg_l2, reg_h2
            do i=reg_l1, reg_h1
               lamfil(i,j,k) = dot_product(ff4b0(4:0:-1), lam(i,j,k-4:k,g))
-              lamfil(i,j,k) = min(1.d0/3.d0, max(1.d-25, lamfil(i,j,k)))
+              lamfil(i,j,k) = min(1.e0_rt/3.e0_rt, max(1.e-25_rt, lamfil(i,j,k)))
            end do
         end do
      end if
@@ -639,7 +640,7 @@ subroutine ca_compute_lamborder(Er, Er_l1, Er_l2, Er_l3, Er_h1, Er_h2, Er_h3, &
   do k=lam_l3,reg_l3-1
      do j=lam_l2,reg_l2-1
         do i=lam_l1,reg_l1-1
-           if (Er(i,j,k,g).eq.-1.d0) then
+           if (Er(i,j,k,g).eq.-1.e0_rt) then
               lam(i,j,k,g) = lam(reg_l1,reg_l2,reg_l3,g)
            end if
         end do
@@ -650,7 +651,7 @@ subroutine ca_compute_lamborder(Er, Er_l1, Er_l2, Er_l3, Er_h1, Er_h2, Er_h3, &
   do k=lam_l3,reg_l3-1
      do j=lam_l2,reg_l2-1
         do i=reg_l1,reg_h1
-           if (Er(i,j,k,g).eq.-1.d0) then
+           if (Er(i,j,k,g).eq.-1.e0_rt) then
               lam(i,j,k,g) = lam(i,reg_l2,reg_l3,g)
            end if
         end do
@@ -661,7 +662,7 @@ subroutine ca_compute_lamborder(Er, Er_l1, Er_l2, Er_l3, Er_h1, Er_h2, Er_h3, &
   do k=lam_l3,reg_l3-1
      do j=lam_l2,reg_l2-1
         do i=reg_h1+1,lam_h1
-           if (Er(i,j,k,g).eq.-1.d0) then
+           if (Er(i,j,k,g).eq.-1.e0_rt) then
               lam(i,j,k,g) = lam(reg_h1,reg_l2,reg_l3,g)
            end if
         end do
@@ -681,7 +682,7 @@ subroutine ca_compute_lamborder(Er, Er_l1, Er_l2, Er_l3, Er_h1, Er_h2, Er_h3, &
   do k=lam_l3,reg_l3-1
      do j=reg_l2,reg_h2
         do i=reg_l1,reg_h1
-           if (Er(i,j,k,g).eq.-1.d0) then
+           if (Er(i,j,k,g).eq.-1.e0_rt) then
               lam(i,j,k,g) = lam(i,j,reg_l3,g)
            end if
         end do
@@ -701,7 +702,7 @@ subroutine ca_compute_lamborder(Er, Er_l1, Er_l2, Er_l3, Er_h1, Er_h2, Er_h3, &
   do k=lam_l3,reg_l3-1
      do j=reg_h2+1,lam_h2
         do i=lam_l1,reg_l1-1
-           if (Er(i,j,k,g).eq.-1.d0) then
+           if (Er(i,j,k,g).eq.-1.e0_rt) then
               lam(i,j,k,g) = lam(reg_l1,reg_h2,reg_l3,g)
            end if
         end do
@@ -712,7 +713,7 @@ subroutine ca_compute_lamborder(Er, Er_l1, Er_l2, Er_l3, Er_h1, Er_h2, Er_h3, &
   do k=lam_l3,reg_l3-1
      do j=reg_h2+1,lam_h2
         do i=reg_l1,reg_h1
-           if (Er(i,j,k,g).eq.-1.d0) then
+           if (Er(i,j,k,g).eq.-1.e0_rt) then
               lam(i,j,k,g) = lam(i,reg_h2,reg_l3,g)
            end if
         end do
@@ -723,7 +724,7 @@ subroutine ca_compute_lamborder(Er, Er_l1, Er_l2, Er_l3, Er_h1, Er_h2, Er_h3, &
   do k=lam_l3,reg_l3-1
      do j=reg_h2+1,lam_h2
         do i=reg_h1+1,lam_h1
-           if (Er(i,j,k,g).eq.-1.d0) then
+           if (Er(i,j,k,g).eq.-1.e0_rt) then
               lam(i,j,k,g) = lam(reg_h1,reg_h2,reg_l3,g)
            end if
         end do
@@ -734,7 +735,7 @@ subroutine ca_compute_lamborder(Er, Er_l1, Er_l2, Er_l3, Er_h1, Er_h2, Er_h3, &
   do k=reg_l3,reg_h3
      do j=lam_l2,reg_l2-1
         do i=lam_l1,reg_l1-1
-           if (Er(i,j,k,g).eq.-1.d0) then
+           if (Er(i,j,k,g).eq.-1.e0_rt) then
               lam(i,j,k,g) = lam(reg_l1,reg_l2,k,g)
            end if
         end do
@@ -745,7 +746,7 @@ subroutine ca_compute_lamborder(Er, Er_l1, Er_l2, Er_l3, Er_h1, Er_h2, Er_h3, &
   do k=reg_l3,reg_h3
      do j=lam_l2,reg_l2-1
         do i=reg_l1,reg_h1
-           if (Er(i,j,k,g).eq.-1.d0) then
+           if (Er(i,j,k,g).eq.-1.e0_rt) then
               lam(i,j,k,g) = lam(i,reg_l2,k,g)
            end if
         end do
@@ -756,7 +757,7 @@ subroutine ca_compute_lamborder(Er, Er_l1, Er_l2, Er_l3, Er_h1, Er_h2, Er_h3, &
   do k=reg_l3,reg_h3
      do j=lam_l2,reg_l2-1
         do i=reg_h1+1,lam_h1
-           if (Er(i,j,k,g).eq.-1.d0) then
+           if (Er(i,j,k,g).eq.-1.e0_rt) then
               lam(i,j,k,g) = lam(reg_h1,reg_l2,k,g)
            end if
         end do
@@ -767,7 +768,7 @@ subroutine ca_compute_lamborder(Er, Er_l1, Er_l2, Er_l3, Er_h1, Er_h2, Er_h3, &
   do k=reg_l3,reg_h3
      do j=reg_l2,reg_h2
         do i=lam_l1,reg_l1-1
-           if (Er(i,j,k,g).eq.-1.d0) then
+           if (Er(i,j,k,g).eq.-1.e0_rt) then
               lam(i,j,k,g) = lam(reg_l1,j,k,g)
            end if
         end do
@@ -778,7 +779,7 @@ subroutine ca_compute_lamborder(Er, Er_l1, Er_l2, Er_l3, Er_h1, Er_h2, Er_h3, &
   do k=reg_l3,reg_h3
      do j=reg_l2,reg_h2
         do i=reg_h1+1,lam_h1
-           if (Er(i,j,k,g).eq.-1.d0) then
+           if (Er(i,j,k,g).eq.-1.e0_rt) then
               lam(i,j,k,g) = lam(reg_h1,j,k,g)
            end if
         end do
@@ -789,7 +790,7 @@ subroutine ca_compute_lamborder(Er, Er_l1, Er_l2, Er_l3, Er_h1, Er_h2, Er_h3, &
   do k=reg_l3,reg_h3
      do j=reg_h2+1,lam_h2
         do i=lam_l1,reg_l1-1
-           if (Er(i,j,k,g).eq.-1.d0) then
+           if (Er(i,j,k,g).eq.-1.e0_rt) then
               lam(i,j,k,g) = lam(reg_l1,reg_h2,k,g)
            end if
         end do
@@ -800,7 +801,7 @@ subroutine ca_compute_lamborder(Er, Er_l1, Er_l2, Er_l3, Er_h1, Er_h2, Er_h3, &
   do k=reg_l3,reg_h3
      do j=reg_h2+1,lam_h2
         do i=reg_l1,reg_h1
-           if (Er(i,j,k,g).eq.-1.d0) then
+           if (Er(i,j,k,g).eq.-1.e0_rt) then
               lam(i,j,k,g) = lam(i,reg_h2,k,g)
            end if
         end do
@@ -811,7 +812,7 @@ subroutine ca_compute_lamborder(Er, Er_l1, Er_l2, Er_l3, Er_h1, Er_h2, Er_h3, &
   do k=reg_l3,reg_h3
      do j=reg_h2+1,lam_h2
         do i=reg_h1+1,lam_h1
-           if (Er(i,j,k,g).eq.-1.d0) then
+           if (Er(i,j,k,g).eq.-1.e0_rt) then
               lam(i,j,k,g) = lam(reg_h1,reg_h2,k,g)
            end if
         end do
@@ -822,7 +823,7 @@ subroutine ca_compute_lamborder(Er, Er_l1, Er_l2, Er_l3, Er_h1, Er_h2, Er_h3, &
   do k=reg_h3+1,lam_h3
      do j=lam_l2,reg_l2-1
         do i=lam_l1,reg_l1-1
-           if (Er(i,j,k,g).eq.-1.d0) then
+           if (Er(i,j,k,g).eq.-1.e0_rt) then
               lam(i,j,k,g) = lam(reg_l1,reg_l2,reg_h3,g)
            end if
         end do
@@ -833,7 +834,7 @@ subroutine ca_compute_lamborder(Er, Er_l1, Er_l2, Er_l3, Er_h1, Er_h2, Er_h3, &
   do k=reg_h3+1,lam_h3
      do j=lam_l2,reg_l2-1
         do i=reg_l1,reg_h1
-           if (Er(i,j,k,g).eq.-1.d0) then
+           if (Er(i,j,k,g).eq.-1.e0_rt) then
               lam(i,j,k,g) = lam(i,reg_l2,reg_h3,g)
            end if
         end do
@@ -844,7 +845,7 @@ subroutine ca_compute_lamborder(Er, Er_l1, Er_l2, Er_l3, Er_h1, Er_h2, Er_h3, &
   do k=reg_h3+1,lam_h3
      do j=lam_l2,reg_l2-1
         do i=reg_h1+1,lam_h1
-           if (Er(i,j,k,g).eq.-1.d0) then
+           if (Er(i,j,k,g).eq.-1.e0_rt) then
               lam(i,j,k,g) = lam(reg_h1,reg_l2,reg_h3,g)
            end if
         end do
@@ -864,7 +865,7 @@ subroutine ca_compute_lamborder(Er, Er_l1, Er_l2, Er_l3, Er_h1, Er_h2, Er_h3, &
   do k=reg_h3+1,lam_h3
      do j=reg_l2,reg_h2
         do i=reg_l1,reg_h1
-           if (Er(i,j,k,g).eq.-1.d0) then
+           if (Er(i,j,k,g).eq.-1.e0_rt) then
               lam(i,j,k,g) = lam(i,j,reg_h3,g)
            end if
         end do
@@ -884,7 +885,7 @@ subroutine ca_compute_lamborder(Er, Er_l1, Er_l2, Er_l3, Er_h1, Er_h2, Er_h3, &
   do k=reg_h3+1,lam_h3
      do j=reg_h2+1,lam_h2
         do i=lam_l1,reg_l1-1
-           if (Er(i,j,k,g).eq.-1.d0) then
+           if (Er(i,j,k,g).eq.-1.e0_rt) then
               lam(i,j,k,g) = lam(reg_l1,reg_h2,reg_h3,g)
            end if
         end do
@@ -895,7 +896,7 @@ subroutine ca_compute_lamborder(Er, Er_l1, Er_l2, Er_l3, Er_h1, Er_h2, Er_h3, &
   do k=reg_h3+1,lam_h3
      do j=reg_h2+1,lam_h2
         do i=reg_l1,reg_h1
-           if (Er(i,j,k,g).eq.-1.d0) then
+           if (Er(i,j,k,g).eq.-1.e0_rt) then
               lam(i,j,k,g) = lam(i,reg_h2,reg_h3,g)
            end if
         end do
@@ -906,7 +907,7 @@ subroutine ca_compute_lamborder(Er, Er_l1, Er_l2, Er_l3, Er_h1, Er_h2, Er_h3, &
   do k=reg_h3+1,lam_h3
      do j=reg_h2+1,lam_h2
         do i=reg_h1+1,lam_h1
-           if (Er(i,j,k,g).eq.-1.d0) then
+           if (Er(i,j,k,g).eq.-1.e0_rt) then
               lam(i,j,k,g) = lam(reg_h1,reg_h2,reg_h3,g)
            end if
         end do
@@ -937,6 +938,7 @@ subroutine ca_get_v_dcf(lo, hi, &
 
   use meth_params_module, only : NVAR, URHO, UMX, UMY, UMZ
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: lo(3), hi(3)
@@ -949,21 +951,21 @@ subroutine ca_get_v_dcf(lo, hi, &
   integer, intent(in) :: kp2_l1,kp2_l2,kp2_l3,kp2_h1,kp2_h2,kp2_h3
   integer, intent(in) :: v_l1,v_l2,v_l3,v_h1,v_h2,v_h3
   integer, intent(in) :: dcf_l1,dcf_l2,dcf_l3,dcf_h1,dcf_h2,dcf_h3
-  double precision, intent(in)  ::  er( er_l1: er_h1,  er_l2: er_h2,  er_l3: er_h3)
-  double precision, intent(in)  ::   s(  s_l1:  s_h1,   s_l2:  s_h2,   s_l3:  s_h3, NVAR)
-  double precision, intent(in)  ::   T(  T_l1:  T_h1,   T_l2:  T_h2,   T_l3:  T_h3)
-  double precision, intent(in)  :: c_v(c_v_l1:c_v_h1, c_v_l2:c_v_h2, c_v_l3:c_v_h3)
-  double precision, intent(in ) ::  kr( kr_l1: kr_h1,  kr_l2: kr_h2,  kr_l3: kr_h3)
-  double precision, intent(in ) ::  kp( kp_l1: kp_h1,  kp_l2: kp_h2,  kp_l3: kp_h3)
-  double precision, intent(in ) :: kp2(kp2_l1:kp2_h1, kp2_l2:kp2_h2, kp2_l3:kp2_h3)
-  double precision, intent(in) :: dtemp, dtime, sigma, c
-  double precision              ::   v(  v_l1:  v_h1,   v_l2:  v_h2,   v_l3:  v_h3, 3)
-  double precision              :: dcf(dcf_l1:dcf_h1, dcf_l2:dcf_h2, dcf_l3:dcf_h3)
+  real(rt)        , intent(in)  ::  er( er_l1: er_h1,  er_l2: er_h2,  er_l3: er_h3)
+  real(rt)        , intent(in)  ::   s(  s_l1:  s_h1,   s_l2:  s_h2,   s_l3:  s_h3, NVAR)
+  real(rt)        , intent(in)  ::   T(  T_l1:  T_h1,   T_l2:  T_h2,   T_l3:  T_h3)
+  real(rt)        , intent(in)  :: c_v(c_v_l1:c_v_h1, c_v_l2:c_v_h2, c_v_l3:c_v_h3)
+  real(rt)        , intent(in ) ::  kr( kr_l1: kr_h1,  kr_l2: kr_h2,  kr_l3: kr_h3)
+  real(rt)        , intent(in ) ::  kp( kp_l1: kp_h1,  kp_l2: kp_h2,  kp_l3: kp_h3)
+  real(rt)        , intent(in ) :: kp2(kp2_l1:kp2_h1, kp2_l2:kp2_h2, kp2_l3:kp2_h3)
+  real(rt)        , intent(in) :: dtemp, dtime, sigma, c
+  real(rt)                      ::   v(  v_l1:  v_h1,   v_l2:  v_h2,   v_l3:  v_h3, 3)
+  real(rt)                      :: dcf(dcf_l1:dcf_h1, dcf_l2:dcf_h2, dcf_l3:dcf_h3)
 
   integer :: i, j, k
-  double precision :: etainv, fac0, fac2, alpha, frc
+  real(rt)         :: etainv, fac0, fac2, alpha, frc
 
-  fac0 = 4.d0 * sigma * dtime / dtemp
+  fac0 = 4.e0_rt * sigma * dtime / dtemp
   fac2 = c * dtime / dtemp
 
   do k=lo(3),hi(3)
@@ -977,10 +979,10 @@ subroutine ca_get_v_dcf(lo, hi, &
                 -          kp (i,j,k) * (T(i,j,k)        ) ** 4)   &
                 -  fac2 * (kp2(i,j,k) - kp(i,j,k)) * er(i,j,k)
 
-           frc = s(i,j,k,URHO) * c_v(i,j,k) + 1.0d-50
+           frc = s(i,j,k,URHO) * c_v(i,j,k) + 1.0e-50_rt
            etainv = frc / (alpha + frc)
 
-           dcf(i,j,k) = 2.d0 * etainv * (kp(i,j,k) / kr(i,j,k))
+           dcf(i,j,k) = 2.e0_rt * etainv * (kp(i,j,k) / kr(i,j,k))
         end do
      end do
   end do
@@ -995,6 +997,7 @@ subroutine ca_compute_dcoefs(lo, hi, &
                              dcf, dcf_l1, dcf_l2, dcf_l3, dcf_h1, dcf_h2, dcf_h3, &
                              r, idir)
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: lo(3), hi(3)
@@ -1004,11 +1007,11 @@ subroutine ca_compute_dcoefs(lo, hi, &
        & dcf_l1, dcf_l2, dcf_l3, dcf_h1, dcf_h2, dcf_h3, &
        idir
 
-  double precision              ::   d(  d_l1:  d_h1,   d_l2:  d_h2,   d_l3:  d_h3)
-  double precision, intent(in)  :: lam(lam_l1:lam_h1, lam_l2:lam_h2, lam_l3:lam_h3)
-  double precision, intent(in)  ::   v(  v_l1:  v_h1,   v_l2:  v_h2,   v_l3:  v_h3, 3)
-  double precision, intent(in)  :: dcf(dcf_l1:dcf_h1, dcf_l2:dcf_h2, dcf_l3:dcf_h3)
-  double precision, intent(in)  ::   r( lo(1): hi(1))
+  real(rt)                      ::   d(  d_l1:  d_h1,   d_l2:  d_h2,   d_l3:  d_h3)
+  real(rt)        , intent(in)  :: lam(lam_l1:lam_h1, lam_l2:lam_h2, lam_l3:lam_h3)
+  real(rt)        , intent(in)  ::   v(  v_l1:  v_h1,   v_l2:  v_h2,   v_l3:  v_h3, 3)
+  real(rt)        , intent(in)  :: dcf(dcf_l1:dcf_h1, dcf_l2:dcf_h2, dcf_l3:dcf_h3)
+  real(rt)        , intent(in)  ::   r( lo(1): hi(1))
 
   integer :: i, j, k
 
@@ -1016,9 +1019,9 @@ subroutine ca_compute_dcoefs(lo, hi, &
      do k = lo(3), hi(3)
         do j = lo(2), hi(2)
            do i = lo(1), hi(1)
-              if (v(i-1,j,k,1) + v(i,j,k,1) .gt. 0.d0) then
+              if (v(i-1,j,k,1) + v(i,j,k,1) .gt. 0.e0_rt) then
                  d(i,j,k) = dcf(i-1,j,k) * v(i-1,j,k,1) * lam(i,j,k)
-              else if (v(i-1,j,k,1) + v(i,j,k,1) .lt. 0.d0) then
+              else if (v(i-1,j,k,1) + v(i,j,k,1) .lt. 0.e0_rt) then
                  d(i,j,k) = dcf(i,j,k) * v(i,j,k,1) * lam(i,j,k)
               else
                  d(i,j,k) = 0.0
@@ -1030,9 +1033,9 @@ subroutine ca_compute_dcoefs(lo, hi, &
      do k = lo(3), hi(3)
         do j = lo(2), hi(2)
            do i = lo(1), hi(1)
-              if (v(i,j-1,k,2) + v(i,j,k,2) .gt. 0.d0) then
+              if (v(i,j-1,k,2) + v(i,j,k,2) .gt. 0.e0_rt) then
                  d(i,j,k) = dcf(i,j-1,k) * v(i,j-1,k,2) * lam(i,j,k)
-              else if (v(i,j-1,k,2) + v(i,j,k,2) .lt. 0.d0) then
+              else if (v(i,j-1,k,2) + v(i,j,k,2) .lt. 0.e0_rt) then
                  d(i,j,k) = dcf(i,j,k) * v(i,j,k,2) * lam(i,j,k)
               else
                  d(i,j,k) = 0.0
@@ -1044,9 +1047,9 @@ subroutine ca_compute_dcoefs(lo, hi, &
      do k = lo(3), hi(3)
         do j = lo(2), hi(2)
            do i = lo(1), hi(1)
-              if (v(i,j,k-1,3) + v(i,j,k,3) .gt. 0.d0) then
+              if (v(i,j,k-1,3) + v(i,j,k,3) .gt. 0.e0_rt) then
                  d(i,j,k) = dcf(i,j,k-1) * v(i,j,k-1,3) * lam(i,j,k)
-              else if (v(i,j,k-1,3) + v(i,j,k,3) .lt. 0.d0) then
+              else if (v(i,j,k-1,3) + v(i,j,k,3) .lt. 0.e0_rt) then
                  d(i,j,k) = dcf(i,j,k) * v(i,j,k,3) * lam(i,j,k)
               else
                  d(i,j,k) = 0.0
@@ -1065,6 +1068,7 @@ subroutine ca_update_dcf(lo, hi, &
                          kp, kp_l1, kp_l2, kp_l3, kp_h1, kp_h2, kp_h3, &
                          kr, kr_l1, kr_l2, kr_l3, kr_h1, kr_h2, kr_h3) bind(C, name="ca_update_dcf")
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: lo(3), hi(3)
@@ -1072,17 +1076,17 @@ subroutine ca_update_dcf(lo, hi, &
   integer, intent(in) :: eti_l1, eti_l2, eti_l3, eti_h1, eti_h2, eti_h3
   integer, intent(in) :: kp_l1, kp_l2, kp_l3, kp_h1, kp_h2, kp_h3
   integer, intent(in) :: kr_l1, kr_l2, kr_l3, kr_h1, kr_h2, kr_h3
-  double precision, intent(in) :: etainv(eti_l1:eti_h1, eti_l2:eti_h2, eti_l3:eti_h3)
-  double precision, intent(in) :: kp(kp_l1:kp_h1, kp_l2:kp_h2, kp_l3:kp_h3)
-  double precision, intent(in) :: kr(kr_l1:kr_h1, kr_l2:kr_h2, kr_l3:kr_h3)
-  double precision             :: dcf(dcf_l1:dcf_h1, dcf_l2:dcf_h2, dcf_l3:dcf_h3)
+  real(rt)        , intent(in) :: etainv(eti_l1:eti_h1, eti_l2:eti_h2, eti_l3:eti_h3)
+  real(rt)        , intent(in) :: kp(kp_l1:kp_h1, kp_l2:kp_h2, kp_l3:kp_h3)
+  real(rt)        , intent(in) :: kr(kr_l1:kr_h1, kr_l2:kr_h2, kr_l3:kr_h3)
+  real(rt)                     :: dcf(dcf_l1:dcf_h1, dcf_l2:dcf_h2, dcf_l3:dcf_h3)
 
   integer :: i, j, k
 
   do k = lo(3), hi(3)
      do j = lo(2), hi(2)
         do i = lo(1), hi(1)
-           dcf(i,j,k) = 2.d0 * etainv(i,j,k) * (kp(i,j,k)/kr(i,j,k))
+           dcf(i,j,k) = 2.e0_rt * etainv(i,j,k) * (kp(i,j,k)/kr(i,j,k))
         end do
      end do
   end do
@@ -1094,16 +1098,17 @@ subroutine ca_set_dterm_face(lo, hi, &
                              Er, Er_l1, Er_l2, Er_l3, Er_h1, Er_h2, Er_h3, &
                              dc, dc_l1, dc_l2, dc_l3, dc_h1, dc_h2, dc_h3, &
                              dtf, dtf_l1, dtf_l2, dtf_l3, dtf_h1, dtf_h2, dtf_h3, dx, idir)
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: Er_l1, Er_l2, Er_l3, Er_h1, Er_h2, Er_h3, &
        dc_l1, dc_l2, dc_l3, dc_h1, dc_h2, dc_h3, &
        dtf_l1, dtf_l2, dtf_l3, dtf_h1, dtf_h2, dtf_h3, idir
   integer, intent(in) :: lo(3), hi(3)
-  double precision, intent(in) :: dx(3)
-  double precision, intent(in) :: Er(Er_l1:Er_h1,Er_l2:Er_h2,Er_l3:Er_h3)
-  double precision, intent(in) :: dc(dc_l1:dc_h1,dc_l2:dc_h2,dc_l3:dc_h3)
-  double precision             :: dtf(dtf_l1:dtf_h1,dtf_l2:dtf_h2,dtf_l3:dtf_h3)
+  real(rt)        , intent(in) :: dx(3)
+  real(rt)        , intent(in) :: Er(Er_l1:Er_h1,Er_l2:Er_h2,Er_l3:Er_h3)
+  real(rt)        , intent(in) :: dc(dc_l1:dc_h1,dc_l2:dc_h2,dc_l3:dc_h3)
+  real(rt)                     :: dtf(dtf_l1:dtf_h1,dtf_l2:dtf_h2,dtf_l3:dtf_h3)
   integer :: i, j, k
 
   if (idir .eq. 0) then
@@ -1142,6 +1147,7 @@ subroutine ca_face2center(lo, hi, &
                           fooz, fooz_l1, fooz_l2, fooz_l3, fooz_h1, fooz_h2, fooz_h3, &
                           fooc, fooc_l1, fooc_l2, fooc_l3, fooc_h1, fooc_h2, fooc_h3)
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: lo(3), hi(3), scomp,dcomp,ncomp,nf,nc
@@ -1149,10 +1155,10 @@ subroutine ca_face2center(lo, hi, &
   integer, intent(in) :: fooy_l1, fooy_l2, fooy_l3, fooy_h1, fooy_h2, fooy_h3
   integer, intent(in) :: fooz_l1, fooz_l2, fooz_l3, fooz_h1, fooz_h2, fooz_h3
   integer, intent(in) :: fooc_l1, fooc_l2, fooc_l3, fooc_h1, fooc_h2, fooc_h3
-  double precision, intent(in)  :: foox(foox_l1:foox_h1,foox_l2:foox_h2,foox_l3:foox_h3,0:nf-1)
-  double precision, intent(in)  :: fooy(fooy_l1:fooy_h1,fooy_l2:fooy_h2,fooy_l3:fooy_h3,0:nf-1)
-  double precision, intent(in)  :: fooz(fooz_l1:fooz_h1,fooz_l2:fooz_h2,fooz_l3:fooz_h3,0:nf-1)
-  double precision              :: fooc(fooc_l1:fooc_h1,fooc_l2:fooc_h2,fooc_l3:fooc_h3,0:nc-1)
+  real(rt)        , intent(in)  :: foox(foox_l1:foox_h1,foox_l2:foox_h2,foox_l3:foox_h3,0:nf-1)
+  real(rt)        , intent(in)  :: fooy(fooy_l1:fooy_h1,fooy_l2:fooy_h2,fooy_l3:fooy_h3,0:nf-1)
+  real(rt)        , intent(in)  :: fooz(fooz_l1:fooz_h1,fooz_l2:fooz_h2,fooz_l3:fooz_h3,0:nf-1)
+  real(rt)                      :: fooc(fooc_l1:fooc_h1,fooc_l2:fooc_h2,fooc_l3:fooc_h3,0:nc-1)
 
   integer :: i,j,k,n
 
@@ -1162,7 +1168,7 @@ subroutine ca_face2center(lo, hi, &
            do i = lo(1), hi(1)
               fooc(i,j,k,dcomp+n) = (foox(i,j,k,scomp+n) + foox(i+1,j,k,scomp+n) &
                    &               + fooy(i,j,k,scomp+n) + fooy(i,j+1,k,scomp+n) &
-                   &               + fooz(i,j,k,scomp+n) + fooz(i,j,k+1,scomp+n) ) * (1.d0/6.d0);
+                   &               + fooz(i,j,k,scomp+n) + fooz(i,j,k+1,scomp+n) ) * (1.e0_rt/6.e0_rt);
            end do
         end do
      end do
@@ -1177,15 +1183,16 @@ subroutine ca_correct_dterm(  &
                             dfz, dfz_l1, dfz_l2, dfz_l3, dfz_h1, dfz_h2, dfz_h3, &
                             re, rc)
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: dfx_l1, dfx_l2, dfx_l3, dfx_h1, dfx_h2, dfx_h3
   integer, intent(in) :: dfy_l1, dfy_l2, dfy_l3, dfy_h1, dfy_h2, dfy_h3
   integer, intent(in) :: dfz_l1, dfz_l2, dfz_l3, dfz_h1, dfz_h2, dfz_h3
-  double precision, intent(inout) :: dfx(dfx_l1:dfx_h1,dfx_l2:dfx_h2,dfx_l3:dfx_h3)
-  double precision, intent(inout) :: dfy(dfy_l1:dfy_h1,dfy_l2:dfy_h2,dfy_l3:dfy_h3)
-  double precision, intent(inout) :: dfz(dfz_l1:dfz_h1,dfz_l2:dfz_h2,dfz_l3:dfz_h3)
-  double precision, intent(in) :: re(1), rc(1)
+  real(rt)        , intent(inout) :: dfx(dfx_l1:dfx_h1,dfx_l2:dfx_h2,dfx_l3:dfx_h3)
+  real(rt)        , intent(inout) :: dfy(dfy_l1:dfy_h1,dfy_l2:dfy_h2,dfy_l3:dfy_h3)
+  real(rt)        , intent(inout) :: dfz(dfz_l1:dfz_h1,dfz_l2:dfz_h2,dfz_l3:dfz_h3)
+  real(rt)        , intent(in) :: re(1), rc(1)
 
 end subroutine ca_correct_dterm
 
@@ -1199,16 +1206,17 @@ subroutine ca_estdt_rad(u,u_l1,u_l2,u_l3,u_h1,u_h2,u_h3, &
   use meth_params_module, only : NVAR, URHO, UMX, UMY, UMZ, UEINT, UTEMP, UFS, &
        UFX, allow_negative_energy
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer          :: u_l1,u_l2,u_l3,u_h1,u_h2,u_h3
   integer          :: gpr_l1,gpr_l2,gpr_l3,gpr_h1,gpr_h2,gpr_h3
   integer          :: lo(3), hi(3)
-  double precision :: u(u_l1:u_h1,u_l2:u_h2,u_l3:u_h3,NVAR)
-  double precision :: gpr(gpr_l1:gpr_h1,gpr_l2:gpr_h2,gpr_l3:gpr_h3)
-  double precision :: dx(3), dt
+  real(rt)         :: u(u_l1:u_h1,u_l2:u_h2,u_l3:u_h3,NVAR)
+  real(rt)         :: gpr(gpr_l1:gpr_h1,gpr_l2:gpr_h2,gpr_l3:gpr_h3)
+  real(rt)         :: dx(3), dt
 
-  double precision :: rhoInv,ux,uy,uz,dt1,dt2,dt3,c
+  real(rt)         :: rhoInv,ux,uy,uz,dt1,dt2,dt3,c
   integer          :: i,j,k
   type(eos_t) :: eos_state
 
@@ -1217,7 +1225,7 @@ subroutine ca_estdt_rad(u,u_l1,u_l2,u_l3,u_h1,u_h2,u_h3, &
      do j = lo(2),hi(2)
         do i = lo(1),hi(1)
 
-           rhoInv = 1.d0/u(i,j,k,URHO)
+           rhoInv = 1.e0_rt/u(i,j,k,URHO)
 
            eos_state % rho = u(i,j,k,URHO)
            eos_state % T   = u(i,j,k,UTEMP)
@@ -1226,11 +1234,11 @@ subroutine ca_estdt_rad(u,u_l1,u_l2,u_l3,u_h1,u_h2,u_h3, &
            eos_state % aux = u(i,j,k,UFX:UFX+naux -1) * rhoInv
 
            ! Protect against negative e
-           if (eos_state%e .gt. 0.d0 .or. allow_negative_energy.eq.1) then
+           if (eos_state%e .gt. 0.e0_rt .or. allow_negative_energy.eq.1) then
               call eos(eos_input_re, eos_state)
               c = eos_state % cs
            else
-              c = 0.d0
+              c = 0.e0_rt
            end if
 
            c = sqrt(c**2 + gpr(i,j,k)*rhoInv)
@@ -1257,19 +1265,20 @@ subroutine ca_est_gpr0(Er, Er_l1, Er_l2, Er_l3, Er_h1, Er_h2, Er_h3, &
 
   use rad_params_module, only : ngroups
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: Er_l1, Er_l2, Er_l3, Er_h1, Er_h2, Er_h3
   integer, intent(in) :: gpr_l1, gpr_l2, gpr_l3, gpr_h1, gpr_h2, gpr_h3
-  double precision, intent(in) :: Er(Er_l1:Er_h1,Er_l2:Er_h2,Er_l3:Er_h3, 0:ngroups-1)
-  double precision, intent(out) :: gPr(gPr_l1:gPr_h1,gPr_l2:gPr_h2,gPr_l3:gPr_h3)
+  real(rt)        , intent(in) :: Er(Er_l1:Er_h1,Er_l2:Er_h2,Er_l3:Er_h3, 0:ngroups-1)
+  real(rt)        , intent(out) :: gPr(gPr_l1:gPr_h1,gPr_l2:gPr_h2,gPr_l3:gPr_h3)
 
   integer :: i, j, k, ig
 
   do k = gPr_l3, gPr_h3
      do j = gPr_l2, gPr_h2
         do i = gPr_l1, gPr_h1
-           gPr(i,j,k) = 0.d0
+           gPr(i,j,k) = 0.e0_rt
         end do
      end do
   end do
@@ -1278,7 +1287,7 @@ subroutine ca_est_gpr0(Er, Er_l1, Er_l2, Er_l3, Er_h1, Er_h2, Er_h3, &
      do k = gPr_l3, gPr_h3
         do j = gPr_l2, gPr_h2
            do i = gPr_l1, gPr_h1
-              gPr(i,j,k) = gPr(i,j,k) + 4.d0/9.d0*Er(i,j,k,ig)
+              gPr(i,j,k) = gPr(i,j,k) + 4.e0_rt/9.e0_rt*Er(i,j,k,ig)
            end do
         end do
      end do
@@ -1295,6 +1304,7 @@ subroutine ca_est_gpr2(kap, kap_l1, kap_l2, kap_l3, kap_h1, kap_h2, kap_h3, &
   use rad_params_module, only : ngroups
   use fluxlimiter_module, only : FLDlambda, Edd_factor
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: kap_l1, kap_l2, kap_l3, kap_h1, kap_h2, kap_h3, &
@@ -1302,75 +1312,75 @@ subroutine ca_est_gpr2(kap, kap_l1, kap_l2, kap_l3, kap_h1, kap_h2, kap_h3, &
        gPr_l1, gPr_l2, gPr_l3, gPr_h1, gPr_h2, gPr_h3
   integer, intent(in) :: vlo(3), vhi(3)  ! the region with valid Er
   integer, intent(in) :: limiter, comoving
-  double precision, intent(in) :: dx(3)
-  double precision, intent(in) :: kap(kap_l1:kap_h1,kap_l2:kap_h2,kap_l3:kap_h3,0:ngroups-1), &
+  real(rt)        , intent(in) :: dx(3)
+  real(rt)        , intent(in) :: kap(kap_l1:kap_h1,kap_l2:kap_h2,kap_l3:kap_h3,0:ngroups-1), &
        Er(Er_l1:Er_h1,Er_l2:Er_h2,Er_l3:Er_h3,0:ngroups-1)
-  double precision, intent(out) :: gPr(gPr_l1:gPr_h1,gPr_l2:gPr_h2,gPr_l3:gPr_h3)
+  real(rt)        , intent(out) :: gPr(gPr_l1:gPr_h1,gPr_l2:gPr_h2,gPr_l3:gPr_h3)
 
   integer :: i, j, k, g
-  double precision :: gE(gPr_l1:gPr_h1,gPr_l2:gPr_h2,gPr_l3:gPr_h3)
-  double precision :: lam, gE1, gE2, gE3, r, f, gamr
+  real(rt)         :: gE(gPr_l1:gPr_h1,gPr_l2:gPr_h2,gPr_l3:gPr_h3)
+  real(rt)         :: lam, gE1, gE2, gE3, r, f, gamr
   integer :: im, ip, jm, jp, km, kp
-  double precision :: xm, xp, ym, yp, zm, zp
+  real(rt)         :: xm, xp, ym, yp, zm, zp
 
   if (gPr_l1-1 .ge. vlo(1)) then
      im = 1
-     xm = 2.d0
+     xm = 2.e0_rt
   else
      im = 0
-     xm = 1.d0
+     xm = 1.e0_rt
   end if
 
   if (gPr_h1+1 .le. vhi(1)) then
      ip = 1
-     xp = 2.d0
+     xp = 2.e0_rt
   else
      ip = 0
-     xp = 1.d0
+     xp = 1.e0_rt
   end if
 
   if (gPr_l2-1 .ge. vlo(2)) then
      jm = 1
-     ym = 2.d0
+     ym = 2.e0_rt
   else
      jm = 0
-     ym = 1.d0
+     ym = 1.e0_rt
   end if
 
   if (gPr_h2+1 .le. vhi(2)) then
      jp = 1
-     yp = 2.d0
+     yp = 2.e0_rt
   else
      jp = 0
-     yp = 1.d0
+     yp = 1.e0_rt
   end if
 
   if (gPr_l3-1 .ge. vlo(3)) then
      km = 1
-     zm = 2.d0
+     zm = 2.e0_rt
   else
      km = 0
-     zm = 1.d0
+     zm = 1.e0_rt
   end if
 
   if (gPr_h3+1 .le. vhi(3)) then
      kp = 1
-     zp = 2.d0
+     zp = 2.e0_rt
   else
      kp = 0
-     zp = 1.d0
+     zp = 1.e0_rt
   end if
 
-  gPr = 0.d0
+  gPr = 0.e0_rt
 
   do g = 0, ngroups-1
 
      do k = gPr_l3+1, gPr_h3-1
         do j = gPr_l2+1, gPr_h2-1
            do i = gPr_l1+1, gPr_h1-1
-              gE1 = (Er(i+1,j,k,g) - Er(i-1,j,k,g)) / (2.d0*dx(1))
-              gE2 = (Er(i,j+1,k,g) - Er(i,j-1,k,g)) / (2.d0*dx(2))
-              gE3 = (Er(i,j,k+1,g) - Er(i,j,k-1,g)) / (2.d0*dx(3))
+              gE1 = (Er(i+1,j,k,g) - Er(i-1,j,k,g)) / (2.e0_rt*dx(1))
+              gE2 = (Er(i,j+1,k,g) - Er(i,j-1,k,g)) / (2.e0_rt*dx(2))
+              gE3 = (Er(i,j,k+1,g) - Er(i,j,k-1,g)) / (2.e0_rt*dx(3))
               gE(i,j,k) = sqrt(gE1**2 + gE2**2 + gE3**2)
            end do
         end do
@@ -1389,7 +1399,7 @@ subroutine ca_est_gpr2(kap, kap_l1, kap_l2, kap_l3, kap_h1, kap_h2, kap_h3, &
      j = gPr_l2
      k = gPr_l3
      do i = gPr_l1+1, gPr_h1-1
-        gE1 = (Er(i+1,j,k,g) - Er(i-1,j,k,g)) / (2.d0*dx(1))
+        gE1 = (Er(i+1,j,k,g) - Er(i-1,j,k,g)) / (2.e0_rt*dx(1))
         gE2 = (Er(i,j+1,k,g) - Er(i,j-jm,k,g)) / (ym*dx(2))
         gE3 = (Er(i,j,k+1,g) - Er(i,j,k-km,g)) / (zm*dx(3))
         gE(i,j,k) = sqrt(gE1**2 + gE2**2 + gE3**2)
@@ -1409,7 +1419,7 @@ subroutine ca_est_gpr2(kap, kap_l1, kap_l2, kap_l3, kap_h1, kap_h2, kap_h3, &
      k = gPr_l3
      do j = gPr_l2+1, gPr_h2-1
         gE1 = (Er(i+1,j,k,g) - Er(i-im,j,k,g)) / (xm*dx(1))
-        gE2 = (Er(i,j+1,k,g) - Er(i,j-1,k,g)) / (2.d0*dx(2))
+        gE2 = (Er(i,j+1,k,g) - Er(i,j-1,k,g)) / (2.e0_rt*dx(2))
         gE3 = (Er(i,j,k+1,g) - Er(i,j,k-km,g)) / (zm*dx(3))
         gE(i,j,k) = sqrt(gE1**2 + gE2**2 + gE3**2)
      end do
@@ -1418,8 +1428,8 @@ subroutine ca_est_gpr2(kap, kap_l1, kap_l2, kap_l3, kap_h1, kap_h2, kap_h3, &
      k = gPr_l3
      do j = gPr_l2+1, gPr_h2-1
         do i = gPr_l1+1, gPr_h1-1
-           gE1 = (Er(i+1,j,k,g) - Er(i-1,j,k,g)) / (2.d0*dx(1))
-           gE2 = (Er(i,j+1,k,g) - Er(i,j-1,k,g)) / (2.d0*dx(2))
+           gE1 = (Er(i+1,j,k,g) - Er(i-1,j,k,g)) / (2.e0_rt*dx(1))
+           gE2 = (Er(i,j+1,k,g) - Er(i,j-1,k,g)) / (2.e0_rt*dx(2))
            gE3 = (Er(i,j,k+1,g) - Er(i,j,k-km,g)) / (zm*dx(3))
            gE(i,j,k) = sqrt(gE1**2 + gE2**2 + gE3**2)
         end do
@@ -1430,7 +1440,7 @@ subroutine ca_est_gpr2(kap, kap_l1, kap_l2, kap_l3, kap_h1, kap_h2, kap_h3, &
      k = gPr_l3
      do j = gPr_l2+1, gPr_h2-1
         gE1 = (Er(i+ip,j,k,g) - Er(i-1,j,k,g)) / (xp*dx(1))
-        gE2 = (Er(i,j+1,k,g) - Er(i,j-1,k,g)) / (2.d0*dx(2))
+        gE2 = (Er(i,j+1,k,g) - Er(i,j-1,k,g)) / (2.e0_rt*dx(2))
         gE3 = (Er(i,j,k+1,g) - Er(i,j,k-km,g)) / (zm*dx(3))
         gE(i,j,k) = sqrt(gE1**2 + gE2**2 + gE3**2)
      end do
@@ -1448,7 +1458,7 @@ subroutine ca_est_gpr2(kap, kap_l1, kap_l2, kap_l3, kap_h1, kap_h2, kap_h3, &
      j = gPr_h2
      k = gPr_l3
      do i = gPr_l1+1, gPr_h1-1
-        gE1 = (Er(i+1,j,k,g) - Er(i-1,j,k,g)) / (2.d0*dx(1))
+        gE1 = (Er(i+1,j,k,g) - Er(i-1,j,k,g)) / (2.e0_rt*dx(1))
         gE2 = (Er(i,j+jp,k,g) - Er(i,j-1,k,g)) / (yp*dx(2))
         gE3 = (Er(i,j,k+1,g) - Er(i,j,k-km,g)) / (zm*dx(3))
         gE(i,j,k) = sqrt(gE1**2 + gE2**2 + gE3**2)
@@ -1469,7 +1479,7 @@ subroutine ca_est_gpr2(kap, kap_l1, kap_l2, kap_l3, kap_h1, kap_h2, kap_h3, &
      do k = gPr_l3+1, gPr_h3-1
         gE1 = (Er(i+1,j,k,g) - Er(i-im,j,k,g)) / (xm*dx(1))
         gE2 = (Er(i,j+1,k,g) - Er(i,j-jm,k,g)) / (ym*dx(2))
-        gE3 = (Er(i,j,k+1,g) - Er(i,j,k-1,g)) / (2.d0*dx(3))
+        gE3 = (Er(i,j,k+1,g) - Er(i,j,k-1,g)) / (2.e0_rt*dx(3))
         gE(i,j,k) = sqrt(gE1**2 + gE2**2 + gE3**2)
      end do
 
@@ -1477,9 +1487,9 @@ subroutine ca_est_gpr2(kap, kap_l1, kap_l2, kap_l3, kap_h1, kap_h2, kap_h3, &
      j = gPr_l2
      do k = gPr_l3+1, gPr_h3-1
         do i = gPr_l1+1, gPr_h1-1
-           gE1 = (Er(i+1,j,k,g) - Er(i-1,j,k,g)) / (2.d0*dx(1))
+           gE1 = (Er(i+1,j,k,g) - Er(i-1,j,k,g)) / (2.e0_rt*dx(1))
            gE2 = (Er(i,j+1,k,g) - Er(i,j-jm,k,g)) / (ym*dx(2))
-           gE3 = (Er(i,j,k+1,g) - Er(i,j,k-1,g)) / (2.d0*dx(3))
+           gE3 = (Er(i,j,k+1,g) - Er(i,j,k-1,g)) / (2.e0_rt*dx(3))
            gE(i,j,k) = sqrt(gE1**2 + gE2**2 + gE3**2)
         end do
      end do
@@ -1490,7 +1500,7 @@ subroutine ca_est_gpr2(kap, kap_l1, kap_l2, kap_l3, kap_h1, kap_h2, kap_h3, &
      do k = gPr_l3+1, gPr_h3-1
         gE1 = (Er(i+ip,j,k,g) - Er(i-1,j,k,g)) / (xp*dx(1))
         gE2 = (Er(i,j+1,k,g) - Er(i,j-jm,k,g)) / (ym*dx(2))
-        gE3 = (Er(i,j,k+1,g) - Er(i,j,k-1,g)) / (2.d0*dx(3))
+        gE3 = (Er(i,j,k+1,g) - Er(i,j,k-1,g)) / (2.e0_rt*dx(3))
         gE(i,j,k) = sqrt(gE1**2 + gE2**2 + gE3**2)
      end do
 
@@ -1499,8 +1509,8 @@ subroutine ca_est_gpr2(kap, kap_l1, kap_l2, kap_l3, kap_h1, kap_h2, kap_h3, &
      do k = gPr_l3+1, gPr_h3-1
         do j = gPr_l2+1, gPr_h2-1
            gE1 = (Er(i+1,j,k,g) - Er(i-im,j,k,g)) / (xm*dx(1))
-           gE2 = (Er(i,j+1,k,g) - Er(i,j-1,k,g)) / (2.d0*dx(2))
-           gE3 = (Er(i,j,k+1,g) - Er(i,j,k-1,g)) / (2.d0*dx(3))
+           gE2 = (Er(i,j+1,k,g) - Er(i,j-1,k,g)) / (2.e0_rt*dx(2))
+           gE3 = (Er(i,j,k+1,g) - Er(i,j,k-1,g)) / (2.e0_rt*dx(3))
            gE(i,j,k) = sqrt(gE1**2 + gE2**2 + gE3**2)
         end do
      end do
@@ -1510,8 +1520,8 @@ subroutine ca_est_gpr2(kap, kap_l1, kap_l2, kap_l3, kap_h1, kap_h2, kap_h3, &
      do k = gPr_l3+1, gPr_h3-1
         do j = gPr_l2+1, gPr_h2-1
            gE1 = (Er(i+ip,j,k,g) - Er(i-1,j,k,g)) / (xp*dx(1))
-           gE2 = (Er(i,j+1,k,g) - Er(i,j-1,k,g)) / (2.d0*dx(2))
-           gE3 = (Er(i,j,k+1,g) - Er(i,j,k-1,g)) / (2.d0*dx(3))
+           gE2 = (Er(i,j+1,k,g) - Er(i,j-1,k,g)) / (2.e0_rt*dx(2))
+           gE3 = (Er(i,j,k+1,g) - Er(i,j,k-1,g)) / (2.e0_rt*dx(3))
            gE(i,j,k) = sqrt(gE1**2 + gE2**2 + gE3**2)
         end do
      end do
@@ -1522,7 +1532,7 @@ subroutine ca_est_gpr2(kap, kap_l1, kap_l2, kap_l3, kap_h1, kap_h2, kap_h3, &
      do k = gPr_l3+1, gPr_h3-1
         gE1 = (Er(i+1,j,k,g) - Er(i-im,j,k,g)) / (xm*dx(1))
         gE2 = (Er(i,j+jp,k,g) - Er(i,j-1,k,g)) / (yp*dx(2))
-        gE3 = (Er(i,j,k+1,g) - Er(i,j,k-1,g)) / (2.d0*dx(3))
+        gE3 = (Er(i,j,k+1,g) - Er(i,j,k-1,g)) / (2.e0_rt*dx(3))
         gE(i,j,k) = sqrt(gE1**2 + gE2**2 + gE3**2)
      end do
 
@@ -1530,9 +1540,9 @@ subroutine ca_est_gpr2(kap, kap_l1, kap_l2, kap_l3, kap_h1, kap_h2, kap_h3, &
      j = gPr_h2
      do k = gPr_l3+1, gPr_h3-1
         do i = gPr_l1+1, gPr_h1-1
-           gE1 = (Er(i+1,j,k,g) - Er(i-1,j,k,g)) / (2.d0*dx(1))
+           gE1 = (Er(i+1,j,k,g) - Er(i-1,j,k,g)) / (2.e0_rt*dx(1))
            gE2 = (Er(i,j+jp,k,g) - Er(i,j-1,k,g)) / (yp*dx(2))
-           gE3 = (Er(i,j,k+1,g) - Er(i,j,k-1,g)) / (2.d0*dx(3))
+           gE3 = (Er(i,j,k+1,g) - Er(i,j,k-1,g)) / (2.e0_rt*dx(3))
            gE(i,j,k) = sqrt(gE1**2 + gE2**2 + gE3**2)
         end do
      end do
@@ -1543,7 +1553,7 @@ subroutine ca_est_gpr2(kap, kap_l1, kap_l2, kap_l3, kap_h1, kap_h2, kap_h3, &
      do k = gPr_l3+1, gPr_h3-1
         gE1 = (Er(i+ip,j,k,g) - Er(i-1,j,k,g)) / (xp*dx(1))
         gE2 = (Er(i,j+jp,k,g) - Er(i,j-1,k,g)) / (yp*dx(2))
-        gE3 = (Er(i,j,k+1,g) - Er(i,j,k-1,g)) / (2.d0*dx(3))
+        gE3 = (Er(i,j,k+1,g) - Er(i,j,k-1,g)) / (2.e0_rt*dx(3))
         gE(i,j,k) = sqrt(gE1**2 + gE2**2 + gE3**2)
      end do
 
@@ -1560,7 +1570,7 @@ subroutine ca_est_gpr2(kap, kap_l1, kap_l2, kap_l3, kap_h1, kap_h2, kap_h3, &
      j = gPr_l2
      k = gPr_h3
      do i = gPr_l1+1, gPr_h1-1
-        gE1 = (Er(i+1,j,k,g) - Er(i-1,j,k,g)) / (2.d0*dx(1))
+        gE1 = (Er(i+1,j,k,g) - Er(i-1,j,k,g)) / (2.e0_rt*dx(1))
         gE2 = (Er(i,j+1,k,g) - Er(i,j-jm,k,g)) / (ym*dx(2))
         gE3 = (Er(i,j,k+kp,g) - Er(i,j,k-1,g)) / (zp*dx(3))
         gE(i,j,k) = sqrt(gE1**2 + gE2**2 + gE3**2)
@@ -1580,7 +1590,7 @@ subroutine ca_est_gpr2(kap, kap_l1, kap_l2, kap_l3, kap_h1, kap_h2, kap_h3, &
      k = gPr_h3
      do j = gPr_l2+1, gPr_h2-1
         gE1 = (Er(i+1,j,k,g) - Er(i-im,j,k,g)) / (xm*dx(1))
-        gE2 = (Er(i,j+1,k,g) - Er(i,j-1,k,g)) / (2.d0*dx(2))
+        gE2 = (Er(i,j+1,k,g) - Er(i,j-1,k,g)) / (2.e0_rt*dx(2))
         gE3 = (Er(i,j,k+kp,g) - Er(i,j,k-1,g)) / (zp*dx(3))
         gE(i,j,k) = sqrt(gE1**2 + gE2**2 + gE3**2)
      end do
@@ -1589,8 +1599,8 @@ subroutine ca_est_gpr2(kap, kap_l1, kap_l2, kap_l3, kap_h1, kap_h2, kap_h3, &
      k = gPr_h3
      do j = gPr_l2+1, gPr_h2-1
         do i = gPr_l1+1, gPr_h1-1
-           gE1 = (Er(i+1,j,k,g) - Er(i-1,j,k,g)) / (2.d0*dx(1))
-           gE2 = (Er(i,j+1,k,g) - Er(i,j-1,k,g)) / (2.d0*dx(2))
+           gE1 = (Er(i+1,j,k,g) - Er(i-1,j,k,g)) / (2.e0_rt*dx(1))
+           gE2 = (Er(i,j+1,k,g) - Er(i,j-1,k,g)) / (2.e0_rt*dx(2))
            gE3 = (Er(i,j,k+kp,g) - Er(i,j,k-1,g)) / (zp*dx(3))
            gE(i,j,k) = sqrt(gE1**2 + gE2**2 + gE3**2)
         end do
@@ -1601,7 +1611,7 @@ subroutine ca_est_gpr2(kap, kap_l1, kap_l2, kap_l3, kap_h1, kap_h2, kap_h3, &
      k = gPr_h3
      do j = gPr_l2+1, gPr_h2-1
         gE1 = (Er(i+ip,j,k,g) - Er(i-1,j,k,g)) / (xp*dx(1))
-        gE2 = (Er(i,j+1,k,g) - Er(i,j-1,k,g)) / (2.d0*dx(2))
+        gE2 = (Er(i,j+1,k,g) - Er(i,j-1,k,g)) / (2.e0_rt*dx(2))
         gE3 = (Er(i,j,k+kp,g) - Er(i,j,k-1,g)) / (zp*dx(3))
         gE(i,j,k) = sqrt(gE1**2 + gE2**2 + gE3**2)
      end do
@@ -1619,7 +1629,7 @@ subroutine ca_est_gpr2(kap, kap_l1, kap_l2, kap_l3, kap_h1, kap_h2, kap_h3, &
      j = gPr_h2
      k = gPr_h3
      do i = gPr_l1+1, gPr_h1-1
-        gE1 = (Er(i+1,j,k,g) - Er(i-1,j,k,g)) / (2.d0*dx(1))
+        gE1 = (Er(i+1,j,k,g) - Er(i-1,j,k,g)) / (2.e0_rt*dx(1))
         gE2 = (Er(i,j+jp,k,g) - Er(i,j-1,k,g)) / (yp*dx(2))
         gE3 = (Er(i,j,k+kp,g) - Er(i,j,k-1,g)) / (zp*dx(3))
         gE(i,j,k) = sqrt(gE1**2 + gE2**2 + gE3**2)
@@ -1637,13 +1647,13 @@ subroutine ca_est_gpr2(kap, kap_l1, kap_l2, kap_l3, kap_h1, kap_h2, kap_h3, &
      do k = gPr_l3, gPr_h3
         do j = gPr_l2, gPr_h2
            do i = gPr_l1, gPr_h1
-              r = gE(i,j,k) / (kap(i,j,k,g) * max(Er(i,j,k,g), 1.d-50))
+              r = gE(i,j,k) / (kap(i,j,k,g) * max(Er(i,j,k,g), 1.e-50_rt))
               lam = FLDlambda(r, limiter)
               if (comoving .eq. 1) then
                  f = Edd_factor(lam)
-                 gamr = (3.d0-f)/2.d0
+                 gamr = (3.e0_rt-f)/2.e0_rt
               else
-                 gamr = lam + 1.d0
+                 gamr = lam + 1.e0_rt
               end if
               gPr(i,j,k) = gPr(i,j,k) +  lam * gamr * Er(i,j,k,g)
            end do

--- a/Source/Radiation/RadSrc_3d/HABEC_3D.F90
+++ b/Source/Radiation/RadSrc_3d/HABEC_3D.F90
@@ -11,6 +11,7 @@ module habec_module
 
   use bl_types
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
 contains
@@ -20,17 +21,18 @@ subroutine hacoef(mat, a, &
                   DIMS(reg), &
                   alpha) bind(C, name="hacoef")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(abox)
   integer :: DIMDEC(reg)
-  real*8 :: a(DIMV(abox))
-  real*8 :: mat(0:3, DIMV(reg))
-  real*8 :: alpha
+  real(rt)         :: a(DIMV(abox))
+  real(rt)         :: mat(0:3, DIMV(reg))
+  real(rt)         :: alpha
   integer :: i, j, k
-  if (alpha == 0.d0) then
+  if (alpha == 0.e0_rt) then
      do k = reg_l3, reg_h3
         do j = reg_l2, reg_h2
            do i = reg_l1, reg_h1
-              mat(3,i,j,k) = 0.d0
+              mat(3,i,j,k) = 0.e0_rt
            enddo
         enddo
      enddo
@@ -50,13 +52,14 @@ subroutine hbcoef(mat, b, &
                   DIMS(reg), &
                   beta, dx, n) bind(C, name="hbcoef")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(bbox)
   integer :: DIMDEC(reg)
   integer :: n
-  real*8 :: b(DIMV(bbox))
-  real*8 :: mat(0:3, DIMV(reg))
-  real*8 :: beta, dx(3)
-  real*8 :: fac
+  real(rt)         :: b(DIMV(bbox))
+  real(rt)         :: mat(0:3, DIMV(reg))
+  real(rt)         :: beta, dx(3)
+  real(rt)         :: fac
   integer :: i, j, k
   if (n == 0) then
      fac = beta / (dx(1)**2)
@@ -101,15 +104,16 @@ subroutine hbmat(mat, &
                  b, DIMS(bbox), &
                  beta, dx) bind(C, name="hbmat")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(reg)
   integer :: DIMDEC(msk)
   integer :: DIMDEC(bbox)
   integer :: cdir, bct
-  real*8 :: bcl, beta, dx(3)
-  real*8 :: mat(0:3, DIMV(reg))
+  real(rt)         :: bcl, beta, dx(3)
+  real(rt)         :: mat(0:3, DIMV(reg))
   integer :: mask(DIMV(msk))
-  real*8 :: b(DIMV(bbox))
-  real*8 :: h, fac, bfm, bfv
+  real(rt)         :: b(DIMV(bbox))
+  real(rt)         :: h, fac, bfm, bfv
   integer :: i, j, k
   if (cdir == 0 .OR. cdir == 3) then
      h = dx(1)
@@ -120,7 +124,7 @@ subroutine hbmat(mat, &
   endif
   fac = beta / (h**2)
   if (bct == LO_DIRICHLET) then
-     bfv = fac * h / (0.5d0 * h + bcl)
+     bfv = fac * h / (0.5e0_rt * h + bcl)
      bfm = bfv - fac
   else if (bct == LO_NEUMANN) then
      bfv = beta / h
@@ -135,7 +139,7 @@ subroutine hbmat(mat, &
         do j = reg_l2, reg_h2
            if (mask(i-1,j,k) > 0) then
               mat(3,i,j,k) = mat(3,i,j,k) + bfm * b(i,j,k)
-              mat(0,i,j,k) = 0.d0
+              mat(0,i,j,k) = 0.e0_rt
            endif
         enddo
      enddo
@@ -154,7 +158,7 @@ subroutine hbmat(mat, &
         do i = reg_l1, reg_h1
            if (mask(i,j-1,k) > 0) then
               mat(3,i,j,k) = mat(3,i,j,k) + bfm * b(i,j,k)
-              mat(1,i,j,k) = 0.d0
+              mat(1,i,j,k) = 0.e0_rt
            endif
         enddo
      enddo
@@ -173,7 +177,7 @@ subroutine hbmat(mat, &
         do i = reg_l1, reg_h1
            if (mask(i,j,k-1) > 0) then
               mat(3,i,j,k) = mat(3,i,j,k) + bfm * b(i,j,k)
-              mat(2,i,j,k) = 0.d0
+              mat(2,i,j,k) = 0.e0_rt
            endif
         enddo
      enddo
@@ -200,19 +204,20 @@ subroutine hbmat3(mat, &
                   beta, dx, c, r, &
                   spa, DIMS(spabox)) bind(C, name="hbmat3")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(reg)
   integer :: DIMDEC(bcv)
   integer :: DIMDEC(msk)
   integer :: DIMDEC(bbox)
   integer :: DIMDEC(spabox)
   integer :: cdir, bctype, tf(DIMV(bcv))
-  real*8 :: bcl, beta, dx(3), c
-  real*8 :: mat(0:3, DIMV(reg))
+  real(rt)         :: bcl, beta, dx(3), c
+  real(rt)         :: mat(0:3, DIMV(reg))
   integer :: mask(DIMV(msk))
-  real*8 :: b(DIMV(bbox))
-  real*8 :: spa(DIMV(spabox))
-  real*8 :: r(1)
-  real*8 :: h, fac, bfm, bfv
+  real(rt)         :: b(DIMV(bbox))
+  real(rt)         :: spa(DIMV(spabox))
+  real(rt)         :: r(1)
+  real(rt)         :: h, fac, bfm, bfv
   integer :: i, j, k, bct
   ! The -fac * b(i,j,k) term applied to the matrix diagonal is the contribution
   ! from the interior stencil which must be removed at the boundary.
@@ -235,22 +240,22 @@ subroutine hbmat3(mat, &
                  bct = bctype
               endif
               if (bct == LO_DIRICHLET) then
-                 bfv = fac * h / (0.5d0 * h + bcl)
+                 bfv = fac * h / (0.5e0_rt * h + bcl)
                  bfm = bfv * b(i,j,k)
               else if (bct == LO_NEUMANN) then
-                 bfm = 0.d0
+                 bfm = 0.e0_rt
               else if (bct == LO_MARSHAK) then
-                 bfv = 2.d0 * c * beta / h
-                 bfm = 0.25d0 * bfv
+                 bfv = 2.e0_rt * c * beta / h
+                 bfm = 0.25e0_rt * bfv
               else if (bct == LO_SANCHEZ_POMRANING) then
-                 bfv = 2.d0 * c * beta / h
+                 bfv = 2.e0_rt * c * beta / h
                  bfm = spa(i,j,k) * bfv
               else
                  print *, "hbmat3: unsupported boundary type"
                  stop
               endif
               mat(3,i,j,k) = mat(3,i,j,k) + bfm - fac * b(i,j,k)
-              mat(0,i,j,k) = 0.d0
+              mat(0,i,j,k) = 0.e0_rt
            endif
         enddo
      enddo
@@ -265,15 +270,15 @@ subroutine hbmat3(mat, &
                  bct = bctype
               endif
               if (bct == LO_DIRICHLET) then
-                 bfv = fac * h / (0.5d0 * h + bcl)
+                 bfv = fac * h / (0.5e0_rt * h + bcl)
                  bfm = bfv * b(i+1,j,k)
               else if (bct == LO_NEUMANN) then
-                 bfm = 0.d0
+                 bfm = 0.e0_rt
               else if (bct == LO_MARSHAK) then
-                 bfv = 2.d0 * c * beta / h
-                 bfm = 0.25d0 * bfv
+                 bfv = 2.e0_rt * c * beta / h
+                 bfm = 0.25e0_rt * bfv
               else if (bct == LO_SANCHEZ_POMRANING) then
-                 bfv = 2.d0 * c * beta / h
+                 bfv = 2.e0_rt * c * beta / h
                  bfm = spa(i,j,k) * bfv
               else
                  print *, "hbmat3: unsupported boundary type"
@@ -294,22 +299,22 @@ subroutine hbmat3(mat, &
                  bct = bctype
               endif
               if (bct == LO_DIRICHLET) then
-                 bfv = fac * h / (0.5d0 * h + bcl)
+                 bfv = fac * h / (0.5e0_rt * h + bcl)
                  bfm = bfv * b(i,j,k)
               else if (bct == LO_NEUMANN) then
-                 bfm = 0.d0
+                 bfm = 0.e0_rt
               else if (bct == LO_MARSHAK) then
-                 bfv = 2.d0 * c * beta / h
-                 bfm = 0.25d0 * bfv
+                 bfv = 2.e0_rt * c * beta / h
+                 bfm = 0.25e0_rt * bfv
               else if (bct == LO_SANCHEZ_POMRANING) then
-                 bfv = 2.d0 * c * beta / h
+                 bfv = 2.e0_rt * c * beta / h
                  bfm = spa(i,j,k) * bfv
               else
                  print *, "hbmat3: unsupported boundary type"
                  stop
               endif
               mat(3,i,j,k) = mat(3,i,j,k) + bfm - fac * b(i,j,k)
-              mat(1,i,j,k) = 0.d0
+              mat(1,i,j,k) = 0.e0_rt
            endif
         enddo
      enddo
@@ -324,15 +329,15 @@ subroutine hbmat3(mat, &
                  bct = bctype
               endif
               if (bct == LO_DIRICHLET) then
-                 bfv = fac * h / (0.5d0 * h + bcl)
+                 bfv = fac * h / (0.5e0_rt * h + bcl)
                  bfm = bfv * b(i,j+1,k)
               else if (bct == LO_NEUMANN) then
-                 bfm = 0.d0
+                 bfm = 0.e0_rt
               else if (bct == LO_MARSHAK) then
-                 bfv = 2.d0 * c * beta / h
-                 bfm = 0.25d0 * bfv
+                 bfv = 2.e0_rt * c * beta / h
+                 bfm = 0.25e0_rt * bfv
               else if (bct == LO_SANCHEZ_POMRANING) then
-                 bfv = 2.d0 * c * beta / h
+                 bfv = 2.e0_rt * c * beta / h
                  bfm = spa(i,j,k) * bfv
               else
                  print *, "hbmat3: unsupported boundary type"
@@ -353,22 +358,22 @@ subroutine hbmat3(mat, &
                  bct = bctype
               endif
               if (bct == LO_DIRICHLET) then
-                 bfv = fac * h / (0.5d0 * h + bcl)
+                 bfv = fac * h / (0.5e0_rt * h + bcl)
                  bfm = bfv * b(i,j,k)
               else if (bct == LO_NEUMANN) then
-                 bfm = 0.d0
+                 bfm = 0.e0_rt
               else if (bct == LO_MARSHAK) then
-                 bfv = 2.d0 * c * beta / h
-                 bfm = 0.25d0 * bfv
+                 bfv = 2.e0_rt * c * beta / h
+                 bfm = 0.25e0_rt * bfv
               else if (bct == LO_SANCHEZ_POMRANING) then
-                 bfv = 2.d0 * c * beta / h
+                 bfv = 2.e0_rt * c * beta / h
                  bfm = spa(i,j,k) * bfv
               else
                  print *, "hbmat3: unsupported boundary type"
                  stop
               endif
               mat(3,i,j,k) = mat(3,i,j,k) + bfm - fac * b(i,j,k)
-              mat(2,i,j,k) = 0.d0
+              mat(2,i,j,k) = 0.e0_rt
            endif
         enddo
      enddo
@@ -383,15 +388,15 @@ subroutine hbmat3(mat, &
                  bct = bctype
               endif
               if (bct == LO_DIRICHLET) then
-                 bfv = fac * h / (0.5d0 * h + bcl)
+                 bfv = fac * h / (0.5e0_rt * h + bcl)
                  bfm = bfv * b(i,j,k+1)
               else if (bct == LO_NEUMANN) then
-                 bfm = 0.d0
+                 bfm = 0.e0_rt
               else if (bct == LO_MARSHAK) then
-                 bfv = 2.d0 * c * beta / h
-                 bfm = 0.25d0 * bfv
+                 bfv = 2.e0_rt * c * beta / h
+                 bfm = 0.25e0_rt * bfv
               else if (bct == LO_SANCHEZ_POMRANING) then
-                 bfv = 2.d0 * c * beta / h
+                 bfv = 2.e0_rt * c * beta / h
                  bfm = spa(i,j,k) * bfv
               else
                  print *, "hbmat3: unsupported boundary type"
@@ -414,18 +419,19 @@ subroutine hbvec(vec, &
                  b, DIMS(bbox), &
                  beta, dx) bind(C, name="hbvec")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(reg)
   integer :: DIMDEC(bcv)
   integer :: DIMDEC(msk)
   integer :: DIMDEC(bbox)
   integer :: cdir, bct, bho
-  real*8 :: bcl, beta, dx(3)
-  real*8 :: vec(DIMV(reg))
-  real*8 :: bcval(DIMV(bcv))
+  real(rt)         :: bcl, beta, dx(3)
+  real(rt)         :: vec(DIMV(reg))
+  real(rt)         :: bcval(DIMV(bcv))
   integer :: mask(DIMV(msk))
-  real*8 :: b(DIMV(bbox))
-  real*8 :: h, bfv
-  real*8 :: h2, th2
+  real(rt)         :: b(DIMV(bbox))
+  real(rt)         :: h, bfv
+  real(rt)         :: h2, th2
   integer :: i, j, k
   if (cdir == 0 .OR. cdir == 3) then
      h = dx(1)
@@ -436,11 +442,11 @@ subroutine hbvec(vec, &
   endif
   if (bct == LO_DIRICHLET) then
      if (bho >= 1) then
-        h2 = 0.5d0 * h
-        th2 = 3.d0 * h2
-        bfv = 2.d0 * beta / ((bcl + h2) * (bcl + th2))
+        h2 = 0.5e0_rt * h
+        th2 = 3.e0_rt * h2
+        bfv = 2.e0_rt * beta / ((bcl + h2) * (bcl + th2))
      else
-        bfv = (beta / h) / (0.5d0 * h + bcl)
+        bfv = (beta / h) / (0.5e0_rt * h + bcl)
      endif
   else if (bct == LO_NEUMANN) then
      bfv = beta / h
@@ -521,19 +527,20 @@ subroutine hbvec3(vec, &
                   b, DIMS(bbox), &
                   beta, dx, r) bind(C, name="hbvec3")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(reg)
   integer :: DIMDEC(bcv)
   integer :: DIMDEC(msk)
   integer :: DIMDEC(bbox)
   integer :: cdir, bctype, tf(DIMV(bcv)), bho
-  real*8 :: bcl, beta, dx(3)
-  real*8 :: vec(DIMV(reg))
-  real*8 :: bcval(DIMV(bcv))
+  real(rt)         :: bcl, beta, dx(3)
+  real(rt)         :: vec(DIMV(reg))
+  real(rt)         :: bcval(DIMV(bcv))
   integer :: mask(DIMV(msk))
-  real*8 :: b(DIMV(bbox))
-  real*8 :: r(1)
-  real*8 :: h, bfv
-  real*8 :: h2, th2
+  real(rt)         :: b(DIMV(bbox))
+  real(rt)         :: r(1)
+  real(rt)         :: h, bfv
+  real(rt)         :: h2, th2
   integer :: i, j, k, bct
   if (cdir == 0 .OR. cdir == 3) then
      h = dx(1)
@@ -554,18 +561,18 @@ subroutine hbvec3(vec, &
               endif
               if (bct == LO_DIRICHLET) then
                  if (bho >= 1) then
-                    h2 = 0.5d0 * h
-                    th2 = 3.d0 * h2
-                    bfv = 2.d0 * beta / ((bcl + h2) * (bcl + th2))
+                    h2 = 0.5e0_rt * h
+                    th2 = 3.e0_rt * h2
+                    bfv = 2.e0_rt * beta / ((bcl + h2) * (bcl + th2))
                  else
-                    bfv = (beta / h) / (0.5d0 * h + bcl)
+                    bfv = (beta / h) / (0.5e0_rt * h + bcl)
                  endif
                  bfv = bfv * b(i,j,k)
               else if (bct == LO_NEUMANN) then
                  bfv = beta / h
               else if (bct == LO_MARSHAK .OR. &
                    bct == LO_SANCHEZ_POMRANING) then
-                 bfv = 2.d0 * beta / h
+                 bfv = 2.e0_rt * beta / h
               else
                  print *, "hbvec3: unsupported boundary type"
                  stop
@@ -586,18 +593,18 @@ subroutine hbvec3(vec, &
               endif
               if (bct == LO_DIRICHLET) then
                  if (bho >= 1) then
-                    h2 = 0.5d0 * h
-                    th2 = 3.d0 * h2
-                    bfv = 2.d0 * beta / ((bcl + h2) * (bcl + th2))
+                    h2 = 0.5e0_rt * h
+                    th2 = 3.e0_rt * h2
+                    bfv = 2.e0_rt * beta / ((bcl + h2) * (bcl + th2))
                  else
-                    bfv = (beta / h) / (0.5d0 * h + bcl)
+                    bfv = (beta / h) / (0.5e0_rt * h + bcl)
                  endif
                  bfv = bfv * b(i+1,j,k)
               else if (bct == LO_NEUMANN) then
                  bfv = beta / h
               else if (bct == LO_MARSHAK .OR. &
                    bct == LO_SANCHEZ_POMRANING) then
-                 bfv = 2.d0 * beta / h
+                 bfv = 2.e0_rt * beta / h
               else
                  print *, "hbvec3: unsupported boundary type"
                  stop
@@ -618,18 +625,18 @@ subroutine hbvec3(vec, &
               endif
               if (bct == LO_DIRICHLET) then
                  if (bho >= 1) then
-                    h2 = 0.5d0 * h
-                    th2 = 3.d0 * h2
-                    bfv = 2.d0 * beta / ((bcl + h2) * (bcl + th2))
+                    h2 = 0.5e0_rt * h
+                    th2 = 3.e0_rt * h2
+                    bfv = 2.e0_rt * beta / ((bcl + h2) * (bcl + th2))
                  else
-                    bfv = (beta / h) / (0.5d0 * h + bcl)
+                    bfv = (beta / h) / (0.5e0_rt * h + bcl)
                  endif
                  bfv = bfv * b(i,j,k)
               else if (bct == LO_NEUMANN) then
                  bfv = beta / h
               else if (bct == LO_MARSHAK .OR. &
                    bct == LO_SANCHEZ_POMRANING) then
-                 bfv = 2.d0 * beta / h
+                 bfv = 2.e0_rt * beta / h
               else
                  print *, "hbvec3: unsupported boundary type"
                  stop
@@ -650,18 +657,18 @@ subroutine hbvec3(vec, &
               endif
               if (bct == LO_DIRICHLET) then
                  if (bho >= 1) then
-                    h2 = 0.5d0 * h
-                    th2 = 3.d0 * h2
-                    bfv = 2.d0 * beta / ((bcl + h2) * (bcl + th2))
+                    h2 = 0.5e0_rt * h
+                    th2 = 3.e0_rt * h2
+                    bfv = 2.e0_rt * beta / ((bcl + h2) * (bcl + th2))
                  else
-                    bfv = (beta / h) / (0.5d0 * h + bcl)
+                    bfv = (beta / h) / (0.5e0_rt * h + bcl)
                  endif
                  bfv = bfv * b(i,j+1,k)
               else if (bct == LO_NEUMANN) then
                  bfv = beta / h
               else if (bct == LO_MARSHAK .OR. &
                    bct == LO_SANCHEZ_POMRANING) then
-                 bfv = 2.d0 * beta / h
+                 bfv = 2.e0_rt * beta / h
               else
                  print *, "hbvec3: unsupported boundary type"
                  stop
@@ -682,18 +689,18 @@ subroutine hbvec3(vec, &
               endif
               if (bct == LO_DIRICHLET) then
                  if (bho >= 1) then
-                    h2 = 0.5d0 * h
-                    th2 = 3.d0 * h2
-                    bfv = 2.d0 * beta / ((bcl + h2) * (bcl + th2))
+                    h2 = 0.5e0_rt * h
+                    th2 = 3.e0_rt * h2
+                    bfv = 2.e0_rt * beta / ((bcl + h2) * (bcl + th2))
                  else
-                    bfv = (beta / h) / (0.5d0 * h + bcl)
+                    bfv = (beta / h) / (0.5e0_rt * h + bcl)
                  endif
                  bfv = bfv * b(i,j,k)
               else if (bct == LO_NEUMANN) then
                  bfv = beta / h
               else if (bct == LO_MARSHAK .OR. &
                    bct == LO_SANCHEZ_POMRANING) then
-                 bfv = 2.d0 * beta / h
+                 bfv = 2.e0_rt * beta / h
               else
                  print *, "hbvec3: unsupported boundary type"
                  stop
@@ -714,18 +721,18 @@ subroutine hbvec3(vec, &
               endif
               if (bct == LO_DIRICHLET) then
                  if (bho >= 1) then
-                    h2 = 0.5d0 * h
-                    th2 = 3.d0 * h2
-                    bfv = 2.d0 * beta / ((bcl + h2) * (bcl + th2))
+                    h2 = 0.5e0_rt * h
+                    th2 = 3.e0_rt * h2
+                    bfv = 2.e0_rt * beta / ((bcl + h2) * (bcl + th2))
                  else
-                    bfv = (beta / h) / (0.5d0 * h + bcl)
+                    bfv = (beta / h) / (0.5e0_rt * h + bcl)
                  endif
                  bfv = bfv * b(i,j,k+1)
               else if (bct == LO_NEUMANN) then
                  bfv = beta / h
               else if (bct == LO_MARSHAK .OR. &
                    bct == LO_SANCHEZ_POMRANING) then
-                 bfv = 2.d0 * beta / h
+                 bfv = 2.e0_rt * beta / h
               else
                  print *, "hbvec3: unsupported boundary type"
                  stop
@@ -749,6 +756,7 @@ subroutine hbflx(flux, &
                  b, DIMS(bbox), &
                  beta, dx, inhom) bind(C, name="hbflx")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(fbox)
   integer :: DIMDEC(ebox)
   integer :: DIMDEC(reg)
@@ -756,14 +764,14 @@ subroutine hbflx(flux, &
   integer :: DIMDEC(msk)
   integer :: DIMDEC(bbox)
   integer :: cdir, bct, bho, inhom
-  real*8 :: bcl, beta, dx(3)
-  real*8 :: flux(DIMV(fbox))
-  real*8 :: er(DIMV(ebox))
-  real*8 :: bcval(DIMV(bcv))
+  real(rt)         :: bcl, beta, dx(3)
+  real(rt)         :: flux(DIMV(fbox))
+  real(rt)         :: er(DIMV(ebox))
+  real(rt)         :: bcval(DIMV(bcv))
   integer :: mask(DIMV(msk))
-  real*8 :: b(DIMV(bbox))
-  real*8 :: h, bfm, bfv
-  real*8 :: bfm2, h2, th2
+  real(rt)         :: b(DIMV(bbox))
+  real(rt)         :: h, bfm, bfv
+  real(rt)         :: bfm2, h2, th2
   integer :: i, j, k
   if (cdir == 0 .OR. cdir == 3) then
      h = dx(1)
@@ -774,13 +782,13 @@ subroutine hbflx(flux, &
   endif
   if (bct == LO_DIRICHLET) then
      if (bho >= 1) then
-        h2 = 0.5d0 * h
-        th2 = 3.d0 * h2
-        bfv = 2.d0 * beta * h / ((bcl + h2) * (bcl + th2))
+        h2 = 0.5e0_rt * h
+        th2 = 3.e0_rt * h2
+        bfv = 2.e0_rt * beta * h / ((bcl + h2) * (bcl + th2))
         bfm = (beta / h) * (th2 - bcl) / (bcl + h2)
         bfm2 = (beta / h) * (bcl - h2) / (bcl + th2)
      else
-        bfv = beta / (0.5d0 * h + bcl)
+        bfv = beta / (0.5e0_rt * h + bcl)
         bfm = bfv
      endif
   else
@@ -788,7 +796,7 @@ subroutine hbflx(flux, &
      stop
   endif
   if (inhom == 0) then
-     bfv = 0.d0
+     bfv = 0.e0_rt
   endif
   if (cdir == 0) then
      i = reg_l1
@@ -890,6 +898,7 @@ subroutine hbflx3(flux, &
                   beta, dx, c, r, inhom, &
                   spa, DIMS(spabox)) bind(C, name="hbflx3")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(fbox)
   integer :: DIMDEC(ebox)
   integer :: DIMDEC(reg)
@@ -898,16 +907,16 @@ subroutine hbflx3(flux, &
   integer :: DIMDEC(bbox)
   integer :: DIMDEC(spabox)
   integer :: cdir, bctype, tf(DIMV(bcv)), bho, inhom
-  real*8 :: bcl, beta, dx(3), c
-  real*8 :: flux(DIMV(fbox))
-  real*8 :: er(DIMV(ebox))
-  real*8 :: bcval(DIMV(bcv))
+  real(rt)         :: bcl, beta, dx(3), c
+  real(rt)         :: flux(DIMV(fbox))
+  real(rt)         :: er(DIMV(ebox))
+  real(rt)         :: bcval(DIMV(bcv))
   integer :: mask(DIMV(msk))
-  real*8 :: b(DIMV(bbox))
-  real*8 :: spa(DIMV(spabox))
-  real*8 :: r(1)
-  real*8 :: h, bfm, bfv
-  real*8 :: bfm2, h2, th2
+  real(rt)         :: b(DIMV(bbox))
+  real(rt)         :: spa(DIMV(spabox))
+  real(rt)         :: r(1)
+  real(rt)         :: h, bfm, bfv
+  real(rt)         :: bfm2, h2, th2
   integer :: i, j, k, bct
   if (cdir == 0 .OR. cdir == 3) then
      h = dx(1)
@@ -928,41 +937,41 @@ subroutine hbflx3(flux, &
               endif
               if (bct == LO_DIRICHLET) then
                  if (bho >= 1) then
-                    h2 = 0.5d0 * h
-                    th2 = 3.d0 * h2
-                    bfv = 2.d0 * beta * h / ((bcl + h2) * (bcl + th2)) * b(i,j,k)
+                    h2 = 0.5e0_rt * h
+                    th2 = 3.e0_rt * h2
+                    bfv = 2.e0_rt * beta * h / ((bcl + h2) * (bcl + th2)) * b(i,j,k)
                     bfm = (beta / h) * (th2 - bcl) / (bcl + h2)  * b(i,j,k)
                     bfm2 = (beta / h) * (bcl - h2) / (bcl + th2) * b(i,j,k)
                  else
-                    bfv = beta / (0.5d0 * h + bcl) * b(i,j,k)
+                    bfv = beta / (0.5e0_rt * h + bcl) * b(i,j,k)
                     bfm = bfv
                  endif
               else if (bct == LO_NEUMANN) then
                  bfv  = beta
-                 bfm  = 0.d0
-                 bfm2 = 0.d0
+                 bfm  = 0.e0_rt
+                 bfm2 = 0.e0_rt
               else if (bct == LO_MARSHAK) then
-                 bfv = 2.d0 * beta
+                 bfv = 2.e0_rt * beta
                  if (bho >= 1) then
-                    bfm  =  0.75d0 * beta * c
-                    bfm2 = -0.25d0 * beta * c
+                    bfm  =  0.75e0_rt * beta * c
+                    bfm2 = -0.25e0_rt * beta * c
                  else
-                    bfm = 0.5d0 * beta * c
+                    bfm = 0.5e0_rt * beta * c
                  endif
               else if (bct == LO_SANCHEZ_POMRANING) then
-                 bfv = 2.d0 * beta
+                 bfv = 2.e0_rt * beta
                  if (bho >= 1) then
-                    bfm  =  3.0d0 * spa(i,j,k) * beta * c
-                    bfm2 = -1.0d0 * spa(i,j,k) * beta * c
+                    bfm  =  3.0e0_rt * spa(i,j,k) * beta * c
+                    bfm2 = -1.0e0_rt * spa(i,j,k) * beta * c
                  else
-                    bfm = 2.0d0 * spa(i,j,k) * beta * c
+                    bfm = 2.0e0_rt * spa(i,j,k) * beta * c
                  endif
               else
                  print *, "hbflx3: unsupported boundary type"
                  stop
               endif
               if (inhom == 0) then
-                 bfv = 0.d0
+                 bfv = 0.e0_rt
               endif
               flux(i,j,k) = (bfv * bcval(i-1,j,k) - bfm * er(i,j,k))
               if (bho >= 1) then
@@ -983,41 +992,41 @@ subroutine hbflx3(flux, &
               endif
               if (bct == LO_DIRICHLET) then
                  if (bho >= 1) then
-                    h2 = 0.5d0 * h
-                    th2 = 3.d0 * h2
-                    bfv = 2.d0 * beta * h / ((bcl + h2) * (bcl + th2)) * b(i+1,j,k)
+                    h2 = 0.5e0_rt * h
+                    th2 = 3.e0_rt * h2
+                    bfv = 2.e0_rt * beta * h / ((bcl + h2) * (bcl + th2)) * b(i+1,j,k)
                     bfm = (beta / h) * (th2 - bcl) / (bcl + h2)  * b(i+1,j,k)
                     bfm2 = (beta / h) * (bcl - h2) / (bcl + th2) * b(i+1,j,k)
                  else
-                    bfv = beta / (0.5d0 * h + bcl) * b(i+1,j,k)
+                    bfv = beta / (0.5e0_rt * h + bcl) * b(i+1,j,k)
                     bfm = bfv
                  endif
               else if (bct == LO_NEUMANN) then
                  bfv  = beta
-                 bfm  = 0.d0
-                 bfm2 = 0.d0
+                 bfm  = 0.e0_rt
+                 bfm2 = 0.e0_rt
               else if (bct == LO_MARSHAK) then
-                 bfv = 2.d0 * beta
+                 bfv = 2.e0_rt * beta
                  if (bho >= 1) then
-                    bfm  =  0.75d0 * beta * c
-                    bfm2 = -0.25d0 * beta * c
+                    bfm  =  0.75e0_rt * beta * c
+                    bfm2 = -0.25e0_rt * beta * c
                  else
-                    bfm = 0.5d0 * beta * c
+                    bfm = 0.5e0_rt * beta * c
                  endif
               else if (bct == LO_SANCHEZ_POMRANING) then
-                 bfv = 2.d0 * beta
+                 bfv = 2.e0_rt * beta
                  if (bho >= 1) then
-                    bfm  =  3.0d0 * spa(i,j,k) * beta * c
-                    bfm2 = -1.0d0 * spa(i,j,k) * beta * c
+                    bfm  =  3.0e0_rt * spa(i,j,k) * beta * c
+                    bfm2 = -1.0e0_rt * spa(i,j,k) * beta * c
                  else
-                    bfm = 2.0d0 * spa(i,j,k) * beta * c
+                    bfm = 2.0e0_rt * spa(i,j,k) * beta * c
                  endif
               else
                  print *, "hbflx3: unsupported boundary type"
                  stop
               endif
               if (inhom == 0) then
-                 bfv = 0.d0
+                 bfv = 0.e0_rt
               endif
               flux(i+1,j,k) = -(bfv * bcval(i+1,j,k) - bfm * er(i,j,k))
               if (bho >= 1) then
@@ -1038,41 +1047,41 @@ subroutine hbflx3(flux, &
               endif
               if (bct == LO_DIRICHLET) then
                  if (bho >= 1) then
-                    h2 = 0.5d0 * h
-                    th2 = 3.d0 * h2
-                    bfv = 2.d0 * beta * h / ((bcl + h2) * (bcl + th2)) * b(i,j,k)
+                    h2 = 0.5e0_rt * h
+                    th2 = 3.e0_rt * h2
+                    bfv = 2.e0_rt * beta * h / ((bcl + h2) * (bcl + th2)) * b(i,j,k)
                     bfm = (beta / h) * (th2 - bcl) / (bcl + h2)  * b(i,j,k)
                     bfm2 = (beta / h) * (bcl - h2) / (bcl + th2) * b(i,j,k)
                  else
-                    bfv = beta / (0.5d0 * h + bcl) * b(i,j,k)
+                    bfv = beta / (0.5e0_rt * h + bcl) * b(i,j,k)
                     bfm = bfv
                  endif
               else if (bct == LO_NEUMANN) then
                  bfv  = beta
-                 bfm  = 0.d0
-                 bfm2 = 0.d0
+                 bfm  = 0.e0_rt
+                 bfm2 = 0.e0_rt
               else if (bct == LO_MARSHAK) then
-                 bfv = 2.d0 * beta
+                 bfv = 2.e0_rt * beta
                  if (bho >= 1) then
-                    bfm  =  0.75d0 * beta * c
-                    bfm2 = -0.25d0 * beta * c
+                    bfm  =  0.75e0_rt * beta * c
+                    bfm2 = -0.25e0_rt * beta * c
                  else
-                    bfm = 0.5d0 * beta * c
+                    bfm = 0.5e0_rt * beta * c
                  endif
               else if (bct == LO_SANCHEZ_POMRANING) then
-                 bfv = 2.d0 * beta
+                 bfv = 2.e0_rt * beta
                  if (bho >= 1) then
-                    bfm  =  3.0d0 * spa(i,j,k) * beta * c
-                    bfm2 = -1.0d0 * spa(i,j,k) * beta * c
+                    bfm  =  3.0e0_rt * spa(i,j,k) * beta * c
+                    bfm2 = -1.0e0_rt * spa(i,j,k) * beta * c
                  else
-                    bfm = 2.0d0 * spa(i,j,k) * beta * c
+                    bfm = 2.0e0_rt * spa(i,j,k) * beta * c
                  endif
               else
                  print *, "hbflx3: unsupported boundary type"
                  stop
               endif
               if (inhom == 0) then
-                 bfv = 0.d0
+                 bfv = 0.e0_rt
               endif
               flux(i,j,k) = (bfv * bcval(i,j-1,k) - bfm * er(i,j,k))
               if (bho >= 1) then
@@ -1093,41 +1102,41 @@ subroutine hbflx3(flux, &
               endif
               if (bct == LO_DIRICHLET) then
                  if (bho >= 1) then
-                    h2 = 0.5d0 * h
-                    th2 = 3.d0 * h2
-                    bfv = 2.d0 * beta * h / ((bcl + h2) * (bcl + th2)) * b(i,j+1,k)
+                    h2 = 0.5e0_rt * h
+                    th2 = 3.e0_rt * h2
+                    bfv = 2.e0_rt * beta * h / ((bcl + h2) * (bcl + th2)) * b(i,j+1,k)
                     bfm = (beta / h) * (th2 - bcl) / (bcl + h2)  * b(i,j+1,k)
                     bfm2 = (beta / h) * (bcl - h2) / (bcl + th2) * b(i,j+1,k)
                  else
-                    bfv = beta / (0.5d0 * h + bcl) * b(i,j+1,k)
+                    bfv = beta / (0.5e0_rt * h + bcl) * b(i,j+1,k)
                     bfm = bfv
                  endif
               else if (bct == LO_NEUMANN) then
                  bfv  = beta
-                 bfm  = 0.d0
-                 bfm2 = 0.d0
+                 bfm  = 0.e0_rt
+                 bfm2 = 0.e0_rt
               else if (bct == LO_MARSHAK) then
-                 bfv = 2.d0 * beta
+                 bfv = 2.e0_rt * beta
                  if (bho >= 1) then
-                    bfm  =  0.75d0 * beta * c
-                    bfm2 = -0.25d0 * beta * c
+                    bfm  =  0.75e0_rt * beta * c
+                    bfm2 = -0.25e0_rt * beta * c
                  else
-                    bfm = 0.5d0 * beta * c
+                    bfm = 0.5e0_rt * beta * c
                  endif
               else if (bct == LO_SANCHEZ_POMRANING) then
-                 bfv = 2.d0 * beta
+                 bfv = 2.e0_rt * beta
                  if (bho >= 1) then
-                    bfm  =  3.0d0 * spa(i,j,k) * beta * c
-                    bfm2 = -1.0d0 * spa(i,j,k) * beta * c
+                    bfm  =  3.0e0_rt * spa(i,j,k) * beta * c
+                    bfm2 = -1.0e0_rt * spa(i,j,k) * beta * c
                  else
-                    bfm = 2.0d0 * spa(i,j,k) * beta * c
+                    bfm = 2.0e0_rt * spa(i,j,k) * beta * c
                  endif
               else
                  print *, "hbflx3: unsupported boundary type"
                  stop
               endif
               if (inhom == 0) then
-                 bfv = 0.d0
+                 bfv = 0.e0_rt
               endif
               flux(i,j+1,k) = -(bfv * bcval(i,j+1,k) - bfm * er(i,j,k))
               if (bho >= 1) then
@@ -1148,41 +1157,41 @@ subroutine hbflx3(flux, &
               endif
               if (bct == LO_DIRICHLET) then
                  if (bho >= 1) then
-                    h2 = 0.5d0 * h
-                    th2 = 3.d0 * h2
-                    bfv = 2.d0 * beta * h / ((bcl + h2) * (bcl + th2)) * b(i,j,k)
+                    h2 = 0.5e0_rt * h
+                    th2 = 3.e0_rt * h2
+                    bfv = 2.e0_rt * beta * h / ((bcl + h2) * (bcl + th2)) * b(i,j,k)
                     bfm = (beta / h) * (th2 - bcl) / (bcl + h2)  * b(i,j,k)
                     bfm2 = (beta / h) * (bcl - h2) / (bcl + th2) * b(i,j,k)
                  else
-                    bfv = beta / (0.5d0 * h + bcl) * b(i,j,k)
+                    bfv = beta / (0.5e0_rt * h + bcl) * b(i,j,k)
                     bfm = bfv
                  endif
               else if (bct == LO_NEUMANN) then
                  bfv  = beta
-                 bfm  = 0.d0
-                 bfm2 = 0.d0
+                 bfm  = 0.e0_rt
+                 bfm2 = 0.e0_rt
               else if (bct == LO_MARSHAK) then
-                 bfv = 2.d0 * beta
+                 bfv = 2.e0_rt * beta
                  if (bho >= 1) then
-                    bfm  =  0.75d0 * beta * c
-                    bfm2 = -0.25d0 * beta * c
+                    bfm  =  0.75e0_rt * beta * c
+                    bfm2 = -0.25e0_rt * beta * c
                  else
-                    bfm = 0.5d0 * beta * c
+                    bfm = 0.5e0_rt * beta * c
                  endif
               else if (bct == LO_SANCHEZ_POMRANING) then
-                 bfv = 2.d0 * beta
+                 bfv = 2.e0_rt * beta
                  if (bho >= 1) then
-                    bfm  =  3.0d0 * spa(i,j,k) * beta * c
-                    bfm2 = -1.0d0 * spa(i,j,k) * beta * c
+                    bfm  =  3.0e0_rt * spa(i,j,k) * beta * c
+                    bfm2 = -1.0e0_rt * spa(i,j,k) * beta * c
                  else
-                    bfm = 2.0d0 * spa(i,j,k) * beta * c
+                    bfm = 2.0e0_rt * spa(i,j,k) * beta * c
                  endif
               else
                  print *, "hbflx3: unsupported boundary type"
                  stop
               endif
               if (inhom == 0) then
-                 bfv = 0.d0
+                 bfv = 0.e0_rt
               endif
               flux(i,j,k) = (bfv * bcval(i,j,k-1) - bfm * er(i,j,k))
               if (bho >= 1) then
@@ -1203,41 +1212,41 @@ subroutine hbflx3(flux, &
               endif
               if (bct == LO_DIRICHLET) then
                  if (bho >= 1) then
-                    h2 = 0.5d0 * h
-                    th2 = 3.d0 * h2
-                    bfv = 2.d0 * beta * h / ((bcl + h2) * (bcl + th2)) * b(i,j,k+1)
+                    h2 = 0.5e0_rt * h
+                    th2 = 3.e0_rt * h2
+                    bfv = 2.e0_rt * beta * h / ((bcl + h2) * (bcl + th2)) * b(i,j,k+1)
                     bfm = (beta / h) * (th2 - bcl) / (bcl + h2)  * b(i,j,k+1)
                     bfm2 = (beta / h) * (bcl - h2) / (bcl + th2) * b(i,j,k+1)
                  else
-                    bfv = beta / (0.5d0 * h + bcl) * b(i,j,k+1)
+                    bfv = beta / (0.5e0_rt * h + bcl) * b(i,j,k+1)
                     bfm = bfv
                  endif
               else if (bct == LO_NEUMANN) then
                  bfv  = beta
-                 bfm  = 0.d0
-                 bfm2 = 0.d0
+                 bfm  = 0.e0_rt
+                 bfm2 = 0.e0_rt
               else if (bct == LO_MARSHAK) then
-                 bfv = 2.d0 * beta
+                 bfv = 2.e0_rt * beta
                  if (bho >= 1) then
-                    bfm  =  0.75d0 * beta * c
-                    bfm2 = -0.25d0 * beta * c
+                    bfm  =  0.75e0_rt * beta * c
+                    bfm2 = -0.25e0_rt * beta * c
                  else
-                    bfm = 0.5d0 * beta * c
+                    bfm = 0.5e0_rt * beta * c
                  endif
               else if (bct == LO_SANCHEZ_POMRANING) then
-                 bfv = 2.d0 * beta
+                 bfv = 2.e0_rt * beta
                  if (bho >= 1) then
-                    bfm  =  3.0d0 * spa(i,j,k) * beta * c
-                    bfm2 = -1.0d0 * spa(i,j,k) * beta * c
+                    bfm  =  3.0e0_rt * spa(i,j,k) * beta * c
+                    bfm2 = -1.0e0_rt * spa(i,j,k) * beta * c
                  else
-                    bfm = 2.0d0 * spa(i,j,k) * beta * c
+                    bfm = 2.0e0_rt * spa(i,j,k) * beta * c
                  endif
               else
                  print *, "hbflx3: unsupported boundary type"
                  stop
               endif
               if (inhom == 0) then
-                 bfv = 0.d0
+                 bfv = 0.e0_rt
               endif
               flux(i,j,k+1) = -(bfv * bcval(i,j,k+1) - bfm * er(i,j,k))
               if (bho >= 1) then
@@ -1261,6 +1270,7 @@ subroutine hdterm(dterm, &
                   d, DIMS(dbox), &
                   dx) bind(C, name="hdterm")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(dtbox)
   integer :: DIMDEC(ebox)
   integer :: DIMDEC(reg)
@@ -1268,13 +1278,13 @@ subroutine hdterm(dterm, &
   integer :: DIMDEC(msk)
   integer :: DIMDEC(dbox)
   integer :: cdir, bct
-  real*8 :: bcl, dx(3)
-  real*8 :: dterm(DIMV(dtbox))
-  real*8 :: er(DIMV(ebox))
-  real*8 :: bcval(DIMV(bcv))
+  real(rt)         :: bcl, dx(3)
+  real(rt)         :: dterm(DIMV(dtbox))
+  real(rt)         :: er(DIMV(ebox))
+  real(rt)         :: bcval(DIMV(bcv))
   integer :: mask(DIMV(msk))
-  real*8 :: d(DIMV(dbox))
-  real*8 :: h, bfm, bfv
+  real(rt)         :: d(DIMV(dbox))
+  real(rt)         :: h, bfm, bfv
   integer :: i, j, k
   if (cdir == 0 .OR. cdir == 3) then
      h = dx(1)
@@ -1291,7 +1301,7 @@ subroutine hdterm(dterm, &
               if (mask(i-1,j,k) > 0) then
                  dterm(i,j,k) = d(i,j,k) * &
                       (er(i,j,k) - bcval(i-1,j,k)) &
-                      / (0.5d0*h + bcl)
+                      / (0.5e0_rt*h + bcl)
               endif
            enddo
         enddo
@@ -1302,7 +1312,7 @@ subroutine hdterm(dterm, &
               if (mask(i+1,j,k) > 0) then
                  dterm(i+1,j,k) = d(i+1,j,k) * &
                       (bcval(i+1,j,k) - er(i,j,k)) &
-                      / (0.5d0*h + bcl)
+                      / (0.5e0_rt*h + bcl)
               endif
            enddo
         enddo
@@ -1313,7 +1323,7 @@ subroutine hdterm(dterm, &
               if (mask(i,j-1,k) > 0) then
                  dterm(i,j,k) = d(i,j,k) * &
                       (er(i,j,k) - bcval(i,j-1,k)) &
-                      / (0.5d0*h + bcl)
+                      / (0.5e0_rt*h + bcl)
               endif
            enddo
         enddo
@@ -1324,7 +1334,7 @@ subroutine hdterm(dterm, &
               if (mask(i,j+1,k) > 0) then
                  dterm(i,j+1,k) = d(i,j+1,k) * &
                       (bcval(i,j+1,k) - er(i,j,k)) &
-                      / (0.5d0*h + bcl)
+                      / (0.5e0_rt*h + bcl)
               endif
            enddo
         enddo
@@ -1335,7 +1345,7 @@ subroutine hdterm(dterm, &
               if (mask(i,j,k-1) > 0) then
                  dterm(i,j,k) = d(i,j,k) * &
                       (er(i,j,k) - bcval(i,j,k-1)) &
-                      / (0.5d0*h + bcl)
+                      / (0.5e0_rt*h + bcl)
               endif
            enddo
         enddo
@@ -1346,7 +1356,7 @@ subroutine hdterm(dterm, &
               if (mask(i,j,k+1) > 0) then
                  dterm(i,j,k+1) = d(i,j,k+1) * &
                       (bcval(i,j,k+1) - er(i,j,k)) &
-                      / (0.5d0*h + bcl)
+                      / (0.5e0_rt*h + bcl)
               endif
            enddo
         enddo
@@ -1369,6 +1379,7 @@ subroutine hdterm3(dterm, &
                    d, DIMS(dbox), &
                    dx) bind(C, name="hdterm3")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(dtbox)
   integer :: DIMDEC(ebox)
   integer :: DIMDEC(reg)
@@ -1376,13 +1387,13 @@ subroutine hdterm3(dterm, &
   integer :: DIMDEC(msk)
   integer :: DIMDEC(dbox)
   integer :: cdir, bctype, tf(DIMV(bcv))
-  real*8 :: bcl, dx(3)
-  real*8 :: dterm(DIMV(dtbox))
-  real*8 :: er(DIMV(ebox))
-  real*8 :: bcval(DIMV(bcv))
+  real(rt)         :: bcl, dx(3)
+  real(rt)         :: dterm(DIMV(dtbox))
+  real(rt)         :: er(DIMV(ebox))
+  real(rt)         :: bcval(DIMV(bcv))
   integer :: mask(DIMV(msk))
-  real*8 :: d(DIMV(dbox))
-  real*8 :: h, bfm, bfv
+  real(rt)         :: d(DIMV(dbox))
+  real(rt)         :: h, bfm, bfv
   integer :: i, j, k, bct
   if (cdir == 0 .OR. cdir == 3) then
      h = dx(1)
@@ -1404,10 +1415,10 @@ subroutine hdterm3(dterm, &
               if (bct == LO_DIRICHLET) then
                  dterm(i,j,k) = d(i,j,k) * &
                       (er(i,j,k) - bcval(i-1,j,k)) &
-                      / (0.5d0*h + bcl)
+                      / (0.5e0_rt*h + bcl)
               else if (bct == LO_NEUMANN &
-                   .AND. bcval(i-1,j,k) == 0.d0) then
-                 dterm(i,j,k) = 0.d0
+                   .AND. bcval(i-1,j,k) == 0.e0_rt) then
+                 dterm(i,j,k) = 0.e0_rt
               else
                  print *, "hdterm3: unsupported boundary type"
                  stop
@@ -1428,10 +1439,10 @@ subroutine hdterm3(dterm, &
               if (bct == LO_DIRICHLET) then
                  dterm(i+1,j,k) = d(i+1,j,k) * &
                       (bcval(i+1,j,k) - er(i,j,k)) &
-                      / (0.5d0*h + bcl)
+                      / (0.5e0_rt*h + bcl)
               else if (bct == LO_NEUMANN &
-                   .AND. bcval(i+1,j,k) == 0.d0) then
-                 dterm(i+1,j,k) = 0.d0
+                   .AND. bcval(i+1,j,k) == 0.e0_rt) then
+                 dterm(i+1,j,k) = 0.e0_rt
               else
                  print *, "hdterm3: unsupported boundary type"
                  stop
@@ -1452,10 +1463,10 @@ subroutine hdterm3(dterm, &
               if (bct == LO_DIRICHLET) then
                  dterm(i,j,k) = d(i,j,k) * &
                       (er(i,j,k) - bcval(i,j-1,k)) &
-                      / (0.5d0*h + bcl)
+                      / (0.5e0_rt*h + bcl)
               else if (bct == LO_NEUMANN &
-                   .AND. bcval(i,j-1,k) == 0.d0) then
-                 dterm(i,j,k) = 0.d0
+                   .AND. bcval(i,j-1,k) == 0.e0_rt) then
+                 dterm(i,j,k) = 0.e0_rt
               else
                  print *, "hdterm3: unsupported boundary type"
                  stop
@@ -1476,10 +1487,10 @@ subroutine hdterm3(dterm, &
               if (bct == LO_DIRICHLET) then
                  dterm(i,j+1,k) = d(i,j+1,k) * &
                       (bcval(i,j+1,k) - er(i,j,k)) &
-                      / (0.5d0*h + bcl)
+                      / (0.5e0_rt*h + bcl)
               else if (bct == LO_NEUMANN &
-                   .AND. bcval(i,j+1,k) == 0.d0) then
-                 dterm(i,j+1,k) = 0.d0
+                   .AND. bcval(i,j+1,k) == 0.e0_rt) then
+                 dterm(i,j+1,k) = 0.e0_rt
               else
                  print *, "hdterm3: unsupported boundary type"
                  stop
@@ -1500,10 +1511,10 @@ subroutine hdterm3(dterm, &
               if (bct == LO_DIRICHLET) then
                  dterm(i,j,k) = d(i,j,k) * &
                       (er(i,j,k) - bcval(i,j,k-1)) &
-                      / (0.5d0*h + bcl)
+                      / (0.5e0_rt*h + bcl)
               else if (bct == LO_NEUMANN &
-                   .AND. bcval(i,j,k-1) == 0.d0) then
-                 dterm(i,j,k) = 0.d0
+                   .AND. bcval(i,j,k-1) == 0.e0_rt) then
+                 dterm(i,j,k) = 0.e0_rt
               else
                  print *, "hdterm3: unsupported boundary type"
                  stop
@@ -1524,10 +1535,10 @@ subroutine hdterm3(dterm, &
               if (bct == LO_DIRICHLET) then
                  dterm(i,j,k+1) = d(i,j,k+1) * &
                       (bcval(i,j,k+1) - er(i,j,k)) &
-                      / (0.5d0*h + bcl)
+                      / (0.5e0_rt*h + bcl)
               else if (bct == LO_NEUMANN &
-                   .AND. bcval(i,j,k+1) == 0.d0) then
-                 dterm(i,j,k+1) = 0.d0
+                   .AND. bcval(i,j,k+1) == 0.e0_rt) then
+                 dterm(i,j,k+1) = 0.e0_rt
               else
                  print *, "hdterm3: unsupported boundary type"
                  stop
@@ -1545,17 +1556,18 @@ subroutine hmac(mat, a, &
                 DIMS(reg), &
                 alpha) bind(C, name="hmac")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(abox)
   integer :: DIMDEC(reg)
-  real*8 :: a(DIMV(abox))
-  real*8 :: mat(0:6, DIMV(reg))
-  real*8 :: alpha
+  real(rt)         :: a(DIMV(abox))
+  real(rt)         :: mat(0:6, DIMV(reg))
+  real(rt)         :: alpha
   integer :: i, j, k
-  if (alpha == 0.d0) then
+  if (alpha == 0.e0_rt) then
      do k = reg_l3, reg_h3
         do j = reg_l2, reg_h2
            do i = reg_l1, reg_h1
-              mat(0,i,j,k) = 0.d0
+              mat(0,i,j,k) = 0.e0_rt
            enddo
         enddo
      enddo
@@ -1575,13 +1587,14 @@ subroutine hmbc(mat, b, &
                 DIMS(reg), &
                 beta, dx, n) bind(C, name="hmbc")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(bbox)
   integer :: DIMDEC(reg)
   integer :: n
-  real*8 :: b(DIMV(bbox))
-  real*8 :: mat(0:6, DIMV(reg))
-  real*8 :: beta, dx(3)
-  real*8 :: fac
+  real(rt)         :: b(DIMV(bbox))
+  real(rt)         :: mat(0:6, DIMV(reg))
+  real(rt)         :: beta, dx(3)
+  real(rt)         :: fac
   integer :: i, j, k
   if (n == 0) then
      fac = beta / (dx(1)**2)
@@ -1624,15 +1637,16 @@ subroutine hma2c(mat, a2, &
                  DIMS(reg), &
                  alpha2, n) bind(C, name="hma2c")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(bbox)
   integer :: DIMDEC(reg)
   integer :: n
-  real*8 :: a2(DIMV(bbox))
-  real*8 :: mat(0:6, DIMV(reg))
-  real*8 :: alpha2
-  real*8 :: fac
+  real(rt)         :: a2(DIMV(bbox))
+  real(rt)         :: mat(0:6, DIMV(reg))
+  real(rt)         :: alpha2
+  real(rt)         :: fac
   integer :: i, j, k
-  fac = 0.25d0 * alpha2
+  fac = 0.25e0_rt * alpha2
   if (n == 0) then
      do k = reg_l3, reg_h3
         do j = reg_l2, reg_h2
@@ -1671,16 +1685,17 @@ subroutine hmcc(mat, c, &
                 DIMS(reg), &
                 gamma, dx, n) bind(C, name="hmcc")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(bbox)
   integer :: DIMDEC(reg)
   integer :: n
-  real*8 :: c(DIMV(bbox))
-  real*8 :: mat(0:6, DIMV(reg))
-  real*8 :: gamma, dx(3)
-  real*8 :: fac
+  real(rt)         :: c(DIMV(bbox))
+  real(rt)         :: mat(0:6, DIMV(reg))
+  real(rt)         :: gamma, dx(3)
+  real(rt)         :: fac
   integer :: i, j, k
   if (n == 0) then
-     fac = 0.5d0 * gamma / dx(1)
+     fac = 0.5e0_rt * gamma / dx(1)
      do k = reg_l3, reg_h3
         do j = reg_l2, reg_h2
            do i = reg_l1, reg_h1
@@ -1691,7 +1706,7 @@ subroutine hmcc(mat, c, &
         enddo
      enddo
   elseif (n == 1) then
-     fac = 0.5d0 * gamma / dx(2)
+     fac = 0.5e0_rt * gamma / dx(2)
      do k = reg_l3, reg_h3
         do j = reg_l2, reg_h2
            do i = reg_l1, reg_h1
@@ -1702,7 +1717,7 @@ subroutine hmcc(mat, c, &
         enddo
      enddo
   else
-     fac = 0.5d0 * gamma / dx(3)
+     fac = 0.5e0_rt * gamma / dx(3)
      do k = reg_l3, reg_h3
         do j = reg_l2, reg_h2
            do i = reg_l1, reg_h1
@@ -1720,16 +1735,17 @@ subroutine hmd1c(mat, d1, &
                  DIMS(reg), &
                  delta1, dx, n) bind(C, name="hmd1c")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(abox)
   integer :: DIMDEC(reg)
   integer :: n
-  real*8 :: d1(DIMV(abox))
-  real*8 :: mat(0:6, DIMV(reg))
-  real*8 :: delta1, dx(3)
-  real*8 :: fac
+  real(rt)         :: d1(DIMV(abox))
+  real(rt)         :: mat(0:6, DIMV(reg))
+  real(rt)         :: delta1, dx(3)
+  real(rt)         :: fac
   integer :: i, j, k
   if (n == 0) then
-     fac = 0.5d0 * delta1 / dx(1)
+     fac = 0.5e0_rt * delta1 / dx(1)
      do k = reg_l3, reg_h3
         do j = reg_l2, reg_h2
            do i = reg_l1, reg_h1
@@ -1739,7 +1755,7 @@ subroutine hmd1c(mat, d1, &
         enddo
      enddo
   elseif (n == 1) then
-     fac = 0.5d0 * delta1 / dx(2)
+     fac = 0.5e0_rt * delta1 / dx(2)
      do k = reg_l3, reg_h3
         do j = reg_l2, reg_h2
            do i = reg_l1, reg_h1
@@ -1749,7 +1765,7 @@ subroutine hmd1c(mat, d1, &
         enddo
      enddo
   else
-     fac = 0.5d0 * delta1 / dx(3)
+     fac = 0.5e0_rt * delta1 / dx(3)
      do k = reg_l3, reg_h3
         do j = reg_l2, reg_h2
            do i = reg_l1, reg_h1
@@ -1766,16 +1782,17 @@ subroutine hmd2c(mat, d2, &
                  DIMS(reg), &
                  delta2, dx, n) bind(C, name="hmd2c")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(bbox)
   integer :: DIMDEC(reg)
   integer :: n
-  real*8 :: d2(DIMV(bbox))
-  real*8 :: mat(0:6, DIMV(reg))
-  real*8 :: delta2, dx(3)
-  real*8 :: fac
+  real(rt)         :: d2(DIMV(bbox))
+  real(rt)         :: mat(0:6, DIMV(reg))
+  real(rt)         :: delta2, dx(3)
+  real(rt)         :: fac
   integer :: i, j, k
   if (n == 0) then
-     fac = 0.5d0 * delta2 / dx(1)
+     fac = 0.5e0_rt * delta2 / dx(1)
      do k = reg_l3, reg_h3
         do j = reg_l2, reg_h2
            do i = reg_l1, reg_h1
@@ -1786,7 +1803,7 @@ subroutine hmd2c(mat, d2, &
         enddo
      enddo
   elseif (n == 1) then
-     fac = 0.5d0 * delta2 / dx(2)
+     fac = 0.5e0_rt * delta2 / dx(2)
      do k = reg_l3, reg_h3
         do j = reg_l2, reg_h2
            do i = reg_l1, reg_h1
@@ -1797,7 +1814,7 @@ subroutine hmd2c(mat, d2, &
         enddo
      enddo
   else
-     fac = 0.5d0 * delta2 / dx(3)
+     fac = 0.5e0_rt * delta2 / dx(3)
      do k = reg_l3, reg_h3
         do j = reg_l2, reg_h2
            do i = reg_l1, reg_h1
@@ -1817,16 +1834,17 @@ subroutine hmmat(mat, &
                  b, DIMS(bbox), &
                  beta, dx) bind(C, name="hmmat")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(reg)
   integer :: DIMDEC(msk)
   integer :: DIMDEC(bbox)
   integer :: cdir, bct, bho
-  real*8 :: bcl, beta, dx(3)
-  real*8 :: mat(0:6, DIMV(reg))
+  real(rt)         :: bcl, beta, dx(3)
+  real(rt)         :: mat(0:6, DIMV(reg))
   integer :: mask(DIMV(msk))
-  real*8 :: b(DIMV(bbox))
-  real*8 :: h, fac, bfm, bfv
-  real*8 :: bfm2, h2, th2
+  real(rt)         :: b(DIMV(bbox))
+  real(rt)         :: h, fac, bfm, bfv
+  real(rt)         :: bfm2, h2, th2
   integer :: i, j, k
   if (cdir == 0 .OR. cdir == 3) then
      h = dx(1)
@@ -1838,17 +1856,17 @@ subroutine hmmat(mat, &
   fac = beta / (h**2)
   if (bct == LO_DIRICHLET) then
      if (bho >= 1) then
-        h2 = 0.5d0 * h
-        th2 = 3.d0 * h2
+        h2 = 0.5e0_rt * h
+        th2 = 3.e0_rt * h2
         bfm = fac * (th2 - bcl) / (bcl + h2) - fac
         bfm2 = fac * (bcl - h2) / (bcl + th2)
      else
-        bfv = (beta / h) / (0.5d0 * h + bcl)
+        bfv = (beta / h) / (0.5e0_rt * h + bcl)
         bfm = bfv - fac
      endif
   else if (bct == LO_NEUMANN) then
      bfm = -fac
-     bfm2 = 0.d0
+     bfm2 = 0.e0_rt
   else
      print *, "hmmat: unsupported boundary type"
      stop
@@ -1859,7 +1877,7 @@ subroutine hmmat(mat, &
         do j = reg_l2, reg_h2
            if (mask(i-1,j,k) > 0) then
               mat(0,i,j,k) = mat(0,i,j,k) + bfm * b(i,j,k)
-              mat(1,i,j,k) = 0.d0
+              mat(1,i,j,k) = 0.e0_rt
               if (bho >= 1) then
                  mat(2,i,j,k) = mat(2,i,j,k) + bfm2 * b(i,j,k)
               endif
@@ -1872,7 +1890,7 @@ subroutine hmmat(mat, &
         do j = reg_l2, reg_h2
            if (mask(i+1,j,k) > 0) then
               mat(0,i,j,k) = mat(0,i,j,k) + bfm * b(i+1,j,k)
-              mat(2,i,j,k) = 0.d0
+              mat(2,i,j,k) = 0.e0_rt
               if (bho >= 1) then
                  mat(1,i,j,k) = mat(1,i,j,k) + bfm2 * b(i+1,j,k)
               endif
@@ -1885,7 +1903,7 @@ subroutine hmmat(mat, &
         do i = reg_l1, reg_h1
            if (mask(i,j-1,k) > 0) then
               mat(0,i,j,k) = mat(0,i,j,k) + bfm * b(i,j,k)
-              mat(3,i,j,k) = 0.d0
+              mat(3,i,j,k) = 0.e0_rt
               if (bho >= 1) then
                  mat(4,i,j,k) = mat(4,i,j,k) + bfm2 * b(i,j,k)
               endif
@@ -1898,7 +1916,7 @@ subroutine hmmat(mat, &
         do i = reg_l1, reg_h1
            if (mask(i,j+1,k) > 0) then
               mat(0,i,j,k) = mat(0,i,j,k) + bfm * b(i,j+1,k)
-              mat(4,i,j,k) = 0.d0
+              mat(4,i,j,k) = 0.e0_rt
               if (bho >= 1) then
                  mat(3,i,j,k) = mat(3,i,j,k) + bfm2 * b(i,j+1,k)
               endif
@@ -1911,7 +1929,7 @@ subroutine hmmat(mat, &
         do i = reg_l1, reg_h1
            if (mask(i,j,k-1) > 0) then
               mat(0,i,j,k) = mat(0,i,j,k) + bfm * b(i,j,k)
-              mat(5,i,j,k) = 0.d0
+              mat(5,i,j,k) = 0.e0_rt
               if (bho >= 1) then
                  mat(6,i,j,k) = mat(6,i,j,k) + bfm2 * b(i,j,k)
               endif
@@ -1924,7 +1942,7 @@ subroutine hmmat(mat, &
         do i = reg_l1, reg_h1
            if (mask(i,j,k+1) > 0) then
               mat(0,i,j,k) = mat(0,i,j,k) + bfm * b(i,j,k+1)
-              mat(6,i,j,k) = 0.d0
+              mat(6,i,j,k) = 0.e0_rt
               if (bho >= 1) then
                  mat(5,i,j,k) = mat(5,i,j,k) + bfm2 * b(i,j,k+1)
               endif
@@ -1945,20 +1963,21 @@ subroutine hmmat3(mat, &
                   beta, dx, c, r, &
                   spa, DIMS(spabox)) bind(C, name="hmmat3")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(reg)
   integer :: DIMDEC(bcv)
   integer :: DIMDEC(msk)
   integer :: DIMDEC(bbox)
   integer :: DIMDEC(spabox)
   integer :: cdir, bctype, tf(DIMV(bcv)), bho
-  real*8 :: bcl, beta, dx(3), c
-  real*8 :: mat(0:6, DIMV(reg))
+  real(rt)         :: bcl, beta, dx(3), c
+  real(rt)         :: mat(0:6, DIMV(reg))
   integer :: mask(DIMV(msk))
-  real*8 :: b(DIMV(bbox))
-  real*8 :: spa(DIMV(spabox))
-  real*8 :: r(1)
-  real*8 :: h, fac, bfm, bfv
-  real*8 :: bfm2, h2, th2
+  real(rt)         :: b(DIMV(bbox))
+  real(rt)         :: spa(DIMV(spabox))
+  real(rt)         :: r(1)
+  real(rt)         :: h, fac, bfm, bfv
+  real(rt)         :: bfm2, h2, th2
   integer :: i, j, k, bct
   ! The -fac * b(i,j,k) term applied to the matrix diagonal is the contribution
   ! from the interior stencil which must be removed at the boundary.
@@ -1982,30 +2001,30 @@ subroutine hmmat3(mat, &
               endif
               if (bct == LO_DIRICHLET) then
                  if (bho >= 1) then
-                    h2 = 0.5d0 * h
-                    th2 = 3.d0 * h2
+                    h2 = 0.5e0_rt * h
+                    th2 = 3.e0_rt * h2
                     bfm = fac * (th2 - bcl) / (bcl + h2)  * b(i,j,k)
                     bfm2 = fac * (bcl - h2) / (bcl + th2) * b(i,j,k)
                  else
-                    bfv = (beta / h) / (0.5d0 * h + bcl)
+                    bfv = (beta / h) / (0.5e0_rt * h + bcl)
                     bfm = bfv * b(i,j,k)
                  endif
               else if (bct == LO_NEUMANN) then
-                 bfm  = 0.d0
-                 bfm2 = 0.d0
+                 bfm  = 0.e0_rt
+                 bfm2 = 0.e0_rt
               else if (bct == LO_MARSHAK) then
-                 bfv = 2.d0 * c * beta / h
+                 bfv = 2.e0_rt * c * beta / h
                  if (bho >= 1) then
-                    bfm  =  0.375d0 * bfv
-                    bfm2 = -0.125d0 * bfv
+                    bfm  =  0.375e0_rt * bfv
+                    bfm2 = -0.125e0_rt * bfv
                  else
-                    bfm = 0.25d0 * bfv
+                    bfm = 0.25e0_rt * bfv
                  endif
               else if (bct == LO_SANCHEZ_POMRANING) then
-                 bfv = 2.d0 * c * beta / h
+                 bfv = 2.e0_rt * c * beta / h
                  if (bho >= 1) then
-                    bfm  =  1.5d0 * spa(i,j,k) * bfv
-                    bfm2 = -0.5d0 * spa(i,j,k) * bfv
+                    bfm  =  1.5e0_rt * spa(i,j,k) * bfv
+                    bfm2 = -0.5e0_rt * spa(i,j,k) * bfv
                  else
                     bfm = spa(i,j,k) * bfv
                  endif
@@ -2014,7 +2033,7 @@ subroutine hmmat3(mat, &
                  stop
               endif
               mat(0,i,j,k) = mat(0,i,j,k) + bfm - fac * b(i,j,k)
-              mat(1,i,j,k) = 0.d0
+              mat(1,i,j,k) = 0.e0_rt
               if (bho >= 1) then
                  mat(2,i,j,k) = mat(2,i,j,k) + bfm2
               endif
@@ -2033,30 +2052,30 @@ subroutine hmmat3(mat, &
               endif
               if (bct == LO_DIRICHLET) then
                  if (bho >= 1) then
-                    h2 = 0.5d0 * h
-                    th2 = 3.d0 * h2
+                    h2 = 0.5e0_rt * h
+                    th2 = 3.e0_rt * h2
                     bfm = fac * (th2 - bcl) / (bcl + h2)  * b(i+1,j,k)
                     bfm2 = fac * (bcl - h2) / (bcl + th2) * b(i+1,j,k)
                  else
-                    bfv = (beta / h) / (0.5d0 * h + bcl)
+                    bfv = (beta / h) / (0.5e0_rt * h + bcl)
                     bfm = bfv * b(i+1,j,k)
                  endif
               else if (bct == LO_NEUMANN) then
-                 bfm  = 0.d0
-                 bfm2 = 0.d0
+                 bfm  = 0.e0_rt
+                 bfm2 = 0.e0_rt
               else if (bct == LO_MARSHAK) then
-                 bfv = 2.d0 * c * beta / h
+                 bfv = 2.e0_rt * c * beta / h
                  if (bho >= 1) then
-                    bfm  =  0.375d0 * bfv
-                    bfm2 = -0.125d0 * bfv
+                    bfm  =  0.375e0_rt * bfv
+                    bfm2 = -0.125e0_rt * bfv
                  else
-                    bfm = 0.25d0 * bfv
+                    bfm = 0.25e0_rt * bfv
                  endif
               else if (bct == LO_SANCHEZ_POMRANING) then
-                 bfv = 2.d0 * c * beta / h
+                 bfv = 2.e0_rt * c * beta / h
                  if (bho >= 1) then
-                    bfm  =  1.5d0 * spa(i,j,k) * bfv
-                    bfm2 = -0.5d0 * spa(i,j,k) * bfv
+                    bfm  =  1.5e0_rt * spa(i,j,k) * bfv
+                    bfm2 = -0.5e0_rt * spa(i,j,k) * bfv
                  else
                     bfm = spa(i,j,k) * bfv
                  endif
@@ -2065,7 +2084,7 @@ subroutine hmmat3(mat, &
                  stop
               endif
               mat(0,i,j,k) = mat(0,i,j,k) + bfm - fac * b(i+1,j,k)
-              mat(2,i,j,k) = 0.d0
+              mat(2,i,j,k) = 0.e0_rt
               if (bho >= 1) then
                  mat(1,i,j,k) = mat(1,i,j,k) + bfm2
               endif
@@ -2084,30 +2103,30 @@ subroutine hmmat3(mat, &
               endif
               if (bct == LO_DIRICHLET) then
                  if (bho >= 1) then
-                    h2 = 0.5d0 * h
-                    th2 = 3.d0 * h2
+                    h2 = 0.5e0_rt * h
+                    th2 = 3.e0_rt * h2
                     bfm = fac * (th2 - bcl) / (bcl + h2)  * b(i,j,k)
                     bfm2 = fac * (bcl - h2) / (bcl + th2) * b(i,j,k)
                  else
-                    bfv = (beta / h) / (0.5d0 * h + bcl)
+                    bfv = (beta / h) / (0.5e0_rt * h + bcl)
                     bfm = bfv * b(i,j,k)
                  endif
               else if (bct == LO_NEUMANN) then
-                 bfm  = 0.d0
-                 bfm2 = 0.d0
+                 bfm  = 0.e0_rt
+                 bfm2 = 0.e0_rt
               else if (bct == LO_MARSHAK) then
-                 bfv = 2.d0 * c * beta / h
+                 bfv = 2.e0_rt * c * beta / h
                  if (bho >= 1) then
-                    bfm  =  0.375d0 * bfv
-                    bfm2 = -0.125d0 * bfv
+                    bfm  =  0.375e0_rt * bfv
+                    bfm2 = -0.125e0_rt * bfv
                  else
-                    bfm = 0.25d0 * bfv
+                    bfm = 0.25e0_rt * bfv
                  endif
               else if (bct == LO_SANCHEZ_POMRANING) then
-                 bfv = 2.d0 * c * beta / h
+                 bfv = 2.e0_rt * c * beta / h
                  if (bho >= 1) then
-                    bfm  =  1.5d0 * spa(i,j,k) * bfv
-                    bfm2 = -0.5d0 * spa(i,j,k) * bfv
+                    bfm  =  1.5e0_rt * spa(i,j,k) * bfv
+                    bfm2 = -0.5e0_rt * spa(i,j,k) * bfv
                  else
                     bfm = spa(i,j,k) * bfv
                  endif
@@ -2116,7 +2135,7 @@ subroutine hmmat3(mat, &
                  stop
               endif
               mat(0,i,j,k) = mat(0,i,j,k) + bfm - fac * b(i,j,k)
-              mat(3,i,j,k) = 0.d0
+              mat(3,i,j,k) = 0.e0_rt
               if (bho >= 1) then
                  mat(4,i,j,k) = mat(4,i,j,k) + bfm2
               endif
@@ -2135,30 +2154,30 @@ subroutine hmmat3(mat, &
               endif
               if (bct == LO_DIRICHLET) then
                  if (bho >= 1) then
-                    h2 = 0.5d0 * h
-                    th2 = 3.d0 * h2
+                    h2 = 0.5e0_rt * h
+                    th2 = 3.e0_rt * h2
                     bfm = fac * (th2 - bcl) / (bcl + h2)  * b(i,j+1,k)
                     bfm2 = fac * (bcl - h2) / (bcl + th2) * b(i,j+1,k)
                  else
-                    bfv = (beta / h) / (0.5d0 * h + bcl)
+                    bfv = (beta / h) / (0.5e0_rt * h + bcl)
                     bfm = bfv * b(i,j+1,k)
                  endif
               else if (bct == LO_NEUMANN) then
-                 bfm  = 0.d0
-                 bfm2 = 0.d0
+                 bfm  = 0.e0_rt
+                 bfm2 = 0.e0_rt
               else if (bct == LO_MARSHAK) then
-                 bfv = 2.d0 * c * beta / h
+                 bfv = 2.e0_rt * c * beta / h
                  if (bho >= 1) then
-                    bfm  =  0.375d0 * bfv
-                    bfm2 = -0.125d0 * bfv
+                    bfm  =  0.375e0_rt * bfv
+                    bfm2 = -0.125e0_rt * bfv
                  else
-                    bfm = 0.25d0 * bfv
+                    bfm = 0.25e0_rt * bfv
                  endif
               else if (bct == LO_SANCHEZ_POMRANING) then
-                 bfv = 2.d0 * c * beta / h
+                 bfv = 2.e0_rt * c * beta / h
                  if (bho >= 1) then
-                    bfm  =  1.5d0 * spa(i,j,k) * bfv
-                    bfm2 = -0.5d0 * spa(i,j,k) * bfv
+                    bfm  =  1.5e0_rt * spa(i,j,k) * bfv
+                    bfm2 = -0.5e0_rt * spa(i,j,k) * bfv
                  else
                     bfm = spa(i,j,k) * bfv
                  endif
@@ -2167,7 +2186,7 @@ subroutine hmmat3(mat, &
                  stop
               endif
               mat(0,i,j,k) = mat(0,i,j,k) + bfm - fac * b(i,j+1,k)
-              mat(4,i,j,k) = 0.d0
+              mat(4,i,j,k) = 0.e0_rt
               if (bho >= 1) then
                  mat(3,i,j,k) = mat(3,i,j,k) + bfm2
               endif
@@ -2186,30 +2205,30 @@ subroutine hmmat3(mat, &
               endif
               if (bct == LO_DIRICHLET) then
                  if (bho >= 1) then
-                    h2 = 0.5d0 * h
-                    th2 = 3.d0 * h2
+                    h2 = 0.5e0_rt * h
+                    th2 = 3.e0_rt * h2
                     bfm = fac * (th2 - bcl) / (bcl + h2)  * b(i,j,k)
                     bfm2 = fac * (bcl - h2) / (bcl + th2) * b(i,j,k)
                  else
-                    bfv = (beta / h) / (0.5d0 * h + bcl)
+                    bfv = (beta / h) / (0.5e0_rt * h + bcl)
                     bfm = bfv * b(i,j,k)
                  endif
               else if (bct == LO_NEUMANN) then
-                 bfm  = 0.d0
-                 bfm2 = 0.d0
+                 bfm  = 0.e0_rt
+                 bfm2 = 0.e0_rt
               else if (bct == LO_MARSHAK) then
-                 bfv = 2.d0 * c * beta / h
+                 bfv = 2.e0_rt * c * beta / h
                  if (bho >= 1) then
-                    bfm  =  0.375d0 * bfv
-                    bfm2 = -0.125d0 * bfv
+                    bfm  =  0.375e0_rt * bfv
+                    bfm2 = -0.125e0_rt * bfv
                  else
-                    bfm = 0.25d0 * bfv
+                    bfm = 0.25e0_rt * bfv
                  endif
               else if (bct == LO_SANCHEZ_POMRANING) then
-                 bfv = 2.d0 * c * beta / h
+                 bfv = 2.e0_rt * c * beta / h
                  if (bho >= 1) then
-                    bfm  =  1.5d0 * spa(i,j,k) * bfv
-                    bfm2 = -0.5d0 * spa(i,j,k) * bfv
+                    bfm  =  1.5e0_rt * spa(i,j,k) * bfv
+                    bfm2 = -0.5e0_rt * spa(i,j,k) * bfv
                  else
                     bfm = spa(i,j,k) * bfv
                  endif
@@ -2218,7 +2237,7 @@ subroutine hmmat3(mat, &
                  stop
               endif
               mat(0,i,j,k) = mat(0,i,j,k) + bfm - fac * b(i,j,k)
-              mat(5,i,j,k) = 0.d0
+              mat(5,i,j,k) = 0.e0_rt
               if (bho >= 1) then
                  mat(6,i,j,k) = mat(6,i,j,k) + bfm2
               endif
@@ -2237,30 +2256,30 @@ subroutine hmmat3(mat, &
               endif
               if (bct == LO_DIRICHLET) then
                  if (bho >= 1) then
-                    h2 = 0.5d0 * h
-                    th2 = 3.d0 * h2
+                    h2 = 0.5e0_rt * h
+                    th2 = 3.e0_rt * h2
                     bfm = fac * (th2 - bcl) / (bcl + h2)  * b(i,j,k+1)
                     bfm2 = fac * (bcl - h2) / (bcl + th2) * b(i,j,k+1)
                  else
-                    bfv = (beta / h) / (0.5d0 * h + bcl)
+                    bfv = (beta / h) / (0.5e0_rt * h + bcl)
                     bfm = bfv * b(i,j,k+1)
                  endif
               else if (bct == LO_NEUMANN) then
-                 bfm  = 0.d0
-                 bfm2 = 0.d0
+                 bfm  = 0.e0_rt
+                 bfm2 = 0.e0_rt
               else if (bct == LO_MARSHAK) then
-                 bfv = 2.d0 * c * beta / h
+                 bfv = 2.e0_rt * c * beta / h
                  if (bho >= 1) then
-                    bfm  =  0.375d0 * bfv
-                    bfm2 = -0.125d0 * bfv
+                    bfm  =  0.375e0_rt * bfv
+                    bfm2 = -0.125e0_rt * bfv
                  else
-                    bfm = 0.25d0 * bfv
+                    bfm = 0.25e0_rt * bfv
                  endif
               else if (bct == LO_SANCHEZ_POMRANING) then
-                 bfv = 2.d0 * c * beta / h
+                 bfv = 2.e0_rt * c * beta / h
                  if (bho >= 1) then
-                    bfm  =  1.5d0 * spa(i,j,k) * bfv
-                    bfm2 = -0.5d0 * spa(i,j,k) * bfv
+                    bfm  =  1.5e0_rt * spa(i,j,k) * bfv
+                    bfm2 = -0.5e0_rt * spa(i,j,k) * bfv
                  else
                     bfm = spa(i,j,k) * bfv
                  endif
@@ -2269,7 +2288,7 @@ subroutine hmmat3(mat, &
                  stop
               endif
               mat(0,i,j,k) = mat(0,i,j,k) + bfm - fac * b(i,j,k+1)
-              mat(6,i,j,k) = 0.d0
+              mat(6,i,j,k) = 0.e0_rt
               if (bho >= 1) then
                  mat(5,i,j,k) = mat(5,i,j,k) + bfm2
               endif
@@ -2289,17 +2308,18 @@ subroutine set_abec_flux( &
                          dx, &
                          flux, DIMS(flux)) bind(C, name="set_abec_flux")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(reg)
   integer :: DIMDEC(density)
   integer :: DIMDEC(dcoef)
   integer :: DIMDEC(flux)
 
-  real*8 :: density(DIMV(density))
-  real*8 :: dcoef(DIMV(dcoef))
-  real*8 :: flux(DIMV(flux))
+  real(rt)         :: density(DIMV(density))
+  real(rt)         :: dcoef(DIMV(dcoef))
+  real(rt)         :: flux(DIMV(flux))
 
   integer :: dir,i,j,k
-  real*8 :: beta, dx(BL_SPACEDIM), fac
+  real(rt)         :: beta, dx(BL_SPACEDIM), fac
 
 
   if( dir == 0 ) then

--- a/Source/Radiation/RadSrc_3d/MGFLD_3d.f90
+++ b/Source/Radiation/RadSrc_3d/MGFLD_3d.f90
@@ -9,6 +9,7 @@ subroutine ca_accel_acoe( lo, hi,  &
 
   use rad_params_module, only : ngroups, clight
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: lo(3), hi(3)
@@ -16,16 +17,16 @@ subroutine ca_accel_acoe( lo, hi,  &
   integer, intent(in) ::  spc_l1, spc_h1, spc_l2, spc_h2, spc_l3, spc_h3
   integer, intent(in) ::  kap_l1, kap_h1, kap_l2, kap_h2, kap_l3, kap_h3
   integer, intent(in) ::  aco_l1, aco_h1, aco_l2, aco_h2, aco_l3, aco_h3
-  double precision, intent(in)::eta1(eta1_l1:eta1_h1,eta1_l2:eta1_h2,eta1_l3:eta1_h3)
-  double precision, intent(in)::spc ( spc_l1: spc_h1, spc_l2: spc_h2, spc_l3: spc_h3,0:ngroups-1)
-  double precision, intent(in)::kap ( kap_l1: kap_h1, kap_l2: kap_h2, kap_l3: kap_h3,0:ngroups-1)
-  double precision            ::aco ( aco_l1: aco_h1, aco_l2: aco_h2, aco_l3: aco_h3)
-  double precision, intent(in)::dt, tau
+  real(rt)        , intent(in)::eta1(eta1_l1:eta1_h1,eta1_l2:eta1_h2,eta1_l3:eta1_h3)
+  real(rt)        , intent(in)::spc ( spc_l1: spc_h1, spc_l2: spc_h2, spc_l3: spc_h3,0:ngroups-1)
+  real(rt)        , intent(in)::kap ( kap_l1: kap_h1, kap_l2: kap_h2, kap_l3: kap_h3,0:ngroups-1)
+  real(rt)                    ::aco ( aco_l1: aco_h1, aco_l2: aco_h2, aco_l3: aco_h3)
+  real(rt)        , intent(in)::dt, tau
 
   integer :: i, j, k
-  double precision :: kbar, H1, dt1
+  real(rt)         :: kbar, H1, dt1
 
-  dt1 = (1.d0+tau)/dt
+  dt1 = (1.e0_rt+tau)/dt
 
   do k = lo(3), hi(3)
   do j = lo(2), hi(2)
@@ -50,6 +51,7 @@ subroutine ca_accel_rhs( lo, hi, &
 
   use rad_params_module, only : ngroups, clight
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: lo(3), hi(3)
@@ -58,15 +60,15 @@ subroutine ca_accel_rhs( lo, hi, &
   integer, intent(in) :: kap_l1, kap_h1, kap_l2, kap_h2, kap_l3, kap_h3
   integer, intent(in) ::etaT_l1,etaT_h1,etaT_l2,etaT_h2,etaT_l3,etaT_h3
   integer, intent(in) :: rhs_l1, rhs_h1, rhs_l2, rhs_h2, rhs_l3, rhs_h3
-  double precision,intent(in)::Ern ( Ern_l1: Ern_h1, Ern_l2: Ern_h2, Ern_l3: Ern_h3,0:ngroups-1)
-  double precision,intent(in)::Erl ( Erl_l1: Erl_h1, Erl_l2: Erl_h2, Erl_l3: Erl_h3,0:ngroups-1)
-  double precision,intent(in):: kap( kap_l1: kap_h1, kap_l2: kap_h2, kap_l3: kap_h3,0:ngroups-1)
-  double precision,intent(in)::etaT(etaT_l1:etaT_h1,etaT_l2:etaT_h2,etaT_l3:etaT_h3)
-  double precision           :: rhs( rhs_l1: rhs_h1, rhs_l2: rhs_h2, rhs_l3: rhs_h3)
-  double precision,intent(in) :: dt
+  real(rt)        ,intent(in)::Ern ( Ern_l1: Ern_h1, Ern_l2: Ern_h2, Ern_l3: Ern_h3,0:ngroups-1)
+  real(rt)        ,intent(in)::Erl ( Erl_l1: Erl_h1, Erl_l2: Erl_h2, Erl_l3: Erl_h3,0:ngroups-1)
+  real(rt)        ,intent(in):: kap( kap_l1: kap_h1, kap_l2: kap_h2, kap_l3: kap_h3,0:ngroups-1)
+  real(rt)        ,intent(in)::etaT(etaT_l1:etaT_h1,etaT_l2:etaT_h2,etaT_l3:etaT_h3)
+  real(rt)                   :: rhs( rhs_l1: rhs_h1, rhs_l2: rhs_h2, rhs_l3: rhs_h3)
+  real(rt)        ,intent(in) :: dt
 
   integer :: i, j, k
-  double precision :: rt_term, H
+  real(rt)         :: rt_term, H
 
   do k = lo(3), hi(3)
   do j = lo(2), hi(2)
@@ -89,31 +91,32 @@ subroutine ca_accel_spec(lo, hi, &
 
   use rad_params_module, only : ngroups, clight
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: lo(3), hi(3)
   integer,intent(in):: kap_l1, kap_h1, kap_l2, kap_h2, kap_l3, kap_h3
   integer,intent(in)::mugT_l1,mugT_h1,mugT_l2,mugT_h2,mugT_l3,mugT_h3
   integer,intent(in)::spec_l1,spec_h1,spec_l2,spec_h2,spec_l3,spec_h3
-  double precision,intent(in)::kap ( kap_l1: kap_h1, kap_l2: kap_h2, kap_l3: kap_h3,0:ngroups-1)
-  double precision,intent(in)::mugT(mugT_l1:mugT_h1,mugT_l2:mugT_h2,mugT_l3:mugT_h3,0:ngroups-1)
-  double precision           ::spec(spec_l1:spec_h1,spec_l2:spec_h2,spec_l3:spec_h3,0:ngroups-1)
-  double precision,intent(in):: dt, tau
+  real(rt)        ,intent(in)::kap ( kap_l1: kap_h1, kap_l2: kap_h2, kap_l3: kap_h3,0:ngroups-1)
+  real(rt)        ,intent(in)::mugT(mugT_l1:mugT_h1,mugT_l2:mugT_h2,mugT_l3:mugT_h3,0:ngroups-1)
+  real(rt)                   ::spec(spec_l1:spec_h1,spec_l2:spec_h2,spec_l3:spec_h3,0:ngroups-1)
+  real(rt)        ,intent(in):: dt, tau
 
   integer :: i, j, k
-  double precision :: cdt1, sumeps
-  double precision,dimension(0:ngroups-1):: epsilon, kapt
+  real(rt)         :: cdt1, sumeps
+  real(rt)        ,dimension(0:ngroups-1):: epsilon, kapt
 
-  cdt1 = 1.d0/(clight*dt)
+  cdt1 = 1.e0_rt/(clight*dt)
 
   do k = lo(3), hi(3)
   do j = lo(2), hi(2)
   do i = lo(1), hi(1)
-     kapt = kap(i,j,k,:) + (1.d0+tau)*cdt1
+     kapt = kap(i,j,k,:) + (1.e0_rt+tau)*cdt1
      epsilon = mugT(i,j,k,:) / kapt
      sumeps = sum(epsilon)
-     if (sumeps .eq. 0.d0) then
-        spec(i,j,k,:) = 0.d0
+     if (sumeps .eq. 0.e0_rt) then
+        spec(i,j,k,:) = 0.e0_rt
      else
         spec(i,j,k,:) = epsilon / sumeps
      end if
@@ -140,6 +143,7 @@ subroutine ca_check_conv( lo, hi, &
      dt)
   use rad_params_module, only : ngroups, clight
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer,intent(in)::lo(3),hi(3)
@@ -153,22 +157,22 @@ subroutine ca_check_conv( lo, hi, &
   integer,intent(in)::kap_l1, kap_h1, kap_l2, kap_h2, kap_l3, kap_h3
   integer,intent(in):: jg_l1,  jg_h1,  jg_l2,  jg_h2,  jg_l3,  jg_h3
   integer,intent(in)::deT_l1, deT_h1, deT_l2, deT_h2, deT_l3, deT_h3
-  double precision,intent(in)::ren(ren_l1:ren_h1,ren_l2:ren_h2,ren_l3:ren_h3)
-  double precision,intent(in)::res(res_l1:res_h1,res_l2:res_h2,res_l3:res_h3)
-  double precision,intent(in)::re2(re2_l1:re2_h1,re2_l2:re2_h2,re2_l3:re2_h3)
-  double precision,intent(in)::ern(ern_l1:ern_h1,ern_l2:ern_h2,ern_l3:ern_h3,0:ngroups-1)
-  double precision,intent(in)::Tmn(Tmn_l1:Tmn_h1,Tmn_l2:Tmn_h2,Tmn_l3:Tmn_h3)
-  double precision,intent(in)::Tms(Tms_l1:Tms_h1,Tms_l2:Tms_h2,Tms_l3:Tms_h3)
-  double precision,intent(in)::rho(rho_l1:rho_h1,rho_l2:rho_h2,rho_l3:rho_h3)
-  double precision,intent(in)::kap(kap_l1:kap_h1,kap_l2:kap_h2,kap_l3:kap_h3,0:ngroups-1)
-  double precision,intent(in):: jg( jg_l1: jg_h1, jg_l2: jg_h2, jg_l3: jg_h3,0:ngroups-1)
-  double precision,intent(in)::deT(deT_l1:deT_h1,deT_l2:deT_h2,deT_l3:deT_h3)
-  double precision,intent(inout)::rel_re, abs_re 
-  double precision,intent(inout)::rel_FT, abs_FT,rel_T, abs_T
-  double precision,intent(in) :: dt
+  real(rt)        ,intent(in)::ren(ren_l1:ren_h1,ren_l2:ren_h2,ren_l3:ren_h3)
+  real(rt)        ,intent(in)::res(res_l1:res_h1,res_l2:res_h2,res_l3:res_h3)
+  real(rt)        ,intent(in)::re2(re2_l1:re2_h1,re2_l2:re2_h2,re2_l3:re2_h3)
+  real(rt)        ,intent(in)::ern(ern_l1:ern_h1,ern_l2:ern_h2,ern_l3:ern_h3,0:ngroups-1)
+  real(rt)        ,intent(in)::Tmn(Tmn_l1:Tmn_h1,Tmn_l2:Tmn_h2,Tmn_l3:Tmn_h3)
+  real(rt)        ,intent(in)::Tms(Tms_l1:Tms_h1,Tms_l2:Tms_h2,Tms_l3:Tms_h3)
+  real(rt)        ,intent(in)::rho(rho_l1:rho_h1,rho_l2:rho_h2,rho_l3:rho_h3)
+  real(rt)        ,intent(in)::kap(kap_l1:kap_h1,kap_l2:kap_h2,kap_l3:kap_h3,0:ngroups-1)
+  real(rt)        ,intent(in):: jg( jg_l1: jg_h1, jg_l2: jg_h2, jg_l3: jg_h3,0:ngroups-1)
+  real(rt)        ,intent(in)::deT(deT_l1:deT_h1,deT_l2:deT_h2,deT_l3:deT_h3)
+  real(rt)        ,intent(inout)::rel_re, abs_re 
+  real(rt)        ,intent(inout)::rel_FT, abs_FT,rel_T, abs_T
+  real(rt)        ,intent(in) :: dt
 
   integer :: i, j, k
-  double precision :: chg, relchg, FT, cdt, FTdenom, dTe
+  real(rt)         :: chg, relchg, FT, cdt, FTdenom, dTe
 
   cdt = clight*dt
 
@@ -176,12 +180,12 @@ subroutine ca_check_conv( lo, hi, &
   do j=lo(2),hi(2)
   do i=lo(1),hi(1)
      chg = abs(ren(i,j,k) - res(i,j,k))
-     relchg = abs(chg/(ren(i,j,k)+1.d-50))
+     relchg = abs(chg/(ren(i,j,k)+1.e-50_rt))
      rel_re = max(rel_re,relchg)
      abs_re = max(abs_re,chg)
 
      chg = abs(Tmn(i,j,k) - Tms(i,j,k))
-     relchg = abs(chg/(Tmn(i,j,k)+1.d-50))
+     relchg = abs(chg/(Tmn(i,j,k)+1.e-50_rt))
      rel_T = max(rel_T,relchg)
      abs_T = max(abs_T,chg)
 
@@ -189,9 +193,9 @@ subroutine ca_check_conv( lo, hi, &
 
      dTe = Tmn(i,j,k)
      FTdenom = rho(i,j,k)*abs(deT(i,j,k)*dTe)
-!     FTdenom = max(abs(ren(i,j,k)-re2(i,j,k)), abs(ren(i,j,k)*1.d-15))
+!     FTdenom = max(abs(ren(i,j,k)-re2(i,j,k)), abs(ren(i,j,k)*1.e-15_rt))
 
-     rel_FT = max(rel_FT, FT/(FTdenom+1.d-50))
+     rel_FT = max(rel_FT, FT/(FTdenom+1.e-50_rt))
      abs_FT = max(abs_FT, FT)
   end do
   end do
@@ -210,6 +214,7 @@ subroutine ca_check_conv_er( lo, hi, &
 
   use rad_params_module, only : ngroups, clight
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer,intent(in):: lo(3), hi(3)
@@ -218,24 +223,24 @@ subroutine ca_check_conv_er( lo, hi, &
   integer,intent(in):: kap_l1, kap_h1, kap_l2, kap_h2, kap_l3, kap_h3
   integer,intent(in)::temp_l1,temp_h1,temp_l2,temp_h2,temp_l3,temp_h3
   integer,intent(in)::etTz_l1,etTz_h1,etTz_l2,etTz_h2,etTz_l3,etTz_h3
-  double precision,intent(in):: Ern( Ern_l1: Ern_h1, Ern_l2: Ern_h2, Ern_l3: Ern_h3,0:ngroups-1)
-  double precision,intent(in):: Erl( Erl_l1: Erl_h1, Erl_l2: Erl_h2, Erl_l3: Erl_h3,0:ngroups-1)
-  double precision,intent(in):: kap( kap_l1: kap_h1, kap_l2: kap_h2, kap_l3: kap_h3,0:ngroups-1)
-  double precision,intent(in)::etTz(etTz_l1:etTz_h1,etTz_l2:etTz_h2,etTz_l3:etTz_h3)
-  double precision,intent(in)::temp(temp_l1:temp_h1,temp_l2:temp_h2,temp_l3:temp_h3)
-  double precision, intent(inout) :: rela, abso, errr
-  double precision, intent(in) :: dt
+  real(rt)        ,intent(in):: Ern( Ern_l1: Ern_h1, Ern_l2: Ern_h2, Ern_l3: Ern_h3,0:ngroups-1)
+  real(rt)        ,intent(in):: Erl( Erl_l1: Erl_h1, Erl_l2: Erl_h2, Erl_l3: Erl_h3,0:ngroups-1)
+  real(rt)        ,intent(in):: kap( kap_l1: kap_h1, kap_l2: kap_h2, kap_l3: kap_h3,0:ngroups-1)
+  real(rt)        ,intent(in)::etTz(etTz_l1:etTz_h1,etTz_l2:etTz_h2,etTz_l3:etTz_h3)
+  real(rt)        ,intent(in)::temp(temp_l1:temp_h1,temp_l2:temp_h2,temp_l3:temp_h3)
+  real(rt)        , intent(inout) :: rela, abso, errr
+  real(rt)        , intent(in) :: dt
 
   integer :: i, j, k, g
-  double precision :: chg, tot, cdt, der, kde, err_T, err
+  real(rt)         :: chg, tot, cdt, der, kde, err_T, err
 
   cdt = clight * dt
   do k = lo(3), hi(3)
   do j = lo(2), hi(2)
   do i = lo(1), hi(1)
-     chg = 0.d0
-     tot = 0.d0
-     kde = 0.d0
+     chg = 0.e0_rt
+     tot = 0.e0_rt
+     kde = 0.e0_rt
      do g=0,ngroups-1
         der = Ern(i,j,k,g)-Erl(i,j,k,g)
         chg = chg + abs(der)
@@ -243,10 +248,10 @@ subroutine ca_check_conv_er( lo, hi, &
         kde = kde + kap(i,j,k,g)*der
      end do
      abso = max(abso, chg)
-     rela = max(rela, chg / (tot + 1.d-50))
+     rela = max(rela, chg / (tot + 1.e-50_rt))
 
      err_T =  etTz(i,j,k)*kde
-     err = abs(err_T/(temp(i,j,k)+1.d-50))
+     err = abs(err_T/(temp(i,j,k)+1.e-50_rt))
      errr = max(errr, err)
   end do
   end do
@@ -263,6 +268,7 @@ subroutine ca_compute_coupt( lo, hi,  &
   
   use rad_params_module, only : ngroups
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: lo(3), hi(3)
@@ -270,14 +276,14 @@ subroutine ca_compute_coupt( lo, hi,  &
   integer, intent(in) :: kpp_l1, kpp_h1, kpp_l2, kpp_h2, kpp_l3, kpp_h3 
   integer, intent(in) ::  eg_l1,  eg_h1,  eg_l2,  eg_h2,  eg_l3,  eg_h3
   integer, intent(in) ::  jg_l1,  jg_h1,  jg_l2,  jg_h2,  jg_l3,  jg_h3
-  double precision           ::cpt(cpt_l1:cpt_h1,cpt_l2:cpt_h2,cpt_l3:cpt_h3)
-  double precision,intent(in)::kpp(kpp_l1:kpp_h1,kpp_l2:kpp_h2,kpp_l3:kpp_h3,0:ngroups-1)
-  double precision,intent(in):: eg( eg_l1: eg_h1, eg_l2: eg_h2, eg_l3: eg_h3,0:ngroups-1)
-  double precision,intent(in):: jg( jg_l1: jg_h1, jg_l2: jg_h2, jg_l3: jg_h3,0:ngroups-1)
+  real(rt)                   ::cpt(cpt_l1:cpt_h1,cpt_l2:cpt_h2,cpt_l3:cpt_h3)
+  real(rt)        ,intent(in)::kpp(kpp_l1:kpp_h1,kpp_l2:kpp_h2,kpp_l3:kpp_h3,0:ngroups-1)
+  real(rt)        ,intent(in):: eg( eg_l1: eg_h1, eg_l2: eg_h2, eg_l3: eg_h3,0:ngroups-1)
+  real(rt)        ,intent(in):: jg( jg_l1: jg_h1, jg_l2: jg_h2, jg_l3: jg_h3,0:ngroups-1)
 
   integer :: i, j, k, g
 
-  cpt(lo(1):hi(1),lo(2):hi(2),lo(3):hi(3)) = 0.d0
+  cpt(lo(1):hi(1),lo(2):hi(2),lo(3):hi(3)) = 0.e0_rt
 
   do g=0, ngroups-1
      do k=lo(3),hi(3)
@@ -305,6 +311,7 @@ subroutine ca_compute_etat( lo, hi, &
 
   use rad_params_module, only : ngroups, clight
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: lo(3), hi(3)
@@ -316,21 +323,21 @@ subroutine ca_compute_etat( lo, hi, &
   integer, intent(in) :: dedT_l1, dedT_h1, dedT_l2, dedT_h2, dedT_l3, dedT_h3
   integer, intent(in) ::  Ers_l1,  Ers_h1,  Ers_l2,  Ers_h2,  Ers_l3,  Ers_h3
   integer, intent(in) ::  rho_l1,  rho_h1,  rho_l2,  rho_h2,  rho_l3,  rho_h3
-  double precision           ::etaT(etaT_l1:etaT_h1,etaT_l2:etaT_h2,etaT_l3:etaT_h3)
-  double precision           ::etTz(etTz_l1:etTz_h1,etTz_l2:etTz_h2,etTz_l3:etTz_h3)
-  double precision           ::eta1(eta1_l1:eta1_h1,eta1_l2:eta1_h2,eta1_l3:eta1_h3)
-  double precision           ::djdT(djdT_l1:djdT_h1,djdT_l2:djdT_h2,djdT_l3:djdT_h3,0:ngroups-1)
-  double precision,intent(in)::dkdT(dkdT_l1:dkdT_h1,dkdT_l2:dkdT_h2,dkdT_l3:dkdT_h3,0:ngroups-1)
-  double precision,intent(in)::dedT(dedT_l1:dedT_h1,dedT_l2:dedT_h2,dedT_l3:dedT_h3)
-  double precision,intent(in)::Ers ( Ers_l1: Ers_h1, Ers_l2: Ers_h2, Ers_l3: Ers_h3,0:ngroups-1)
-  double precision,intent(in)::rho ( rho_l1: rho_h1, rho_l2: rho_h2, rho_l3: rho_h3)
-  double precision,intent(in):: dt, tau
+  real(rt)                   ::etaT(etaT_l1:etaT_h1,etaT_l2:etaT_h2,etaT_l3:etaT_h3)
+  real(rt)                   ::etTz(etTz_l1:etTz_h1,etTz_l2:etTz_h2,etTz_l3:etTz_h3)
+  real(rt)                   ::eta1(eta1_l1:eta1_h1,eta1_l2:eta1_h2,eta1_l3:eta1_h3)
+  real(rt)                   ::djdT(djdT_l1:djdT_h1,djdT_l2:djdT_h2,djdT_l3:djdT_h3,0:ngroups-1)
+  real(rt)        ,intent(in)::dkdT(dkdT_l1:dkdT_h1,dkdT_l2:dkdT_h2,dkdT_l3:dkdT_h3,0:ngroups-1)
+  real(rt)        ,intent(in)::dedT(dedT_l1:dedT_h1,dedT_l2:dedT_h2,dedT_l3:dedT_h3)
+  real(rt)        ,intent(in)::Ers ( Ers_l1: Ers_h1, Ers_l2: Ers_h2, Ers_l3: Ers_h3,0:ngroups-1)
+  real(rt)        ,intent(in)::rho ( rho_l1: rho_h1, rho_l2: rho_h2, rho_l3: rho_h3)
+  real(rt)        ,intent(in):: dt, tau
 
   integer :: i, j, k
-  double precision :: cdt, sigma
-  double precision :: dZdT(0:ngroups-1), sumdZdT, foo, bar
+  real(rt)         :: cdt, sigma
+  real(rt)         :: dZdT(0:ngroups-1), sumdZdT, foo, bar
 
-  sigma = 1.d0 + tau
+  sigma = 1.e0_rt + tau
   cdt = clight * dt
 
   do k = lo(3), hi(3)
@@ -338,8 +345,8 @@ subroutine ca_compute_etat( lo, hi, &
   do i = lo(1), hi(1)
      dZdT = djdT(i,j,k,:) - dkdT(i,j,k,:)*Ers(i,j,k,:)
      sumdZdT = sum(dZdT)
-     if (sumdZdT .eq. 0.d0) then
-        sumdZdT = 1.d-50
+     if (sumdZdT .eq. 0.e0_rt) then
+        sumdZdT = 1.e-50_rt
      end if
      foo = cdt * sumdZdT
      bar = sigma*rho(i,j,k)*dedT(i,j,k)
@@ -366,6 +373,7 @@ subroutine ca_compute_emissivity( lo, hi, &
        pi, clight, hplanck, kboltz, arad
   use blackbody_module, only : BdBdTIndefInteg
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in)  :: lo(3), hi(3) 
@@ -374,22 +382,22 @@ subroutine ca_compute_emissivity( lo, hi, &
   integer, intent(in) ::    T_l1,    T_h1,    T_l2,    T_h2,    T_l3,    T_h3
   integer, intent(in) ::  kap_l1,  kap_h1,  kap_l2,  kap_h2,  kap_l3,  kap_h3
   integer, intent(in) :: dkdT_l1, dkdT_h1, dkdT_l2, dkdT_h2, dkdT_l3, dkdT_h3
-  double precision           ::jg  (  jg_l1:  jg_h1,  jg_l2:  jg_h2,  jg_l3:  jg_h3,0:ngroups-1)
-  double precision           ::djdT(djdT_l1:djdT_h1,djdT_l2:djdT_h2,djdT_l3:djdT_h3,0:ngroups-1)
-  double precision,intent(in)::   T(   T_l1:   T_h1,   T_l2:   T_h2,   T_l3:   T_h3)
-  double precision,intent(in):: kap( kap_l1: kap_h1, kap_l2: kap_h2, kap_l3: kap_h3,0:ngroups-1)
-  double precision,intent(in)::dkdT(dkdT_l1:dkdT_h1,dkdT_l2:dkdT_h2,dkdT_l3:dkdT_h3,0:ngroups-1)
-  double precision,intent(in)::pfc(0:ngroups-1)
+  real(rt)                   ::jg  (  jg_l1:  jg_h1,  jg_l2:  jg_h2,  jg_l3:  jg_h3,0:ngroups-1)
+  real(rt)                   ::djdT(djdT_l1:djdT_h1,djdT_l2:djdT_h2,djdT_l3:djdT_h3,0:ngroups-1)
+  real(rt)        ,intent(in)::   T(   T_l1:   T_h1,   T_l2:   T_h2,   T_l3:   T_h3)
+  real(rt)        ,intent(in):: kap( kap_l1: kap_h1, kap_l2: kap_h2, kap_l3: kap_h3,0:ngroups-1)
+  real(rt)        ,intent(in)::dkdT(dkdT_l1:dkdT_h1,dkdT_l2:dkdT_h2,dkdT_l3:dkdT_h3,0:ngroups-1)
+  real(rt)        ,intent(in)::pfc(0:ngroups-1)
   integer, intent(in) :: use_WiensLaw, integrate_Planck
-  double precision, intent(in) :: Tf
+  real(rt)        , intent(in) :: Tf
 
   integer :: i, j, k, g
-  double precision :: dBdT, Bg
-  double precision :: Teff, nu, num, nup, hoverk
-  double precision :: cB, Tfix
-  double precision :: B0, B1, dBdT0, dBdT1
-  double precision :: dnu, nubar, expnubar, cdBdT
-  double precision :: xnu_full(0:ngroups)
+  real(rt)         :: dBdT, Bg
+  real(rt)         :: Teff, nu, num, nup, hoverk
+  real(rt)         :: cB, Tfix
+  real(rt)         :: B0, B1, dBdT0, dBdT1
+  real(rt)         :: dnu, nubar, expnubar, cdBdT
+  real(rt)         :: xnu_full(0:ngroups)
 
   if (ngroups .eq. 1) then
 
@@ -397,7 +405,7 @@ subroutine ca_compute_emissivity( lo, hi, &
      do j = lo(2), hi(2)
      do i = lo(1), hi(1)
         Bg = arad*T(i,j,k)**4
-        dBdT = 4.d0*arad*T(i,j,k)**3
+        dBdT = 4.e0_rt*arad*T(i,j,k)**3
         g = 0
         jg(i,j,k,g) = Bg*kap(i,j,k,g)
         djdT(i,j,k,g) = dkdT(i,j,k,g)*Bg + dBdT*kap(i,j,k,g)
@@ -405,12 +413,12 @@ subroutine ca_compute_emissivity( lo, hi, &
      end do     
      end do     
 
-  else if (pfc(0) > 0.d0) then  ! a special case for picket-fence model in Su-Olson test
+  else if (pfc(0) > 0.e0_rt) then  ! a special case for picket-fence model in Su-Olson test
      do k = lo(3), hi(3)
      do j = lo(2), hi(2)
      do i = lo(1), hi(1)
         Bg = arad*T(i,j,k)**4
-        dBdT = 4.d0*arad*T(i,j,k)**3
+        dBdT = 4.e0_rt*arad*T(i,j,k)**3
         do g=0, ngroups-1
            jg(i,j,k,g) = pfc(g) * Bg*kap(i,j,k,g)
            djdT(i,j,k,g) = pfc(g) * (dkdT(i,j,k,g)*Bg + dBdT*kap(i,j,k,g))
@@ -430,7 +438,7 @@ subroutine ca_compute_emissivity( lo, hi, &
         do k = lo(3), hi(3)
         do j = lo(2), hi(2)
         do i = lo(1), hi(1)
-           if (Tf < 0.d0) then
+           if (Tf < 0.e0_rt) then
               Tfix = T(i,j,k)
            else
               Tfix = Tf
@@ -447,13 +455,13 @@ subroutine ca_compute_emissivity( lo, hi, &
   else if (integrate_Planck > 0) then
 
      xnu_full = xnu(0:ngroups)
-     xnu_full(0) = 0.d0
-     xnu_full(ngroups) = max(xnu(ngroups), 1.d25)
+     xnu_full(0) = 0.e0_rt
+     xnu_full(ngroups) = max(xnu(ngroups), 1.e25_rt)
 
      do k=lo(3), hi(3)
      do j=lo(2), hi(2)
      do i=lo(1), hi(1)
-        Teff = max(T(i,j,k), 1.d-50)
+        Teff = max(T(i,j,k), 1.e-50_rt)
         call BdBdTIndefInteg(Teff, xnu_full(0), B1, dBdT1)
         do g=0, ngroups-1
            B0 = B1
@@ -471,8 +479,8 @@ subroutine ca_compute_emissivity( lo, hi, &
 
   else
 
-     cB = 8.d0*pi*hplanck / clight**3
-     cdBdT = 8.d0*pi*hplanck**2 / (kboltz*clight**3)
+     cB = 8.e0_rt*pi*hplanck / clight**3
+     cdBdT = 8.e0_rt*pi*hplanck**2 / (kboltz*clight**3)
 
      do g=0, ngroups-1
         nu = nugroup(g)
@@ -481,18 +489,18 @@ subroutine ca_compute_emissivity( lo, hi, &
         do k=lo(3), hi(3)
         do j=lo(2), hi(2)
         do i=lo(1), hi(1)
-           Teff = max(T(i,j,k), 1.d-50)
+           Teff = max(T(i,j,k), 1.e-50_rt)
            nubar = hplanck * nu / (kboltz * Teff)
-           if (nubar > 100.d0) then
-              Bg = 0.d0
-              dBdT = 0.d0
-           else if (nubar < 1.d-15) then
-              Bg = 0.d0
-              dBdT = 0.d0           
+           if (nubar > 100.e0_rt) then
+              Bg = 0.e0_rt
+              dBdT = 0.e0_rt
+           else if (nubar < 1.e-15_rt) then
+              Bg = 0.e0_rt
+              dBdT = 0.e0_rt           
            else
               expnubar = exp(nubar)
-              Bg = cB * nu**3 / (expnubar - 1.d0) * dnu
-              dBdT = cdBdT * nu**4 / Teff**2 * expnubar / (expnubar-1.d0)**2 * dnu
+              Bg = cB * nu**3 / (expnubar - 1.e0_rt) * dnu
+              dBdT = cdBdT * nu**4 / Teff**2 * expnubar / (expnubar-1.e0_rt)**2 * dnu
            end if
 
            jg(i,j,k,g) = Bg*kap(i,j,k,g)
@@ -523,6 +531,7 @@ subroutine ca_compute_kappas(lo, hi, &
   use fundamental_constants_module, only : hplanck, k_B
   use meth_params_module, only : NVAR, URHO
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: lo(3), hi(3) 
@@ -532,19 +541,19 @@ subroutine ca_compute_kappas(lo, hi, &
   integer, intent(in) :: kpr_l1, kpr_h1, kpr_l2, kpr_h2, kpr_l3, kpr_h3
   integer, intent(in) :: kpT_l1, kpT_h1, kpT_l2, kpT_h2, kpT_l3, kpT_h3
   integer, intent(in) :: do_stme, use_dkdT
-  double precision,intent(in)::stt(stt_l1:stt_h1,stt_l2:stt_h2,stt_l3:stt_h3,NVAR)
-  double precision,intent(in)::  T(  T_l1:  T_h1,  T_l2:  T_h2,  T_l3:  T_h3)
-  double precision           ::kpp(kpp_l1:kpp_h1,kpp_l2:kpp_h2,kpp_l3:kpp_h3,0:ngroups-1)
-  double precision           ::kpr(kpr_l1:kpr_h1,kpr_l2:kpr_h2,kpr_l3:kpr_h3,0:ngroups-1)
-  double precision           ::kpT(kpT_l1:kpT_h1,kpT_l2:kpT_h2,kpT_l3:kpT_h3,0:ngroups-1)
-  double precision, intent(in)   :: c_kpp, kpp_m, kpp_n, kpp_p 
-  double precision, intent(in)   :: c_kpr, kpr_m, kpr_n, kpr_p 
-  double precision, intent(in)   :: c_sct, sct_m, sct_n, sct_p 
-  double precision, intent(in)   :: Tfloor
+  real(rt)        ,intent(in)::stt(stt_l1:stt_h1,stt_l2:stt_h2,stt_l3:stt_h3,NVAR)
+  real(rt)        ,intent(in)::  T(  T_l1:  T_h1,  T_l2:  T_h2,  T_l3:  T_h3)
+  real(rt)                   ::kpp(kpp_l1:kpp_h1,kpp_l2:kpp_h2,kpp_l3:kpp_h3,0:ngroups-1)
+  real(rt)                   ::kpr(kpr_l1:kpr_h1,kpr_l2:kpr_h2,kpr_l3:kpr_h3,0:ngroups-1)
+  real(rt)                   ::kpT(kpT_l1:kpT_h1,kpT_l2:kpT_h2,kpT_l3:kpT_h3,0:ngroups-1)
+  real(rt)        , intent(in)   :: c_kpp, kpp_m, kpp_n, kpp_p 
+  real(rt)        , intent(in)   :: c_kpr, kpr_m, kpr_n, kpr_p 
+  real(rt)        , intent(in)   :: c_sct, sct_m, sct_n, sct_p 
+  real(rt)        , intent(in)   :: Tfloor
 
   integer :: i, j, k, g
-  double precision, parameter :: tiny = 1.0d-50
-  double precision :: Teff, nup_kpp, nup_kpr, nup_sct, sct, foo, hnuoverkt, exptmp
+  real(rt)        , parameter :: tiny = 1.0e-50_rt
+  real(rt)         :: Teff, nup_kpp, nup_kpr, nup_sct, sct, foo, hnuoverkt, exptmp
 
   do g=0, ngroups-1
      nup_kpp = nugroup(g)**kpp_p
@@ -562,17 +571,17 @@ subroutine ca_compute_kappas(lo, hi, &
            foo = kpp(i,j,k,g)
            hnuoverkt = hplanck*nugroup(g)/(k_B*Teff)
            exptmp = exp(-hnuoverkt)
-           kpp(i,j,k,g) = foo * (1.d0 - exptmp)
-           kpT(i,j,k,g) = foo*(-kpp_n/Teff)*(1.d0-exptmp) - foo*exptmp*(hnuoverkt/Teff)
+           kpp(i,j,k,g) = foo * (1.e0_rt - exptmp)
+           kpT(i,j,k,g) = foo*(-kpp_n/Teff)*(1.e0_rt-exptmp) - foo*exptmp*(hnuoverkt/Teff)
         else
            kpT(i,j,k,g) = kpp(i,j,k,g) * (-kpp_n/Teff)           
         end if
 
         if (use_dkdT.eq.0) then
-           kpT(i,j,k,g) = 0.d0
+           kpT(i,j,k,g) = 0.e0_rt
         end if
 
-        if (c_kpr < 0.0d0) then
+        if (c_kpr < 0.0e0_rt) then
            sct       = c_sct * (stt(i,j,k,URHO) ** sct_m) * (Teff ** (-sct_n)) * nup_sct
            kpr(i,j,k,g) = kpp(i,j,k,g) + sct
         else
@@ -601,6 +610,7 @@ subroutine ca_compute_rhs( lo, hi, &
 
   use rad_params_module, only : ngroups, clight
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer,intent(in):: lo(3), hi(3) 
@@ -613,23 +623,23 @@ subroutine ca_compute_rhs( lo, hi, &
   integer,intent(in):: re2_l1, re2_h1, re2_l2, re2_h2, re2_l3, re2_h3
   integer,intent(in):: Ers_l1, Ers_h1, Ers_l2, Ers_h2, Ers_l3, Ers_h3
   integer,intent(in):: res_l1, res_h1, res_l2, res_h2, res_l3, res_h3
-  double precision           ::rhs ( rhs_l1: rhs_h1, rhs_l2: rhs_h2, rhs_l3: rhs_h3)
-  double precision,intent(in)::jg  (  jg_l1:  jg_h1,  jg_l2:  jg_h2,  jg_l3:  jg_h3,0:ngroups-1)
-  double precision,intent(in)::mugT(mugT_l1:mugT_h1,mugT_l2:mugT_h2,mugT_l3:mugT_h3,0:ngroups-1)
-  double precision,intent(in)::cpT ( cpT_l1: cpT_h1, cpT_l2: cpT_h2, cpT_l3: cpT_h3)
-  double precision,intent(in)::etaT(etaT_l1:etaT_h1,etaT_l2:etaT_h2,etaT_l3:etaT_h3)
-  double precision,intent(in)::Er2 ( Er2_l1: Er2_h1, Er2_l2: Er2_h2, Er2_l3: Er2_h3,0:ngroups-1)
-  double precision,intent(in)::re2 ( re2_l1: re2_h1, re2_l2: re2_h2, re2_l3: re2_h3)
-  double precision,intent(in)::Ers ( Ers_l1: Ers_h1, Ers_l2: Ers_h2, Ers_l3: Ers_h3,0:ngroups-1)
-  double precision,intent(in)::res ( res_l1: res_h1, res_l2: res_h2, res_l3: res_h3)
-  double precision,intent(in):: r(lo(1):hi(1))
-  double precision,intent(in):: dt, tau
+  real(rt)                   ::rhs ( rhs_l1: rhs_h1, rhs_l2: rhs_h2, rhs_l3: rhs_h3)
+  real(rt)        ,intent(in)::jg  (  jg_l1:  jg_h1,  jg_l2:  jg_h2,  jg_l3:  jg_h3,0:ngroups-1)
+  real(rt)        ,intent(in)::mugT(mugT_l1:mugT_h1,mugT_l2:mugT_h2,mugT_l3:mugT_h3,0:ngroups-1)
+  real(rt)        ,intent(in)::cpT ( cpT_l1: cpT_h1, cpT_l2: cpT_h2, cpT_l3: cpT_h3)
+  real(rt)        ,intent(in)::etaT(etaT_l1:etaT_h1,etaT_l2:etaT_h2,etaT_l3:etaT_h3)
+  real(rt)        ,intent(in)::Er2 ( Er2_l1: Er2_h1, Er2_l2: Er2_h2, Er2_l3: Er2_h3,0:ngroups-1)
+  real(rt)        ,intent(in)::re2 ( re2_l1: re2_h1, re2_l2: re2_h2, re2_l3: re2_h3)
+  real(rt)        ,intent(in)::Ers ( Ers_l1: Ers_h1, Ers_l2: Ers_h2, Ers_l3: Ers_h3,0:ngroups-1)
+  real(rt)        ,intent(in)::res ( res_l1: res_h1, res_l2: res_h2, res_l3: res_h3)
+  real(rt)        ,intent(in):: r(lo(1):hi(1))
+  real(rt)        ,intent(in):: dt, tau
   integer, intent(in) :: igroup
 
   integer :: i, j, k
-  double precision :: Hg, dt1
+  real(rt)         :: Hg, dt1
 
-  dt1 = 1.d0/dt
+  dt1 = 1.e0_rt/dt
   do k=lo(3), hi(3)
   do j=lo(2), hi(2)
   do i=lo(1), hi(1)
@@ -657,6 +667,7 @@ subroutine ca_compute_rhs_so( lo, hi, & ! MG Su-Olson
 
   use rad_params_module, only : ngroups, clight
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer,intent(in):: lo(3), hi(3) 
@@ -668,24 +679,24 @@ subroutine ca_compute_rhs_so( lo, hi, & ! MG Su-Olson
   integer,intent(in):: Er2_l1, Er2_h1, Er2_l2, Er2_h2, Er2_l3, Er2_h3
   integer,intent(in):: re2_l1, re2_h1, re2_l2, re2_h2, re2_l3, re2_h3
   integer,intent(in):: res_l1, res_h1, res_l2, res_h2, res_l3, res_h3
-  double precision          ::rhs ( rhs_l1: rhs_h1, rhs_l2: rhs_h2, rhs_l3: rhs_h3)
-  double precision,intent(in)::jg  (  jg_l1:  jg_h1,  jg_l2:  jg_h2,  jg_l3:  jg_h3,0:ngroups-1)
-  double precision,intent(in)::mugT(mugT_l1:mugT_h1,mugT_l2:mugT_h2,mugT_l3:mugT_h3,0:ngroups-1)
-  double precision,intent(in)::cpt ( cpt_l1: cpt_h1, cpt_l2: cpt_h2, cpt_l3: cpt_h3)
-  double precision,intent(in)::eta ( eta_l1: eta_h1, eta_l2: eta_h2, eta_l3: eta_h3)
-  double precision,intent(in)::Er2 ( Er2_l1: Er2_h1, Er2_l2: Er2_h2, Er2_l3: Er2_h3,0:ngroups-1)
-  double precision,intent(in)::re2 ( re2_l1: re2_h1, re2_l2: re2_h2, re2_l3: re2_h3)
-  double precision,intent(in)::res ( res_l1: res_h1, res_l2: res_h2, res_l3: res_h3)
-  double precision,intent(in):: x(lo(1):hi(1))
-  double precision,intent(in):: t, dt
+  real(rt)                  ::rhs ( rhs_l1: rhs_h1, rhs_l2: rhs_h2, rhs_l3: rhs_h3)
+  real(rt)        ,intent(in)::jg  (  jg_l1:  jg_h1,  jg_l2:  jg_h2,  jg_l3:  jg_h3,0:ngroups-1)
+  real(rt)        ,intent(in)::mugT(mugT_l1:mugT_h1,mugT_l2:mugT_h2,mugT_l3:mugT_h3,0:ngroups-1)
+  real(rt)        ,intent(in)::cpt ( cpt_l1: cpt_h1, cpt_l2: cpt_h2, cpt_l3: cpt_h3)
+  real(rt)        ,intent(in)::eta ( eta_l1: eta_h1, eta_l2: eta_h2, eta_l3: eta_h3)
+  real(rt)        ,intent(in)::Er2 ( Er2_l1: Er2_h1, Er2_l2: Er2_h2, Er2_l3: Er2_h3,0:ngroups-1)
+  real(rt)        ,intent(in)::re2 ( re2_l1: re2_h1, re2_l2: re2_h2, re2_l3: re2_h3)
+  real(rt)        ,intent(in)::res ( res_l1: res_h1, res_l2: res_h2, res_l3: res_h3)
+  real(rt)        ,intent(in):: x(lo(1):hi(1))
+  real(rt)        ,intent(in):: t, dt
   integer, intent(in) :: igroup
 
-  double precision, parameter :: x0 = 0.5d0
-  double precision, parameter :: t0 = 3.3356409519815202d-10 
-  double precision, parameter :: qn = 1.134074546528399d20 
+  real(rt)        , parameter :: x0 = 0.5e0_rt
+  real(rt)        , parameter :: t0 = 3.3356409519815202e-10_rt 
+  real(rt)        , parameter :: qn = 1.134074546528399e20_rt 
 
   integer :: i, j, k
-  double precision :: Hg
+  real(rt)         :: Hg
 
   do k=lo(3), hi(3)
   do j=lo(2), hi(2)
@@ -713,6 +724,7 @@ subroutine ca_local_accel( lo, hi,  &
 
   use rad_params_module, only : ngroups, clight
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer,intent(in):: lo(3), hi(3)
@@ -721,18 +733,18 @@ subroutine ca_local_accel( lo, hi,  &
   integer,intent(in):: kap_l1, kap_h1, kap_l2, kap_h2, kap_l3, kap_h3
   integer,intent(in)::etaT_l1,etaT_h1,etaT_l2,etaT_h2,etaT_l3,etaT_h3
   integer,intent(in)::mugT_l1,mugT_h1,mugT_l2,mugT_h2,mugT_l3,mugT_h3
-  double precision           ::Ern ( Ern_l1: Ern_h1, Ern_l2: Ern_h2, Ern_l3: Ern_h3,0:ngroups-1)
-  double precision,intent(in)::Erl ( Erl_l1: Erl_h1, Erl_l2: Erl_h2, Erl_l3: Erl_h3,0:ngroups-1)
-  double precision,intent(in)::kap ( kap_l1: kap_h1, kap_l2: kap_h2, kap_l3: kap_h3,0:ngroups-1)
-  double precision,intent(in)::etaT(etaT_l1:etaT_h1,etaT_l2:etaT_h2,etaT_l3:etaT_h3)
-  double precision,intent(in)::mugT(mugT_l1:mugT_h1,mugT_l2:mugT_h2,mugT_l3:mugT_h3,0:ngroups-1)
-  double precision,intent(in) :: dt, tau
+  real(rt)                   ::Ern ( Ern_l1: Ern_h1, Ern_l2: Ern_h2, Ern_l3: Ern_h3,0:ngroups-1)
+  real(rt)        ,intent(in)::Erl ( Erl_l1: Erl_h1, Erl_l2: Erl_h2, Erl_l3: Erl_h3,0:ngroups-1)
+  real(rt)        ,intent(in)::kap ( kap_l1: kap_h1, kap_l2: kap_h2, kap_l3: kap_h3,0:ngroups-1)
+  real(rt)        ,intent(in)::etaT(etaT_l1:etaT_h1,etaT_l2:etaT_h2,etaT_l3:etaT_h3)
+  real(rt)        ,intent(in)::mugT(mugT_l1:mugT_h1,mugT_l2:mugT_h2,mugT_l3:mugT_h3,0:ngroups-1)
+  real(rt)        ,intent(in) :: dt, tau
 
   integer :: i, j, k
-  double precision :: cdt1, rt_term, p
-  double precision,dimension(0:ngroups-1)::Hg, epsilon, kapt, kk
+  real(rt)         :: cdt1, rt_term, p
+  real(rt)        ,dimension(0:ngroups-1)::Hg, epsilon, kapt, kk
 
-  cdt1 = 1.d0/(clight*dt)
+  cdt1 = 1.e0_rt/(clight*dt)
 
   do k = lo(3), hi(3)
   do j = lo(2), hi(2)
@@ -741,11 +753,11 @@ subroutine ca_local_accel( lo, hi,  &
 
      Hg = mugT(i,j,k,:)*etaT(i,j,k)
 
-     kapt = kap(i,j,k,:) + (1.d0+tau)*cdt1
+     kapt = kap(i,j,k,:) + (1.e0_rt+tau)*cdt1
      kk = kap(i,j,k,:) / kapt
 
-     p = 1.d0-sum(Hg*kk)
-     epsilon = (Hg * rt_term) / (kapt*p + 1.d-50)
+     p = 1.e0_rt-sum(Hg*kk)
+     epsilon = (Hg * rt_term) / (kapt*p + 1.e-50_rt)
 
      Ern(i,j,k,:) = Ern(i,j,k,:) + epsilon
   end do
@@ -764,6 +776,7 @@ subroutine ca_state_update( lo, hi, &
 
   use meth_params_module, only : NVAR, UEDEN, UEINT, UTEMP
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: lo(3), hi(3) 
@@ -771,26 +784,26 @@ subroutine ca_state_update( lo, hi, &
   integer, intent(in) ::  rhoe_l1,  rhoe_h1,  rhoe_l2,  rhoe_h2,  rhoe_l3,  rhoe_h3
   integer, intent(in) ::  temp_l1,  temp_h1,  temp_l2,  temp_h2,  temp_l3,  temp_h3
   integer, intent(in) ::   msk_l1,   msk_h1,   msk_l2,   msk_h2,   msk_l3,   msk_h3
-  double precision,intent(in):: rhoe( rhoe_l1: rhoe_h1, rhoe_l2: rhoe_h2, rhoe_l3: rhoe_h3)
-  double precision,intent(in):: temp( temp_l1: temp_h1, temp_l2: temp_h2, temp_l3: temp_h3)
-  double precision,intent(in)::  msk(  msk_l1:  msk_h1,  msk_l2:  msk_h2,  msk_l3:  msk_h3)
-  double precision           ::state(state_l1:state_h1,state_l2:state_h2,state_l3:state_h3,NVAR)
-  double precision, intent(inout) :: derat, dTrat
+  real(rt)        ,intent(in):: rhoe( rhoe_l1: rhoe_h1, rhoe_l2: rhoe_h2, rhoe_l3: rhoe_h3)
+  real(rt)        ,intent(in):: temp( temp_l1: temp_h1, temp_l2: temp_h2, temp_l3: temp_h3)
+  real(rt)        ,intent(in)::  msk(  msk_l1:  msk_h1,  msk_l2:  msk_h2,  msk_l3:  msk_h3)
+  real(rt)                   ::state(state_l1:state_h1,state_l2:state_h2,state_l3:state_h3,NVAR)
+  real(rt)        , intent(inout) :: derat, dTrat
 
   integer :: i, j, k
-  double precision :: ei, ek, Told
+  real(rt)         :: ei, ek, Told
 
   do k=lo(3), hi(3)
   do j=lo(2), hi(2)
   do i=lo(1), hi(1)
      ei = state(i,j,k,UEINT)
-     derat = max(derat, abs((rhoe(i,j,k) - ei)*msk(i,j,k)/ max(ei, 1.d-50)))
+     derat = max(derat, abs((rhoe(i,j,k) - ei)*msk(i,j,k)/ max(ei, 1.e-50_rt)))
      ek = state(i,j,k,UEDEN) - state(i,j,k,UEINT)
      state(i,j,k,UEINT) = rhoe(i,j,k)
      state(i,j,k,UEDEN) = rhoe(i,j,k) + ek
 
      Told = state(i,j,k,UTEMP);
-     dTrat = max(dTrat, abs((temp(i,j,k)-Told)*msk(i,j,k)/ max(Told, 1.d-50)))
+     dTrat = max(dTrat, abs((temp(i,j,k)-Told)*msk(i,j,k)/ max(Told, 1.e-50_rt)))
      state(i,j,k,UTEMP) = temp(i,j,k)
   end do
   end do
@@ -815,6 +828,7 @@ subroutine ca_update_matter( lo, hi,  &
   use rad_params_module, only : ngroups, clight
   use meth_params_module, only : NVAR
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer,intent(in)::lo(3),hi(3)
@@ -828,20 +842,20 @@ subroutine ca_update_matter( lo, hi,  &
   integer,intent(in):: kpp_l1,  kpp_h1,  kpp_l2,  kpp_h2,  kpp_l3,  kpp_h3
   integer,intent(in)::mugT_l1, mugT_h1, mugT_l2, mugT_h2, mugT_l3, mugT_h3
   integer,intent(in)::Snew_l1, Snew_h1, Snew_l2, Snew_h2, Snew_l3, Snew_h3
-  double precision           ::re_n(re_n_l1:re_n_h1,re_n_l2:re_n_h2,re_n_l3:re_n_h3)
-  double precision,intent(in)::Er_n(Er_n_l1:Er_n_h1,Er_n_l2:Er_n_h2,Er_n_l3:Er_n_h3,0:ngroups-1)
-  double precision,intent(in)::Er_l(Er_l_l1:Er_l_h1,Er_l_l2:Er_l_h2,Er_l_l3:Er_l_h3,0:ngroups-1)
-  double precision,intent(in)::re_s(re_s_l1:re_s_h1,re_s_l2:re_s_h2,re_s_l3:re_s_h3)
-  double precision,intent(in)::re_2(re_2_l1:re_2_h1,re_2_l2:re_2_h2,re_2_l3:re_2_h3)
-  double precision,intent(in)::eta1(eta1_l1:eta1_h1,eta1_l2:eta1_h2,eta1_l3:eta1_h3)
-  double precision,intent(in):: cpt( cpt_l1: cpt_h1, cpt_l2: cpt_h2, cpt_l3: cpt_h3)
-  double precision,intent(in):: kpp( kpp_l1: kpp_h1, kpp_l2: kpp_h2, kpp_l3: kpp_h3,0:ngroups-1)
-  double precision,intent(in)::mugT(mugT_l1:mugT_h1,mugT_l2:mugT_h2,mugT_l3:mugT_h3,0:ngroups-1)
-  double precision,intent(in)::Snew(Snew_l1:Snew_h1,Snew_l2:Snew_h2,Snew_l3:Snew_h3,NVAR)
-  double precision,intent(in) :: dt, tau
+  real(rt)                   ::re_n(re_n_l1:re_n_h1,re_n_l2:re_n_h2,re_n_l3:re_n_h3)
+  real(rt)        ,intent(in)::Er_n(Er_n_l1:Er_n_h1,Er_n_l2:Er_n_h2,Er_n_l3:Er_n_h3,0:ngroups-1)
+  real(rt)        ,intent(in)::Er_l(Er_l_l1:Er_l_h1,Er_l_l2:Er_l_h2,Er_l_l3:Er_l_h3,0:ngroups-1)
+  real(rt)        ,intent(in)::re_s(re_s_l1:re_s_h1,re_s_l2:re_s_h2,re_s_l3:re_s_h3)
+  real(rt)        ,intent(in)::re_2(re_2_l1:re_2_h1,re_2_l2:re_2_h2,re_2_l3:re_2_h3)
+  real(rt)        ,intent(in)::eta1(eta1_l1:eta1_h1,eta1_l2:eta1_h2,eta1_l3:eta1_h3)
+  real(rt)        ,intent(in):: cpt( cpt_l1: cpt_h1, cpt_l2: cpt_h2, cpt_l3: cpt_h3)
+  real(rt)        ,intent(in):: kpp( kpp_l1: kpp_h1, kpp_l2: kpp_h2, kpp_l3: kpp_h3,0:ngroups-1)
+  real(rt)        ,intent(in)::mugT(mugT_l1:mugT_h1,mugT_l2:mugT_h2,mugT_l3:mugT_h3,0:ngroups-1)
+  real(rt)        ,intent(in)::Snew(Snew_l1:Snew_h1,Snew_l2:Snew_h2,Snew_l3:Snew_h3,NVAR)
+  real(rt)        ,intent(in) :: dt, tau
 
   integer :: i,j,k
-  double precision :: cdt, H1, dkEE, chg
+  real(rt)         :: cdt, H1, dkEE, chg
 
   cdt = clight * dt
   do k = lo(3), hi(3)
@@ -855,7 +869,7 @@ subroutine ca_update_matter( lo, hi,  &
 
      re_n(i,j,k) = re_s(i,j,k) + chg
 
-     re_n(i,j,k) = (re_n(i,j,k) + tau*re_s(i,j,k)) / (1.d0+tau)
+     re_n(i,j,k) = (re_n(i,j,k) + tau*re_s(i,j,k)) / (1.e0_rt+tau)
 
      ! temperature will be updated after exiting this subroutine
   end do
@@ -877,6 +891,7 @@ subroutine ca_ncupdate_matter( lo, hi,  &
 
   use rad_params_module, only : ngroups, clight
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer,intent(in)::lo(3),hi(3)
@@ -887,26 +902,26 @@ subroutine ca_ncupdate_matter( lo, hi,  &
   integer,intent(in)::etTz_l1,etTz_h1,etTz_l2,etTz_h2,etTz_l3,etTz_h3
   integer,intent(in):: kpp_l1, kpp_h1, kpp_l2, kpp_h2, kpp_l3, kpp_h3
   integer,intent(in)::  jg_l1,  jg_h1,  jg_l2,  jg_h2,  jg_l3,  jg_h3
-  double precision           ::Tp_n(Tp_n_l1:Tp_n_h1,Tp_n_l2:Tp_n_h2,Tp_n_l3:Tp_n_h3)
-  double precision,intent(in)::Er_n(Er_n_l1:Er_n_h1,Er_n_l2:Er_n_h2,Er_n_l3:Er_n_h3,0:ngroups-1)
-  double precision,intent(in)::re_s(re_s_l1:re_s_h1,re_s_l2:re_s_h2,re_s_l3:re_s_h3)
-  double precision,intent(in)::re_2(re_2_l1:re_2_h1,re_2_l2:re_2_h2,re_2_l3:re_2_h3)
-  double precision,intent(in)::etTz(etTz_l1:etTz_h1,etTz_l2:etTz_h2,etTz_l3:etTz_h3)
-  double precision,intent(in):: kpp( kpp_l1: kpp_h1, kpp_l2: kpp_h2, kpp_l3: kpp_h3,0:ngroups-1)
-  double precision,intent(in)::  jg(  jg_l1:  jg_h1,  jg_l2:  jg_h2,  jg_l3:  jg_h3,0:ngroups-1)
-  double precision,intent(in) :: dt
+  real(rt)                   ::Tp_n(Tp_n_l1:Tp_n_h1,Tp_n_l2:Tp_n_h2,Tp_n_l3:Tp_n_h3)
+  real(rt)        ,intent(in)::Er_n(Er_n_l1:Er_n_h1,Er_n_l2:Er_n_h2,Er_n_l3:Er_n_h3,0:ngroups-1)
+  real(rt)        ,intent(in)::re_s(re_s_l1:re_s_h1,re_s_l2:re_s_h2,re_s_l3:re_s_h3)
+  real(rt)        ,intent(in)::re_2(re_2_l1:re_2_h1,re_2_l2:re_2_h2,re_2_l3:re_2_h3)
+  real(rt)        ,intent(in)::etTz(etTz_l1:etTz_h1,etTz_l2:etTz_h2,etTz_l3:etTz_h3)
+  real(rt)        ,intent(in):: kpp( kpp_l1: kpp_h1, kpp_l2: kpp_h2, kpp_l3: kpp_h3,0:ngroups-1)
+  real(rt)        ,intent(in)::  jg(  jg_l1:  jg_h1,  jg_l2:  jg_h2,  jg_l3:  jg_h3,0:ngroups-1)
+  real(rt)        ,intent(in) :: dt
 
    integer :: i,j,k,g
-   double precision :: cdt1, cpT, scrch_re
-   double precision :: dTemp
-   double precision, parameter :: fac = 0.01d0
+   real(rt)         :: cdt1, cpT, scrch_re
+   real(rt)         :: dTemp
+   real(rt)        , parameter :: fac = 0.01e0_rt
 
-   cdt1 = 1.d0 / (clight * dt)
+   cdt1 = 1.e0_rt / (clight * dt)
    do k = lo(3), hi(3)
    do j = lo(2), hi(2)
    do i = lo(1), hi(1)
 
-      cpT = 0.d0
+      cpT = 0.e0_rt
       do g = 0, ngroups-1
          cpT = cpT + kpp(i,j,k,g)*Er_n(i,j,k,g) - jg(i,j,k,g)
       end do
@@ -915,7 +930,7 @@ subroutine ca_ncupdate_matter( lo, hi,  &
 
       dTemp = etTz(i,j,k)*scrch_re
 
-      if (abs(dTemp/(Tp_n(i,j,k)+1.d-50)) > fac) then
+      if (abs(dTemp/(Tp_n(i,j,k)+1.e-50_rt)) > fac) then
          dTemp = sign(fac*Tp_n(i,j,k), dTemp)
       end if
 
@@ -942,6 +957,7 @@ subroutine ca_opacs( lo, hi,  &
   use network, only : naux
   use meth_params_module, only : NVAR, URHO, UFX
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: lo(3), hi(3)
@@ -951,24 +967,24 @@ subroutine ca_opacs( lo, hi,  &
   integer, intent(in) ::  kpp_l1,  kpp_h1,  kpp_l2,  kpp_h2,  kpp_l3,  kpp_h3 
   integer, intent(in) ::  kpr_l1,  kpr_h1,  kpr_l2,  kpr_h2,  kpr_l3,  kpr_h3
   integer, intent(in) :: dkdT_l1, dkdT_h1, dkdT_l2, dkdT_h2, dkdT_l3, dkdT_h3
-  double precision,intent(in)::Snew(Snew_l1:Snew_h1,Snew_l2:Snew_h2,Snew_l3:Snew_h3,NVAR)
-  double precision,intent(in)::T   (   T_l1:   T_h1,   T_l2:   T_h2,   T_l3:   T_h3)
-  double precision,intent(in)::Ts  (  Ts_l1:  Ts_h1,  Ts_l2:  Ts_h2,  Ts_l3:  Ts_h3)
-  double precision           ::kpp ( kpp_l1: kpp_h1, kpp_l2: kpp_h2, kpp_l3: kpp_h3,0:ngroups-1)
-  double precision           ::kpr ( kpr_l1: kpr_h1, kpr_l2: kpr_h2, kpr_l3: kpr_h3,0:ngroups-1)
-  double precision           ::dkdT(dkdT_l1:dkdT_h1,dkdT_l2:dkdT_h2,dkdT_l3:dkdT_h3,0:ngroups-1)
+  real(rt)        ,intent(in)::Snew(Snew_l1:Snew_h1,Snew_l2:Snew_h2,Snew_l3:Snew_h3,NVAR)
+  real(rt)        ,intent(in)::T   (   T_l1:   T_h1,   T_l2:   T_h2,   T_l3:   T_h3)
+  real(rt)        ,intent(in)::Ts  (  Ts_l1:  Ts_h1,  Ts_l2:  Ts_h2,  Ts_l3:  Ts_h3)
+  real(rt)                   ::kpp ( kpp_l1: kpp_h1, kpp_l2: kpp_h2, kpp_l3: kpp_h3,0:ngroups-1)
+  real(rt)                   ::kpr ( kpr_l1: kpr_h1, kpr_l2: kpr_h2, kpr_l3: kpr_h3,0:ngroups-1)
+  real(rt)                   ::dkdT(dkdT_l1:dkdT_h1,dkdT_l2:dkdT_h2,dkdT_l3:dkdT_h3,0:ngroups-1)
   integer, intent(in) :: use_dkdT, validStar, lag_opac
 
   integer :: i, j, k, g
-  double precision :: kp, kr, nu, rho, temp, Ye
-  double precision :: kp1, kr1
-  double precision :: kp2, kr2
-  double precision :: dT
+  real(rt)         :: kp, kr, nu, rho, temp, Ye
+  real(rt)         :: kp1, kr1
+  real(rt)         :: kp2, kr2
+  real(rt)         :: dT
   logical :: comp_kp, comp_kr
-  double precision, parameter :: fac = 0.5d0, minfrac = 1.d-8
+  real(rt)        , parameter :: fac = 0.5e0_rt, minfrac = 1.e-8_rt
 
   if (lag_opac .eq. 1) then
-     dkdT(lo(1):hi(1),lo(2):hi(2),lo(3):hi(3),:) = 0.d0
+     dkdT(lo(1):hi(1),lo(2):hi(2),lo(3):hi(3),:) = 0.e0_rt
      return
   end if
 
@@ -981,14 +997,14 @@ subroutine ca_opacs( lo, hi,  &
      if (naux > 0) then
         Ye = Snew(i,j,k,UFX)
      else
-        Ye = 0.d0
+        Ye = 0.e0_rt
      end if
 
      if (validStar > 0) then
         dT = fac*abs(Ts(i,j,k) - T(i,j,k))
         dT = max(dT, minfrac*T(i,j,k))
      else
-        dT = T(i,j,k) * 1.d-3 + 1.d-50
+        dT = T(i,j,k) * 1.e-3_rt + 1.e-50_rt
      end if
 
      do g=0, ngroups-1
@@ -1003,7 +1019,7 @@ subroutine ca_opacs( lo, hi,  &
         kpr(i,j,k,g) = kr 
 
         if (use_dkdT .eq. 0) then        
-           dkdT(i,j,k,g) = 0.d0
+           dkdT(i,j,k,g) = 0.e0_rt
         else
 
            comp_kp = .true.
@@ -1012,7 +1028,7 @@ subroutine ca_opacs( lo, hi,  &
            call get_opacities(kp1, kr1, rho, temp-dT, Ye, nu, comp_kp, comp_kr)
            call get_opacities(kp2, kr2, rho, temp+dT, Ye, nu, comp_kp, comp_kr)
 
-           dkdT(i,j,k,g) = (kp2-kp1)/(2.d0*dT)
+           dkdT(i,j,k,g) = (kp2-kp1)/(2.e0_rt*dT)
 
         end if
 
@@ -1033,16 +1049,17 @@ subroutine ca_compute_rosseland( lo, hi,   &
   use network, only : naux
   use meth_params_module, only : NVAR, URHO, UTEMP, UFX
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: lo(3), hi(3)
   integer, intent(in) ::  kpr_l1, kpr_l2, kpr_l3, kpr_h1, kpr_h2, kpr_h3
   integer, intent(in) :: stat_l1,stat_l2,stat_l3,stat_h1,stat_h2,stat_h3
-  double precision           ::kpr ( kpr_l1: kpr_h1, kpr_l2: kpr_h2, kpr_l3: kpr_h3,0:ngroups-1)
-  double precision,intent(in)::stat(stat_l1:stat_h1,stat_l2:stat_h2,stat_l3:stat_h3,NVAR)
+  real(rt)                   ::kpr ( kpr_l1: kpr_h1, kpr_l2: kpr_h2, kpr_l3: kpr_h3,0:ngroups-1)
+  real(rt)        ,intent(in)::stat(stat_l1:stat_h1,stat_l2:stat_h2,stat_l3:stat_h3,NVAR)
 
   integer :: i, j, k, g
-  double precision :: kp, kr, nu, rho, temp, Ye
+  real(rt)         :: kp, kr, nu, rho, temp, Ye
   logical, parameter :: comp_kp = .false. 
   logical, parameter :: comp_kr = .true.
 
@@ -1059,7 +1076,7 @@ subroutine ca_compute_rosseland( lo, hi,   &
         if (naux > 0) then
            Ye = stat(i,j,k,UFX)
         else
-           Ye = 0.d0
+           Ye = 0.e0_rt
         end if
 
         call get_opacities(kp, kr, rho, temp, Ye, nu, comp_kp, comp_kr)
@@ -1083,16 +1100,17 @@ subroutine ca_compute_planck( lo, hi,  &
   use network, only : naux
   use meth_params_module, only : NVAR, URHO, UTEMP, UFX
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: lo(3), hi(3)
   integer, intent(in) ::  kpp_l1, kpp_l2, kpp_l3, kpp_h1, kpp_h2, kpp_h3
   integer, intent(in) :: stat_l1,stat_l2,stat_l3,stat_h1,stat_h2,stat_h3
-  double precision           ::kpp ( kpp_l1: kpp_h1, kpp_l2: kpp_h2, kpp_l3: kpp_h3,0:ngroups-1)
-  double precision,intent(in)::stat(stat_l1:stat_h1,stat_l2:stat_h2,stat_l3:stat_h3,NVAR)
+  real(rt)                   ::kpp ( kpp_l1: kpp_h1, kpp_l2: kpp_h2, kpp_l3: kpp_h3,0:ngroups-1)
+  real(rt)        ,intent(in)::stat(stat_l1:stat_h1,stat_l2:stat_h2,stat_l3:stat_h3,NVAR)
 
   integer :: i, j, k, g
-  double precision :: kp, kr, nu, rho, temp, Ye
+  real(rt)         :: kp, kr, nu, rho, temp, Ye
   logical, parameter :: comp_kp = .true. 
   logical, parameter :: comp_kr = .false.
 
@@ -1109,7 +1127,7 @@ subroutine ca_compute_planck( lo, hi,  &
         if (naux > 0) then
            Ye = stat(i,j,k,UFX)
         else
-           Ye = 0.d0
+           Ye = 0.e0_rt
         end if
 
         call get_opacities(kp, kr, rho, temp, Ye, nu, comp_kp, comp_kr)
@@ -1137,43 +1155,44 @@ subroutine ca_accel_ccoe( lo, hi, &
 
   use rad_params_module, only : ngroups
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: lo(3), hi(3)
   integer, intent(in) :: bcgr_l1, bcgr_h1, bcgr_l2, bcgr_h2, bcgr_l3, bcgr_h3
   integer, intent(in) :: spec_l1, spec_h1, spec_l2, spec_h2, spec_l3, spec_h3
   integer, intent(in) :: ccoe_l1, ccoe_h1, ccoe_l2, ccoe_h2, ccoe_l3, ccoe_h3
-  double precision,intent(in)::bcgr(bcgr_l1:bcgr_h1,bcgr_l2:bcgr_h2,bcgr_l3:bcgr_h3)
-  double precision,intent(in)::spec(spec_l1:spec_h1,spec_l2:spec_h2,spec_l3:spec_h3,0:ngroups-1)
-  double precision           ::ccoe(ccoe_l1:ccoe_h1,ccoe_l2:ccoe_h2,ccoe_l3:ccoe_h3,0:1)
-  double precision, intent(in) :: dx(3)
+  real(rt)        ,intent(in)::bcgr(bcgr_l1:bcgr_h1,bcgr_l2:bcgr_h2,bcgr_l3:bcgr_h3)
+  real(rt)        ,intent(in)::spec(spec_l1:spec_h1,spec_l2:spec_h2,spec_l3:spec_h3,0:ngroups-1)
+  real(rt)                   ::ccoe(ccoe_l1:ccoe_h1,ccoe_l2:ccoe_h2,ccoe_l3:ccoe_h3,0:1)
+  real(rt)        , intent(in) :: dx(3)
   integer, intent(in) :: idim, igroup
 
   integer :: i, j, k, ioff, joff, koff
-  double precision :: grad_spec, foo, h1
+  real(rt)         :: grad_spec, foo, h1
 
   if (idim .eq. 0) then
      ioff = 1
      joff = 0
      koff = 0
-     h1 = 1.d0/dx(1)
+     h1 = 1.e0_rt/dx(1)
   else if (idim .eq. 1) then
      ioff = 0
      joff = 1
      koff = 0
-     h1 = 1.d0/dx(2)
+     h1 = 1.e0_rt/dx(2)
   else
      ioff = 0
      joff = 0
      koff = 1
-     h1 = 1.d0/dx(3)
+     h1 = 1.e0_rt/dx(3)
   end if
 
   do k = lo(3), hi(3)
   do j = lo(2), hi(2)
   do i = lo(1), hi(1)
      grad_spec = (spec(i,j,k,igroup) - spec(i-ioff,j-joff,k-koff,igroup)) * h1
-     foo = - 0.5d0 * bcgr(i,j,k) * grad_spec
+     foo = - 0.5e0_rt * bcgr(i,j,k) * grad_spec
      ccoe(i,j,k,0) = ccoe(i,j,k,0) + foo
      ccoe(i,j,k,1) = ccoe(i,j,k,1) + foo
   end do
@@ -1189,6 +1208,7 @@ subroutine ca_flux_face2center( lo, hi, &
      x, x_l1, x_h1, nt, idim, iflx)
 
   use rad_params_module, only : ngroups
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer,intent(in):: lo(3), hi(3)
@@ -1196,9 +1216,9 @@ subroutine ca_flux_face2center( lo, hi, &
   integer,intent(in)::f_l1,f_h1,f_l2,f_h2,f_l3,f_h3
   integer,intent(in)::x_l1,x_h1
   integer,intent(in) :: nt, idim, iflx
-  double precision           ::t(t_l1:t_h1,t_l2:t_h2,t_l3:t_h3,0:nt-1)
-  double precision,intent(in)::f(f_l1:f_h1,f_l2:f_h2,f_l3:f_h3)
-  double precision,intent(in)::x(x_l1:x_h1)
+  real(rt)                   ::t(t_l1:t_h1,t_l2:t_h2,t_l3:t_h3,0:nt-1)
+  real(rt)        ,intent(in)::f(f_l1:f_h1,f_l2:f_h2,f_l3:f_h3)
+  real(rt)        ,intent(in)::x(x_l1:x_h1)
 
   integer it, i, j, k
 
@@ -1208,7 +1228,7 @@ subroutine ca_flux_face2center( lo, hi, &
      do k=lo(3), hi(3)
         do j=lo(2), hi(2)
            do i=lo(1), hi(1)
-              t(i,j,k,it) = (f(i,j,k) + f(i+1,j,k)) * 0.5d0
+              t(i,j,k,it) = (f(i,j,k) + f(i+1,j,k)) * 0.5e0_rt
            end do
         end do
      end do
@@ -1216,7 +1236,7 @@ subroutine ca_flux_face2center( lo, hi, &
      do k=lo(3), hi(3)
         do j=lo(2), hi(2)
            do i=lo(1), hi(1)
-              t(i,j,k,it) = (f(i,j,k) + f(i,j+1,k)) * 0.5d0
+              t(i,j,k,it) = (f(i,j,k) + f(i,j+1,k)) * 0.5e0_rt
            end do
         end do
      end do
@@ -1224,7 +1244,7 @@ subroutine ca_flux_face2center( lo, hi, &
      do k=lo(3), hi(3)
         do j=lo(2), hi(2)
            do i=lo(1), hi(1)
-              t(i,j,k,it) = (f(i,j,k) + f(i,j,k+1)) * 0.5d0
+              t(i,j,k,it) = (f(i,j,k) + f(i,j,k+1)) * 0.5e0_rt
            end do
         end do
      end do
@@ -1235,12 +1255,13 @@ end subroutine ca_flux_face2center
 subroutine ca_rhstoer( lo, hi, &
      rhs, rhs_l1, rhs_l2, rhs_l3, rhs_h1, rhs_h2, rhs_h3, &
      r, dt)
+  use bl_fort_module, only : rt => c_real
   implicit none
   integer,intent(in):: lo(3), hi(3)
   integer,intent(in):: rhs_l1, rhs_h1, rhs_l2, rhs_h2, rhs_l3, rhs_h3
-  double precision ::rhs ( rhs_l1: rhs_h1, rhs_l2: rhs_h2, rhs_l3: rhs_h3)
-  double precision,intent(in):: r(lo(1):hi(1))
-  double precision,intent(in):: dt
+  real(rt)         ::rhs ( rhs_l1: rhs_h1, rhs_l2: rhs_h2, rhs_l3: rhs_h3)
+  real(rt)        ,intent(in):: r(lo(1):hi(1))
+  real(rt)        ,intent(in):: dt
   integer :: i, j, k
   do k=lo(3), hi(3)
   do j=lo(2), hi(2)
@@ -1264,22 +1285,23 @@ subroutine ca_compute_powerlaw_kappa_s( lo, hi,  &
   use rad_params_module, only : ngroups, nugroup
   use meth_params_module, only : NVAR, URHO, UTEMP
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: lo(3), hi(3)
   integer, intent(in) :: k_l1, k_l2, k_l3, k_h1, k_h2, k_h3, &
                          u_l1, u_l2, u_l3, u_h1, u_h2, u_h3
-  double precision             :: kappa(k_l1:k_h1, k_l2:k_h2, k_l3:k_h3, 0:ngroups-1)
-  double precision, intent(in) ::     u(u_l1:u_h1, u_l2:u_h2, u_l3:u_h3, NVAR)
-  double precision, intent(in) :: kappa0, m, n, p, Tfloor, kfloor
-  double precision, intent(in) :: s0, sm, sn, sp
+  real(rt)                     :: kappa(k_l1:k_h1, k_l2:k_h2, k_l3:k_h3, 0:ngroups-1)
+  real(rt)        , intent(in) ::     u(u_l1:u_h1, u_l2:u_h2, u_l3:u_h3, NVAR)
+  real(rt)        , intent(in) :: kappa0, m, n, p, Tfloor, kfloor
+  real(rt)        , intent(in) :: s0, sm, sn, sp
 
   integer :: i, j, k, g
-  double precision, parameter :: tiny = 1.0d-50
-  double precision :: Teff, kf, sct, nup, nusp
+  real(rt)        , parameter :: tiny = 1.0e-50_rt
+  real(rt)         :: Teff, kf, sct, nup, nusp
 
-  if (  m.eq.0.d0 .and.  n.eq.0.d0 .and.  p.eq.0.d0 .and. &
-       sm.eq.0.d0 .and. sn.eq.0.d0 .and. sp.eq.0.d0 ) then
+  if (  m.eq.0.e0_rt .and.  n.eq.0.e0_rt .and.  p.eq.0.e0_rt .and. &
+       sm.eq.0.e0_rt .and. sn.eq.0.e0_rt .and. sp.eq.0.e0_rt ) then
      kappa(lo(1):hi(1),lo(2):hi(2),lo(3):hi(3),:) = kappa0 + s0
   else
      do g = 0, ngroups-1
@@ -1310,20 +1332,21 @@ subroutine ca_compute_powerlaw_kappa( lo, hi,  &
   use rad_params_module, only : ngroups, nugroup
   use meth_params_module, only : NVAR, URHO, UTEMP
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: lo(3), hi(3)
   integer, intent(in) :: k_l1, k_l2, k_l3, k_h1, k_h2, k_h3, &
                          u_l1, u_l2, u_l3, u_h1, u_h2, u_h3
-  double precision             :: kappa(k_l1:k_h1, k_l2:k_h2, k_l3:k_h3, 0:ngroups-1)
-  double precision, intent(in) ::     u(u_l1:u_h1, u_l2:u_h2, u_l3:u_h3, NVAR)
-  double precision, intent(in) :: kappa0, m, n, p, Tfloor, kfloor
+  real(rt)                     :: kappa(k_l1:k_h1, k_l2:k_h2, k_l3:k_h3, 0:ngroups-1)
+  real(rt)        , intent(in) ::     u(u_l1:u_h1, u_l2:u_h2, u_l3:u_h3, NVAR)
+  real(rt)        , intent(in) :: kappa0, m, n, p, Tfloor, kfloor
 
   integer :: i, j, k, g
-  double precision, parameter :: tiny = 1.0d-50
-  double precision :: Teff, kf, nup
+  real(rt)        , parameter :: tiny = 1.0e-50_rt
+  real(rt)         :: Teff, kf, nup
 
-  if (  m.eq.0.d0 .and.  n.eq.0.d0 .and.  p.eq.0.d0 ) then
+  if (  m.eq.0.e0_rt .and.  n.eq.0.e0_rt .and.  p.eq.0.e0_rt ) then
      kappa(lo(1):hi(1),lo(2):hi(2),lo(3):hi(3),:) = kappa0
   else
      do g = 0, ngroups-1
@@ -1354,6 +1377,7 @@ subroutine ca_spalpha( lo, hi, &
 
   use rad_params_module, only : ngroups
   use fluxlimiter_module, only : FLDalpha
+  use bl_fort_module, only : rt => c_real
   implicit none
   integer, intent(in) :: lo(3), hi(3)
   integer, intent(in) :: spa_l1, spa_h1, spa_l2, spa_h2, spa_l3, spa_h3
@@ -1361,12 +1385,12 @@ subroutine ca_spalpha( lo, hi, &
   integer, intent(in) :: lmy_l1, lmy_h1, lmy_l2, lmy_h2, lmy_l3, lmy_h3
   integer, intent(in) :: lmz_l1, lmz_h1, lmz_l2, lmz_h2, lmz_l3, lmz_h3
   integer, intent(in) :: igroup
-  double precision             :: spa(spa_l1:spa_h1,spa_l2:spa_h2,spa_l3:spa_h3)
-  double precision, intent(in) :: lmx(lmx_l1:lmx_h1,lmx_l2:lmx_h2,lmx_l3:lmx_h3,0:ngroups-1)
-  double precision, intent(in) :: lmy(lmy_l1:lmy_h1,lmy_l2:lmy_h2,lmy_l3:lmy_h3,0:ngroups-1)
-  double precision, intent(in) :: lmz(lmz_l1:lmz_h1,lmz_l2:lmz_h2,lmz_l3:lmz_h3,0:ngroups-1)
+  real(rt)                     :: spa(spa_l1:spa_h1,spa_l2:spa_h2,spa_l3:spa_h3)
+  real(rt)        , intent(in) :: lmx(lmx_l1:lmx_h1,lmx_l2:lmx_h2,lmx_l3:lmx_h3,0:ngroups-1)
+  real(rt)        , intent(in) :: lmy(lmy_l1:lmy_h1,lmy_l2:lmy_h2,lmy_l3:lmy_h3,0:ngroups-1)
+  real(rt)        , intent(in) :: lmz(lmz_l1:lmz_h1,lmz_l2:lmz_h2,lmz_l3:lmz_h3,0:ngroups-1)
   integer :: i,j,k
-  double precision :: lam
+  real(rt)         :: lam
 
   do k = lo(3), hi(3)
   do j = lo(2), hi(2)
@@ -1376,7 +1400,7 @@ subroutine ca_spalpha( lo, hi, &
           k.eq.spa_l3 .or. k.eq.spa_h3 ) then
         lam = (lmx(i,j,k,igroup) + lmx(i+1,j  ,k  ,igroup) &
              + lmy(i,j,k,igroup) + lmy(i  ,j+1,k  ,igroup) &
-             + lmz(i,j,k,igroup) + lmz(i  ,j  ,k+1,igroup)) / 6.d0
+             + lmz(i,j,k,igroup) + lmz(i  ,j  ,k+1,igroup)) / 6.e0_rt
         spa(i,j,k) = FLDalpha(lam)
      end if
   end do

--- a/Source/Radiation/RadSrc_3d/MGFLDneut_3d.f90
+++ b/Source/Radiation/RadSrc_3d/MGFLDneut_3d.f90
@@ -10,6 +10,7 @@ subroutine ca_accel_acoe_neut( lo, hi,  &
 
   use rad_params_module, only : ngroups, clight, erg2rhoYe
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: lo(3), hi(3)
@@ -19,24 +20,24 @@ subroutine ca_accel_acoe_neut( lo, hi,  &
   integer, intent(in) ::  spc_l1, spc_h1, spc_l2, spc_h2, spc_l3, spc_h3
   integer, intent(in) ::  kap_l1, kap_h1, kap_l2, kap_h2, kap_l3, kap_h3
   integer, intent(in) ::  aco_l1, aco_h1, aco_l2, aco_h2, aco_l3, aco_h3
-  double precision,intent(in)::eta1(eta1_l1:eta1_h1,eta1_l2:eta1_h2,eta1_l3:eta1_h3)
-  double precision,intent(in)::theT(theT_l1:theT_h1,theT_l2:theT_h2,theT_l3:theT_h3)
-  double precision,intent(in)::theY(theY_l1:theY_h1,theY_l2:theY_h2,theY_l3:theY_h3)
-  double precision,intent(in)::spc ( spc_l1: spc_h1, spc_l2: spc_h2, spc_l3: spc_h3,0:ngroups-1)
-  double precision,intent(in)::kap ( kap_l1: kap_h1, kap_l2: kap_h2, kap_l3: kap_h3,0:ngroups-1)
-  double precision           ::aco ( aco_l1: aco_h1, aco_l2: aco_h2, aco_l3: aco_h3)
-  double precision,intent(in) :: dt, tau
+  real(rt)        ,intent(in)::eta1(eta1_l1:eta1_h1,eta1_l2:eta1_h2,eta1_l3:eta1_h3)
+  real(rt)        ,intent(in)::theT(theT_l1:theT_h1,theT_l2:theT_h2,theT_l3:theT_h3)
+  real(rt)        ,intent(in)::theY(theY_l1:theY_h1,theY_l2:theY_h2,theY_l3:theY_h3)
+  real(rt)        ,intent(in)::spc ( spc_l1: spc_h1, spc_l2: spc_h2, spc_l3: spc_h3,0:ngroups-1)
+  real(rt)        ,intent(in)::kap ( kap_l1: kap_h1, kap_l2: kap_h2, kap_l3: kap_h3,0:ngroups-1)
+  real(rt)                   ::aco ( aco_l1: aco_h1, aco_l2: aco_h2, aco_l3: aco_h3)
+  real(rt)        ,intent(in) :: dt, tau
 
   integer :: i, j, k, g
-  double precision :: kbar, kybar, H1, Theta, dt1, foo
+  real(rt)         :: kbar, kybar, H1, Theta, dt1, foo
 
-  dt1 = (1.d0+tau)/dt
+  dt1 = (1.e0_rt+tau)/dt
 
   do k = lo(3), hi(3)
   do j = lo(2), hi(2)
   do i = lo(1), hi(1)
-     kbar = 0.d0
-     kybar = 0.d0
+     kbar = 0.e0_rt
+     kybar = 0.e0_rt
      do g=0, ngroups-1
         foo = spc(i,j,k,g) * kap(i,j,k,g)
         kbar = kbar + foo
@@ -67,6 +68,7 @@ subroutine ca_accel_rhs_neut( lo, hi,  &
 
   use rad_params_module, only : ngroups, clight, erg2rhoYe
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: lo(3), hi(3)
@@ -78,24 +80,24 @@ subroutine ca_accel_rhs_neut( lo, hi,  &
   integer, intent(in) ::theT_l1,theT_h1,theT_l2,theT_h2,theT_l3,theT_h3
   integer, intent(in) ::theY_l1,theY_h1,theY_l2,theY_h2,theY_l3,theY_h3
   integer, intent(in) :: rhs_l1, rhs_h1, rhs_l2, rhs_h2, rhs_l3, rhs_h3
-  double precision,intent(in)::Ern ( Ern_l1: Ern_h1, Ern_l2: Ern_h2, Ern_l3: Ern_h3,0:ngroups-1)
-  double precision,intent(in)::Erl ( Erl_l1: Erl_h1, Erl_l2: Erl_h2, Erl_l3: Erl_h3,0:ngroups-1)
-  double precision,intent(in):: kap( kap_l1: kap_h1, kap_l2: kap_h2, kap_l3: kap_h3,0:ngroups-1)
-  double precision,intent(in)::etaT(etaT_l1:etaT_h1,etaT_l2:etaT_h2,etaT_l3:etaT_h3)
-  double precision,intent(in)::etaY(etaY_l1:etaY_h1,etaY_l2:etaY_h2,etaY_l3:etaY_h3)
-  double precision,intent(in)::theT(theT_l1:theT_h1,theT_l2:theT_h2,theT_l3:theT_h3)
-  double precision,intent(in)::theY(theY_l1:theY_h1,theY_l2:theY_h2,theY_l3:theY_h3)
-  double precision           :: rhs( rhs_l1: rhs_h1, rhs_l2: rhs_h2, rhs_l3: rhs_h3)
-  double precision,intent(in) :: dt
+  real(rt)        ,intent(in)::Ern ( Ern_l1: Ern_h1, Ern_l2: Ern_h2, Ern_l3: Ern_h3,0:ngroups-1)
+  real(rt)        ,intent(in)::Erl ( Erl_l1: Erl_h1, Erl_l2: Erl_h2, Erl_l3: Erl_h3,0:ngroups-1)
+  real(rt)        ,intent(in):: kap( kap_l1: kap_h1, kap_l2: kap_h2, kap_l3: kap_h3,0:ngroups-1)
+  real(rt)        ,intent(in)::etaT(etaT_l1:etaT_h1,etaT_l2:etaT_h2,etaT_l3:etaT_h3)
+  real(rt)        ,intent(in)::etaY(etaY_l1:etaY_h1,etaY_l2:etaY_h2,etaY_l3:etaY_h3)
+  real(rt)        ,intent(in)::theT(theT_l1:theT_h1,theT_l2:theT_h2,theT_l3:theT_h3)
+  real(rt)        ,intent(in)::theY(theY_l1:theY_h1,theY_l2:theY_h2,theY_l3:theY_h3)
+  real(rt)                   :: rhs( rhs_l1: rhs_h1, rhs_l2: rhs_h2, rhs_l3: rhs_h3)
+  real(rt)        ,intent(in) :: dt
 
   integer :: i, j, k, g
-  double precision :: rt, ry, H, Theta, foo
+  real(rt)         :: rt, ry, H, Theta, foo
 
   do k = lo(3), hi(3)
   do j = lo(2), hi(2)
   do i = lo(1), hi(1)
-     rt = 0.d0
-     ry = 0.d0
+     rt = 0.e0_rt
+     ry = 0.e0_rt
      do g=0,ngroups-1
         foo = kap(i,j,k,g)*(Ern(i,j,k,g)-Erl(i,j,k,g))
         rt = rt + foo
@@ -128,6 +130,7 @@ subroutine ca_accel_spec_neut( lo, hi, &
 
   use rad_params_module, only : ngroups, clight, erg2rhoYe
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: lo(3), hi(3)
@@ -141,30 +144,30 @@ subroutine ca_accel_spec_neut( lo, hi, &
   integer,intent(in)::mugT_l1,mugT_h1,mugT_l2,mugT_h2,mugT_l3,mugT_h3
   integer,intent(in)::mugY_l1,mugY_h1,mugY_l2,mugY_h2,mugY_l3,mugY_h3
   integer,intent(in)::spec_l1,spec_h1,spec_l2,spec_h2,spec_l3,spec_h3
-  double precision,intent(in)::Ern ( Ern_l1: Ern_h1, Ern_l2: Ern_h2, Ern_l3: Ern_h3,0:ngroups-1)
-  double precision,intent(in)::Erl ( Erl_l1: Erl_h1, Erl_l2: Erl_h2, Erl_l3: Erl_h3,0:ngroups-1)
-  double precision,intent(in)::kap ( kap_l1: kap_h1, kap_l2: kap_h2, kap_l3: kap_h3,0:ngroups-1)
-  double precision,intent(in)::etaT(etaT_l1:etaT_h1,etaT_l2:etaT_h2,etaT_l3:etaT_h3)
-  double precision,intent(in)::etaY(etaY_l1:etaY_h1,etaY_l2:etaY_h2,etaY_l3:etaY_h3)
-  double precision,intent(in)::theT(theT_l1:theT_h1,theT_l2:theT_h2,theT_l3:theT_h3)
-  double precision,intent(in)::theY(theY_l1:theY_h1,theY_l2:theY_h2,theY_l3:theY_h3)
-  double precision,intent(in)::mugT(mugT_l1:mugT_h1,mugT_l2:mugT_h2,mugT_l3:mugT_h3,0:ngroups-1)
-  double precision,intent(in)::mugY(mugY_l1:mugY_h1,mugY_l2:mugY_h2,mugY_l3:mugY_h3,0:ngroups-1)
-  double precision           ::spec(spec_l1:spec_h1,spec_l2:spec_h2,spec_l3:spec_h3,0:ngroups-1)
-  double precision,intent(in) :: dt, tau
+  real(rt)        ,intent(in)::Ern ( Ern_l1: Ern_h1, Ern_l2: Ern_h2, Ern_l3: Ern_h3,0:ngroups-1)
+  real(rt)        ,intent(in)::Erl ( Erl_l1: Erl_h1, Erl_l2: Erl_h2, Erl_l3: Erl_h3,0:ngroups-1)
+  real(rt)        ,intent(in)::kap ( kap_l1: kap_h1, kap_l2: kap_h2, kap_l3: kap_h3,0:ngroups-1)
+  real(rt)        ,intent(in)::etaT(etaT_l1:etaT_h1,etaT_l2:etaT_h2,etaT_l3:etaT_h3)
+  real(rt)        ,intent(in)::etaY(etaY_l1:etaY_h1,etaY_l2:etaY_h2,etaY_l3:etaY_h3)
+  real(rt)        ,intent(in)::theT(theT_l1:theT_h1,theT_l2:theT_h2,theT_l3:theT_h3)
+  real(rt)        ,intent(in)::theY(theY_l1:theY_h1,theY_l2:theY_h2,theY_l3:theY_h3)
+  real(rt)        ,intent(in)::mugT(mugT_l1:mugT_h1,mugT_l2:mugT_h2,mugT_l3:mugT_h3,0:ngroups-1)
+  real(rt)        ,intent(in)::mugY(mugY_l1:mugY_h1,mugY_l2:mugY_h2,mugY_l3:mugY_h3,0:ngroups-1)
+  real(rt)                   ::spec(spec_l1:spec_h1,spec_l2:spec_h2,spec_l3:spec_h3,0:ngroups-1)
+  real(rt)        ,intent(in) :: dt, tau
 
   integer :: i, j, k, g
-  double precision :: cdt1, rt, ry, p, q, r, s, foo, sumeps
-  double precision,dimension(0:ngroups-1)::Hg, Tg, epsilon, kapt, kk
+  real(rt)         :: cdt1, rt, ry, p, q, r, s, foo, sumeps
+  real(rt)        ,dimension(0:ngroups-1)::Hg, Tg, epsilon, kapt, kk
 
-  cdt1 = 1.d0/(clight*dt)
+  cdt1 = 1.e0_rt/(clight*dt)
 
   do k = lo(3), hi(3)
   do j = lo(2), hi(2)
   do i = lo(1), hi(1)
 
-     rt = 0.d0
-     ry = 0.d0
+     rt = 0.e0_rt
+     ry = 0.e0_rt
      do g=0,ngroups-1
         foo = kap(i,j,k,g)*(Ern(i,j,k,g)-Erl(i,j,k,g))
         rt = rt + foo
@@ -174,19 +177,19 @@ subroutine ca_accel_spec_neut( lo, hi, &
      Hg = mugT(i,j,k,:)*etaT(i,j,k) - mugY(i,j,k,:)*etaY(i,j,k)
      Tg = -mugT(i,j,k,:)*theT(i,j,k) + mugY(i,j,k,:)*theY(i,j,k)
 
-     kapt = kap(i,j,k,:) + (1.d0+tau)*cdt1
+     kapt = kap(i,j,k,:) + (1.e0_rt+tau)*cdt1
      kk = kap(i,j,k,:) / kapt
 
-     p = 1.d0 - sum(Hg*kk)
-     q = 1.d0 - sum(Tg*erg2rhoYe*kk)
+     p = 1.e0_rt - sum(Hg*kk)
+     q = 1.e0_rt - sum(Tg*erg2rhoYe*kk)
      r = sum(Hg*erg2rhoYe*kk)
      s = sum(Tg*kk)
 
      epsilon = ((r*Tg + q*Hg) * rt + (s*Hg + p*Tg) * ry) / kapt
 
      sumeps = sum(epsilon)
-     if (sumeps .eq. 0.d0) then
-        sumeps = 1.d-50
+     if (sumeps .eq. 0.e0_rt) then
+        sumeps = 1.e-50_rt
      end if
      
      spec(i,j,k,:) = epsilon / sumeps
@@ -218,6 +221,7 @@ subroutine ca_check_conv_neut( lo, hi, &
      dt)
   use rad_params_module, only : ngroups, clight, erg2rhoYe
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer,intent(in)::lo(3),hi(3)
@@ -235,27 +239,27 @@ subroutine ca_check_conv_neut( lo, hi, &
   integer,intent(in):: jg_l1,  jg_h1,  jg_l2,  jg_h2,  jg_l3,  jg_h3
   integer,intent(in)::deT_l1, deT_h1, deT_l2, deT_h2, deT_l3, deT_h3
   integer,intent(in)::deY_l1, deY_h1, deY_l2, deY_h2, deY_l3, deY_h3
-  double precision,intent(in)::ren(ren_l1:ren_h1,ren_l2:ren_h2,ren_l3:ren_h3)
-  double precision,intent(in)::res(res_l1:res_h1,res_l2:res_h2,res_l3:res_h3)
-  double precision,intent(in)::re2(re2_l1:re2_h1,re2_l2:re2_h2,re2_l3:re2_h3)
-  double precision,intent(in)::ern(ern_l1:ern_h1,ern_l2:ern_h2,ern_l3:ern_h3,0:ngroups-1)
-  double precision,intent(in)::Tmn(Tmn_l1:Tmn_h1,Tmn_l2:Tmn_h2,Tmn_l3:Tmn_h3)
-  double precision,intent(in)::Tms(Tms_l1:Tms_h1,Tms_l2:Tms_h2,Tms_l3:Tms_h3)
-  double precision,intent(in)::rYn(rYn_l1:rYn_h1,rYn_l2:rYn_h2,rYn_l3:rYn_h3)
-  double precision,intent(in)::rYs(rYs_l1:rYs_h1,rYs_l2:rYs_h2,rYs_l3:rYs_h3)
-  double precision,intent(in)::rY2(rY2_l1:rY2_h1,rY2_l2:rY2_h2,rY2_l3:rY2_h3)
-  double precision,intent(in)::rho(rho_l1:rho_h1,rho_l2:rho_h2,rho_l3:rho_h3)
-  double precision,intent(in)::kap(kap_l1:kap_h1,kap_l2:kap_h2,kap_l3:kap_h3,0:ngroups-1)
-  double precision,intent(in):: jg( jg_l1: jg_h1, jg_l2: jg_h2, jg_l3: jg_h3,0:ngroups-1)
-  double precision,intent(in)::deT(deT_l1:deT_h1,deT_l2:deT_h2,deT_l3:deT_h3)
-  double precision,intent(in)::deY(deY_l1:deY_h1,deY_l2:deY_h2,deY_l3:deY_h3)
-  double precision,intent(inout)::rel_re, abs_re
-  double precision,intent(inout)::rel_FT, abs_FT,rel_T, abs_T
-  double precision,intent(inout)::rel_FY, abs_FY,rel_Y, abs_Y
-  double precision,intent(in) :: dt
+  real(rt)        ,intent(in)::ren(ren_l1:ren_h1,ren_l2:ren_h2,ren_l3:ren_h3)
+  real(rt)        ,intent(in)::res(res_l1:res_h1,res_l2:res_h2,res_l3:res_h3)
+  real(rt)        ,intent(in)::re2(re2_l1:re2_h1,re2_l2:re2_h2,re2_l3:re2_h3)
+  real(rt)        ,intent(in)::ern(ern_l1:ern_h1,ern_l2:ern_h2,ern_l3:ern_h3,0:ngroups-1)
+  real(rt)        ,intent(in)::Tmn(Tmn_l1:Tmn_h1,Tmn_l2:Tmn_h2,Tmn_l3:Tmn_h3)
+  real(rt)        ,intent(in)::Tms(Tms_l1:Tms_h1,Tms_l2:Tms_h2,Tms_l3:Tms_h3)
+  real(rt)        ,intent(in)::rYn(rYn_l1:rYn_h1,rYn_l2:rYn_h2,rYn_l3:rYn_h3)
+  real(rt)        ,intent(in)::rYs(rYs_l1:rYs_h1,rYs_l2:rYs_h2,rYs_l3:rYs_h3)
+  real(rt)        ,intent(in)::rY2(rY2_l1:rY2_h1,rY2_l2:rY2_h2,rY2_l3:rY2_h3)
+  real(rt)        ,intent(in)::rho(rho_l1:rho_h1,rho_l2:rho_h2,rho_l3:rho_h3)
+  real(rt)        ,intent(in)::kap(kap_l1:kap_h1,kap_l2:kap_h2,kap_l3:kap_h3,0:ngroups-1)
+  real(rt)        ,intent(in):: jg( jg_l1: jg_h1, jg_l2: jg_h2, jg_l3: jg_h3,0:ngroups-1)
+  real(rt)        ,intent(in)::deT(deT_l1:deT_h1,deT_l2:deT_h2,deT_l3:deT_h3)
+  real(rt)        ,intent(in)::deY(deY_l1:deY_h1,deY_l2:deY_h2,deY_l3:deY_h3)
+  real(rt)        ,intent(inout)::rel_re, abs_re
+  real(rt)        ,intent(inout)::rel_FT, abs_FT,rel_T, abs_T
+  real(rt)        ,intent(inout)::rel_FY, abs_FY,rel_Y, abs_Y
+  real(rt)        ,intent(in) :: dt
 
   integer :: i, j, k
-  double precision :: chg, relchg, FT, FY, cdt, FTdenom, FYdenom, dTe, dYe
+  real(rt)         :: chg, relchg, FT, FY, cdt, FTdenom, FYdenom, dTe, dYe
 
   cdt = clight*dt
 
@@ -263,17 +267,17 @@ subroutine ca_check_conv_neut( lo, hi, &
   do j=lo(2),hi(2)
   do i=lo(1),hi(1)
      chg = abs(ren(i,j,k) - res(i,j,k))
-     relchg = abs(chg/(ren(i,j,k)+1.d-50))
+     relchg = abs(chg/(ren(i,j,k)+1.e-50_rt))
      rel_re = max(rel_re,relchg)
      abs_re = max(abs_re,chg)
 
      chg = abs(Tmn(i,j,k) - Tms(i,j,k))
-     relchg = abs(chg/(Tmn(i,j,k)+1.d-50))
+     relchg = abs(chg/(Tmn(i,j,k)+1.e-50_rt))
      rel_T = max(rel_T,relchg)
      abs_T = max(abs_T,chg)
 
      chg = abs(rYn(i,j,k) - rYs(i,j,k))
-     relchg = abs(chg/(rYn(i,j,k)+1.d-50))
+     relchg = abs(chg/(rYn(i,j,k)+1.e-50_rt))
      rel_Y = max(rel_Y,relchg)
      abs_Y = max(abs_Y,chg/rho(i,j,k))
 
@@ -285,10 +289,10 @@ subroutine ca_check_conv_neut( lo, hi, &
      FTdenom = rho(i,j,k)*(abs(deT(i,j,k)*dTe)+abs(deY(i,j,k)*dYe))
      FYdenom = rYn(i,j,k)
 
-     rel_FT = max(rel_FT, FT/(FTdenom+1.d-50))
+     rel_FT = max(rel_FT, FT/(FTdenom+1.e-50_rt))
      abs_FT = max(abs_FT, FT)
 
-     rel_FY = max(rel_FY, FY/(FYdenom+1.d-50))
+     rel_FY = max(rel_FY, FY/(FYdenom+1.e-50_rt))
      abs_FY = max(abs_FY, FY)
   end do
   end do
@@ -311,6 +315,7 @@ subroutine ca_check_conv_er_neut( lo, hi,  &
 
   use rad_params_module, only : ngroups, clight, erg2rhoYe
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer,intent(in):: lo(3), hi(3)
@@ -323,29 +328,29 @@ subroutine ca_check_conv_er_neut( lo, hi,  &
   integer,intent(in)::etYz_l1,etYz_h1,etYz_l2,etYz_h2,etYz_l3,etYz_h3
   integer,intent(in)::thTz_l1,thTz_h1,thTz_l2,thTz_h2,thTz_l3,thTz_h3
   integer,intent(in)::thYz_l1,thYz_h1,thYz_l2,thYz_h2,thYz_l3,thYz_h3
-  double precision,intent(in):: Ern( Ern_l1: Ern_h1, Ern_l2: Ern_h2, Ern_l3: Ern_h3,0:ngroups-1)
-  double precision,intent(in):: Erl( Erl_l1: Erl_h1, Erl_l2: Erl_h2, Erl_l3: Erl_h3,0:ngroups-1)
-  double precision,intent(in):: kap( kap_l1: kap_h1, kap_l2: kap_h2, kap_l3: kap_h3,0:ngroups-1)
-  double precision,intent(in)::etTz(etTz_l1:etTz_h1,etTz_l2:etTz_h2,etTz_l3:etTz_h3)
-  double precision,intent(in)::etYz(etYz_l1:etYz_h1,etYz_l2:etYz_h2,etYz_l3:etYz_h3)
-  double precision,intent(in)::thTz(thTz_l1:thTz_h1,thTz_l2:thTz_h2,thTz_l3:thTz_h3)
-  double precision,intent(in)::thYz(thYz_l1:thYz_h1,thYz_l2:thYz_h2,thYz_l3:thYz_h3)
-  double precision,intent(in)::temp(temp_l1:temp_h1,temp_l2:temp_h2,temp_l3:temp_h3)
-  double precision,intent(in)::Ye  (  Ye_l1:  Ye_h1,  Ye_l2:  Ye_h2,  Ye_l3:  Ye_h3)
-  double precision, intent(inout) :: rela, abso, errr
-  double precision, intent(in) :: dt
+  real(rt)        ,intent(in):: Ern( Ern_l1: Ern_h1, Ern_l2: Ern_h2, Ern_l3: Ern_h3,0:ngroups-1)
+  real(rt)        ,intent(in):: Erl( Erl_l1: Erl_h1, Erl_l2: Erl_h2, Erl_l3: Erl_h3,0:ngroups-1)
+  real(rt)        ,intent(in):: kap( kap_l1: kap_h1, kap_l2: kap_h2, kap_l3: kap_h3,0:ngroups-1)
+  real(rt)        ,intent(in)::etTz(etTz_l1:etTz_h1,etTz_l2:etTz_h2,etTz_l3:etTz_h3)
+  real(rt)        ,intent(in)::etYz(etYz_l1:etYz_h1,etYz_l2:etYz_h2,etYz_l3:etYz_h3)
+  real(rt)        ,intent(in)::thTz(thTz_l1:thTz_h1,thTz_l2:thTz_h2,thTz_l3:thTz_h3)
+  real(rt)        ,intent(in)::thYz(thYz_l1:thYz_h1,thYz_l2:thYz_h2,thYz_l3:thYz_h3)
+  real(rt)        ,intent(in)::temp(temp_l1:temp_h1,temp_l2:temp_h2,temp_l3:temp_h3)
+  real(rt)        ,intent(in)::Ye  (  Ye_l1:  Ye_h1,  Ye_l2:  Ye_h2,  Ye_l3:  Ye_h3)
+  real(rt)        , intent(inout) :: rela, abso, errr
+  real(rt)        , intent(in) :: dt
 
   integer :: i, j, k, g
-  double precision :: chg, tot, cdt, der, kdeT, kdeY, err_T, err_Y, err
+  real(rt)         :: chg, tot, cdt, der, kdeT, kdeY, err_T, err_Y, err
 
   cdt = clight * dt
   do k = lo(3), hi(3)
   do j = lo(2), hi(2)
   do i = lo(1), hi(1)
-     chg = 0.d0
-     tot = 0.d0
-     kdeT = 0.d0
-     kdeY = 0.d0
+     chg = 0.e0_rt
+     tot = 0.e0_rt
+     kdeT = 0.e0_rt
+     kdeY = 0.e0_rt
      do g=0,ngroups-1
         der = Ern(i,j,k,g)-Erl(i,j,k,g)
         chg = chg + abs(der)
@@ -354,11 +359,11 @@ subroutine ca_check_conv_er_neut( lo, hi,  &
         kdeY = kdeY + erg2rhoYe(g)*kap(i,j,k,g)*der
      end do
      abso = max(abso, chg)
-     rela = max(rela, chg / (tot + 1.d-50))
+     rela = max(rela, chg / (tot + 1.e-50_rt))
 
      err_T =  etTz(i,j,k)*kdeT - thTz(i,j,k)*kdeY 
      err_Y = -etYz(i,j,k)*kdeT + thYz(i,j,k)*kdeY 
-     err = max(abs(err_T/(temp(i,j,k)+1.d-50)), abs(err_Y/(Ye(i,j,k)+1.d-50)))
+     err = max(abs(err_T/(temp(i,j,k)+1.e-50_rt)), abs(err_Y/(Ye(i,j,k)+1.e-50_rt)))
      errr = max(errr, err)
   end do
   end do
@@ -376,6 +381,7 @@ subroutine ca_compute_coupty( lo, hi,  &
   
   use rad_params_module, only : ngroups, erg2rhoYe
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: lo(3), hi(3)
@@ -384,20 +390,20 @@ subroutine ca_compute_coupty( lo, hi,  &
   integer, intent(in) :: kpp_l1, kpp_h1, kpp_l2, kpp_h2, kpp_l3, kpp_h3
   integer, intent(in) ::  eg_l1,  eg_h1,  eg_l2,  eg_h2,  eg_l3,  eg_h3
   integer, intent(in) ::  jg_l1,  jg_h1,  jg_l2,  jg_h2,  jg_l3,  jg_h3
-  double precision             :: cpt(cpt_l1:cpt_h1,cpt_l2:cpt_h2,cpt_l3:cpt_h3)
-  double precision             :: cpy(cpy_l1:cpy_h1,cpy_l2:cpy_h2,cpy_l3:cpy_h3)
-  double precision, intent(in) :: kpp(kpp_l1:kpp_h1,kpp_l2:kpp_h2,kpp_l3:kpp_h3,0:ngroups-1)
-  double precision, intent(in) ::  eg( eg_l1: eg_h1, eg_l2: eg_h2, eg_l3: eg_h3,0:ngroups-1)
-  double precision, intent(in) ::  jg( jg_l1: jg_h1, jg_l2: jg_h2, jg_l3: jg_h3,0:ngroups-1)
+  real(rt)                     :: cpt(cpt_l1:cpt_h1,cpt_l2:cpt_h2,cpt_l3:cpt_h3)
+  real(rt)                     :: cpy(cpy_l1:cpy_h1,cpy_l2:cpy_h2,cpy_l3:cpy_h3)
+  real(rt)        , intent(in) :: kpp(kpp_l1:kpp_h1,kpp_l2:kpp_h2,kpp_l3:kpp_h3,0:ngroups-1)
+  real(rt)        , intent(in) ::  eg( eg_l1: eg_h1, eg_l2: eg_h2, eg_l3: eg_h3,0:ngroups-1)
+  real(rt)        , intent(in) ::  jg( jg_l1: jg_h1, jg_l2: jg_h2, jg_l3: jg_h3,0:ngroups-1)
 
   integer :: i, j, k, g
-  double precision :: foo
+  real(rt)         :: foo
 
   do k=lo(3),hi(3)
      do j=lo(2),hi(2)
         do i=lo(1),hi(1)
-           cpt(i,j,k) = 0.d0
-           cpy(i,j,k) = 0.d0
+           cpt(i,j,k) = 0.e0_rt
+           cpy(i,j,k) = 0.e0_rt
         end do
      end do
   end do
@@ -431,6 +437,7 @@ subroutine ca_compute_dedx( lo, hi,  &
   use network, only : nspec, naux
   use meth_params_module, only : NVAR, URHO, UFS
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: lo(3), hi(3)
@@ -441,26 +448,26 @@ subroutine ca_compute_dedx( lo, hi,  &
   integer, intent(in) ::  Yes_l1,  Yes_h1,  Yes_l2,  Yes_h2,  Yes_l3,  Yes_h3
   integer, intent(in) :: dedT_l1, dedT_h1, dedT_l2, dedT_h2, dedT_l3, dedT_h3
   integer, intent(in) :: dedY_l1, dedY_h1, dedY_l2, dedY_h2, dedY_l3, dedY_h3
-  double precision, intent(in) :: S   (   S_l1:   S_h1,   S_l2:   S_h2,   S_l3:   S_h3,NVAR)
-  double precision, intent(in) :: T   (   T_l1:   T_h1,   T_l2:   T_h2,   T_l3:   T_h3)
-  double precision, intent(in) :: Ye  (  Ye_l1:  Ye_h1,  Ye_l2:  Ye_h2,  Ye_l3:  Ye_h3)
-  double precision, intent(in) :: Ts  (  Ts_l1:  Ts_h1,  Ts_l2:  Ts_h2,  Ts_l3:  Ts_h3)
-  double precision, intent(in) :: Yes ( Yes_l1: Yes_h1, Yes_l2: Yes_h2, Yes_l3: Yes_h3)
-  double precision             :: dedT(dedT_l1:dedT_h1,dedT_l2:dedT_h2,dedT_l3:dedT_h3)
-  double precision             :: dedY(dedY_l1:dedY_h1,dedY_l2:dedY_h2,dedY_l3:dedY_h3)
+  real(rt)        , intent(in) :: S   (   S_l1:   S_h1,   S_l2:   S_h2,   S_l3:   S_h3,NVAR)
+  real(rt)        , intent(in) :: T   (   T_l1:   T_h1,   T_l2:   T_h2,   T_l3:   T_h3)
+  real(rt)        , intent(in) :: Ye  (  Ye_l1:  Ye_h1,  Ye_l2:  Ye_h2,  Ye_l3:  Ye_h3)
+  real(rt)        , intent(in) :: Ts  (  Ts_l1:  Ts_h1,  Ts_l2:  Ts_h2,  Ts_l3:  Ts_h3)
+  real(rt)        , intent(in) :: Yes ( Yes_l1: Yes_h1, Yes_l2: Yes_h2, Yes_l3: Yes_h3)
+  real(rt)                     :: dedT(dedT_l1:dedT_h1,dedT_l2:dedT_h2,dedT_l3:dedT_h3)
+  real(rt)                     :: dedY(dedY_l1:dedY_h1,dedY_l2:dedY_h2,dedY_l3:dedY_h3)
   integer, intent(in) :: validStar
 
   integer :: i, j, k
-  double precision :: rhoinv, e1, e2
+  real(rt)         :: rhoinv, e1, e2
   type(eos_t) :: eos_state
-  double precision :: dT, dYe, T1, T2, Ye1, Ye2
-  double precision, parameter :: fac = 0.5d0, minfrac = 1.d-8
+  real(rt)         :: dT, dYe, T1, T2, Ye1, Ye2
+  real(rt)        , parameter :: fac = 0.5e0_rt, minfrac = 1.e-8_rt
 
   do k=lo(3),hi(3)
   do j=lo(2),hi(2)
   do i=lo(1),hi(1)
 
-     rhoinv = 1.d0/S(i,j,k,URHO)
+     rhoinv = 1.e0_rt/S(i,j,k,URHO)
      eos_state % rho = S(i,j,k,URHO)
      eos_state % xn  = S(i,j,k,UFS:UFS+nspec-1) * rhoinv
      eos_state % aux = ye(i,j,k)
@@ -471,18 +478,18 @@ subroutine ca_compute_dedx( lo, hi,  &
         dYe = fac*abs(Yes(i,j,k) - Ye(i,j,k))
         dYe = max(dYe, minfrac*Ye(i,j,k))
      else
-        dT = T(i,j,k) * 1.d-3 + 1.d-50
-        dYe = 1.d-4
+        dT = T(i,j,k) * 1.e-3_rt + 1.e-50_rt
+        dYe = 1.e-4_rt
      end if
 
      T1 = T(i,j,k) - dT
-     if (T1 < Tmin*(1.d0+1.d-6)) then
+     if (T1 < Tmin*(1.e0_rt+1.e-6_rt)) then
         T1 = T(i,j,k)
      end if
      T2 = T(i,j,k) + dT
 
      Ye1 = Ye(i,j,k) - dYe
-     if (Ye1 < Ymin*(1.d0+1.d-6)) then
+     if (Ye1 < Ymin*(1.e0_rt+1.e-6_rt)) then
         Ye1 = Ye(i,j,k)
      end if
      Ye2 = Ye(i,j,k) + dYe
@@ -539,6 +546,7 @@ subroutine ca_compute_eta_the( lo, hi, &
 
   use rad_params_module, only : ngroups, clight, erg2rhoYe
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: lo(3), hi(3)
@@ -560,32 +568,32 @@ subroutine ca_compute_eta_the( lo, hi, &
   integer, intent(in) :: dedY_l1, dedY_h1, dedY_l2, dedY_h2, dedY_l3, dedY_h3
   integer, intent(in) ::  Ers_l1,  Ers_h1,  Ers_l2,  Ers_h2,  Ers_l3,  Ers_h3
   integer, intent(in) ::  rho_l1,  rho_h1,  rho_l2,  rho_h2,  rho_l3,  rho_h3
-  double precision           ::etaT(etaT_l1:etaT_h1,etaT_l2:etaT_h2,etaT_l3:etaT_h3)
-  double precision           ::etTz(etTz_l1:etTz_h1,etTz_l2:etTz_h2,etTz_l3:etTz_h3)
-  double precision           ::etaY(etaY_l1:etaY_h1,etaY_l2:etaY_h2,etaY_l3:etaY_h3)
-  double precision           ::etYz(etYz_l1:etYz_h1,etYz_l2:etYz_h2,etYz_l3:etYz_h3)
-  double precision           ::eta1(eta1_l1:eta1_h1,eta1_l2:eta1_h2,eta1_l3:eta1_h3)
-  double precision           ::theT(theT_l1:theT_h1,theT_l2:theT_h2,theT_l3:theT_h3)
-  double precision           ::thTz(thTz_l1:thTz_h1,thTz_l2:thTz_h2,thTz_l3:thTz_h3)
-  double precision           ::theY(theY_l1:theY_h1,theY_l2:theY_h2,theY_l3:theY_h3)
-  double precision           ::thYz(thYz_l1:thYz_h1,thYz_l2:thYz_h2,thYz_l3:thYz_h3)
-  double precision           ::the1(the1_l1:the1_h1,the1_l2:the1_h2,the1_l3:the1_h3)
-  double precision           ::djdT(djdT_l1:djdT_h1,djdT_l2:djdT_h2,djdT_l3:djdT_h3,0:ngroups-1)
-  double precision           ::djdY(djdY_l1:djdY_h1,djdY_l2:djdY_h2,djdY_l3:djdY_h3,0:ngroups-1)
-  double precision,intent(in)::dkdT(dkdT_l1:dkdT_h1,dkdT_l2:dkdT_h2,dkdT_l3:dkdT_h3,0:ngroups-1)
-  double precision,intent(in)::dkdY(dkdY_l1:dkdY_h1,dkdY_l2:dkdY_h2,dkdY_l3:dkdY_h3,0:ngroups-1)
-  double precision,intent(in)::dedT(dedT_l1:dedT_h1,dedT_l2:dedT_h2,dedT_l3:dedT_h3)
-  double precision,intent(in)::dedY(dedY_l1:dedY_h1,dedY_l2:dedY_h2,dedY_l3:dedY_h3)
-  double precision,intent(in)::Ers ( Ers_l1: Ers_h1, Ers_l2: Ers_h2, Ers_l3: Ers_h3,0:ngroups-1)
-  double precision,intent(in)::rho ( rho_l1: rho_h1, rho_l2: rho_h2, rho_l3: rho_h3)
-  double precision,intent(in) :: dt, tau
+  real(rt)                   ::etaT(etaT_l1:etaT_h1,etaT_l2:etaT_h2,etaT_l3:etaT_h3)
+  real(rt)                   ::etTz(etTz_l1:etTz_h1,etTz_l2:etTz_h2,etTz_l3:etTz_h3)
+  real(rt)                   ::etaY(etaY_l1:etaY_h1,etaY_l2:etaY_h2,etaY_l3:etaY_h3)
+  real(rt)                   ::etYz(etYz_l1:etYz_h1,etYz_l2:etYz_h2,etYz_l3:etYz_h3)
+  real(rt)                   ::eta1(eta1_l1:eta1_h1,eta1_l2:eta1_h2,eta1_l3:eta1_h3)
+  real(rt)                   ::theT(theT_l1:theT_h1,theT_l2:theT_h2,theT_l3:theT_h3)
+  real(rt)                   ::thTz(thTz_l1:thTz_h1,thTz_l2:thTz_h2,thTz_l3:thTz_h3)
+  real(rt)                   ::theY(theY_l1:theY_h1,theY_l2:theY_h2,theY_l3:theY_h3)
+  real(rt)                   ::thYz(thYz_l1:thYz_h1,thYz_l2:thYz_h2,thYz_l3:thYz_h3)
+  real(rt)                   ::the1(the1_l1:the1_h1,the1_l2:the1_h2,the1_l3:the1_h3)
+  real(rt)                   ::djdT(djdT_l1:djdT_h1,djdT_l2:djdT_h2,djdT_l3:djdT_h3,0:ngroups-1)
+  real(rt)                   ::djdY(djdY_l1:djdY_h1,djdY_l2:djdY_h2,djdY_l3:djdY_h3,0:ngroups-1)
+  real(rt)        ,intent(in)::dkdT(dkdT_l1:dkdT_h1,dkdT_l2:dkdT_h2,dkdT_l3:dkdT_h3,0:ngroups-1)
+  real(rt)        ,intent(in)::dkdY(dkdY_l1:dkdY_h1,dkdY_l2:dkdY_h2,dkdY_l3:dkdY_h3,0:ngroups-1)
+  real(rt)        ,intent(in)::dedT(dedT_l1:dedT_h1,dedT_l2:dedT_h2,dedT_l3:dedT_h3)
+  real(rt)        ,intent(in)::dedY(dedY_l1:dedY_h1,dedY_l2:dedY_h2,dedY_l3:dedY_h3)
+  real(rt)        ,intent(in)::Ers ( Ers_l1: Ers_h1, Ers_l2: Ers_h2, Ers_l3: Ers_h3,0:ngroups-1)
+  real(rt)        ,intent(in)::rho ( rho_l1: rho_h1, rho_l2: rho_h2, rho_l3: rho_h3)
+  real(rt)        ,intent(in) :: dt, tau
 
   integer :: i, j, k
-  double precision :: cdt, det, et, ey, tt, ty, sigma
-  double precision :: dZdT(0:ngroups-1), dZdY(0:ngroups-1)
-  double precision :: sumdZdT, sumdZdY, fooT, fooY, barT, barY
+  real(rt)         :: cdt, det, et, ey, tt, ty, sigma
+  real(rt)         :: dZdT(0:ngroups-1), dZdY(0:ngroups-1)
+  real(rt)         :: sumdZdT, sumdZdY, fooT, fooY, barT, barY
 
-  sigma = 1.d0 + tau
+  sigma = 1.e0_rt + tau
   cdt = clight * dt
 
   do k = lo(3), hi(3)
@@ -597,12 +605,12 @@ subroutine ca_compute_eta_the( lo, hi, &
      sumdZdT = sum(dZdT)
      sumdZdY = sum(dZdY)
 
-     if (sumdZdT .eq. 0.d0) then
-        sumdZdT = 1.d-50
+     if (sumdZdT .eq. 0.e0_rt) then
+        sumdZdT = 1.e-50_rt
      end if
 
-     if (sumdZdY .eq. 0.d0) then
-        sumdZdY = 1.d-50
+     if (sumdZdY .eq. 0.e0_rt) then
+        sumdZdY = 1.e-50_rt
      end if
 
      fooT = cdt * sumdZdT
@@ -658,6 +666,7 @@ subroutine ca_compute_rhs_neut( lo, hi, &
 
   use rad_params_module, only : ngroups, clight
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer,intent(in):: lo(3), hi(3) 
@@ -677,30 +686,30 @@ subroutine ca_compute_rhs_neut( lo, hi, &
   integer,intent(in):: Ers_l1, Ers_h1, Ers_l2, Ers_h2, Ers_l3, Ers_h3
   integer,intent(in):: res_l1, res_h1, res_l2, res_h2, res_l3, res_h3
   integer,intent(in):: rYs_l1, rYs_h1, rYs_l2, rYs_h2, rYs_l3, rYs_h3
-  double precision           ::rhs ( rhs_l1: rhs_h1, rhs_l2: rhs_h2, rhs_l3: rhs_h3)
-  double precision,intent(in)::jg  (  jg_l1:  jg_h1,  jg_l2:  jg_h2,  jg_l3:  jg_h3,0:ngroups-1)
-  double precision,intent(in)::mugT(mugT_l1:mugT_h1,mugT_l2:mugT_h2,mugT_l3:mugT_h3,0:ngroups-1)
-  double precision,intent(in)::mugY(mugY_l1:mugY_h1,mugY_l2:mugY_h2,mugY_l3:mugY_h3,0:ngroups-1)
-  double precision,intent(in)::cpT ( cpT_l1: cpT_h1, cpT_l2: cpT_h2, cpT_l3: cpT_h3)
-  double precision,intent(in)::cpY ( cpY_l1: cpY_h1, cpY_l2: cpY_h2, cpY_l3: cpY_h3)
-  double precision,intent(in)::etaT(etaT_l1:etaT_h1,etaT_l2:etaT_h2,etaT_l3:etaT_h3)
-  double precision,intent(in)::etaY(etaY_l1:etaY_h1,etaY_l2:etaY_h2,etaY_l3:etaY_h3)
-  double precision,intent(in)::theT(theT_l1:theT_h1,theT_l2:theT_h2,theT_l3:theT_h3)
-  double precision,intent(in)::theY(theY_l1:theY_h1,theY_l2:theY_h2,theY_l3:theY_h3)
-  double precision,intent(in)::Er2 ( Er2_l1: Er2_h1, Er2_l2: Er2_h2, Er2_l3: Er2_h3,0:ngroups-1)
-  double precision,intent(in)::re2 ( re2_l1: re2_h1, re2_l2: re2_h2, re2_l3: re2_h3)
-  double precision,intent(in)::rY2 ( rY2_l1: rY2_h1, rY2_l2: rY2_h2, rY2_l3: rY2_h3)
-  double precision,intent(in)::Ers ( Ers_l1: Ers_h1, Ers_l2: Ers_h2, Ers_l3: Ers_h3,0:ngroups-1)
-  double precision,intent(in)::res ( res_l1: res_h1, res_l2: res_h2, res_l3: res_h3)
-  double precision,intent(in)::rYs ( rYs_l1: rYs_h1, rYs_l2: rYs_h2, rYs_l3: rYs_h3)
-  double precision,intent(in)::   r(lo(1):hi(1))
-  double precision,intent(in):: dt, tau             
+  real(rt)                   ::rhs ( rhs_l1: rhs_h1, rhs_l2: rhs_h2, rhs_l3: rhs_h3)
+  real(rt)        ,intent(in)::jg  (  jg_l1:  jg_h1,  jg_l2:  jg_h2,  jg_l3:  jg_h3,0:ngroups-1)
+  real(rt)        ,intent(in)::mugT(mugT_l1:mugT_h1,mugT_l2:mugT_h2,mugT_l3:mugT_h3,0:ngroups-1)
+  real(rt)        ,intent(in)::mugY(mugY_l1:mugY_h1,mugY_l2:mugY_h2,mugY_l3:mugY_h3,0:ngroups-1)
+  real(rt)        ,intent(in)::cpT ( cpT_l1: cpT_h1, cpT_l2: cpT_h2, cpT_l3: cpT_h3)
+  real(rt)        ,intent(in)::cpY ( cpY_l1: cpY_h1, cpY_l2: cpY_h2, cpY_l3: cpY_h3)
+  real(rt)        ,intent(in)::etaT(etaT_l1:etaT_h1,etaT_l2:etaT_h2,etaT_l3:etaT_h3)
+  real(rt)        ,intent(in)::etaY(etaY_l1:etaY_h1,etaY_l2:etaY_h2,etaY_l3:etaY_h3)
+  real(rt)        ,intent(in)::theT(theT_l1:theT_h1,theT_l2:theT_h2,theT_l3:theT_h3)
+  real(rt)        ,intent(in)::theY(theY_l1:theY_h1,theY_l2:theY_h2,theY_l3:theY_h3)
+  real(rt)        ,intent(in)::Er2 ( Er2_l1: Er2_h1, Er2_l2: Er2_h2, Er2_l3: Er2_h3,0:ngroups-1)
+  real(rt)        ,intent(in)::re2 ( re2_l1: re2_h1, re2_l2: re2_h2, re2_l3: re2_h3)
+  real(rt)        ,intent(in)::rY2 ( rY2_l1: rY2_h1, rY2_l2: rY2_h2, rY2_l3: rY2_h3)
+  real(rt)        ,intent(in)::Ers ( Ers_l1: Ers_h1, Ers_l2: Ers_h2, Ers_l3: Ers_h3,0:ngroups-1)
+  real(rt)        ,intent(in)::res ( res_l1: res_h1, res_l2: res_h2, res_l3: res_h3)
+  real(rt)        ,intent(in)::rYs ( rYs_l1: rYs_h1, rYs_l2: rYs_h2, rYs_l3: rYs_h3)
+  real(rt)        ,intent(in)::   r(lo(1):hi(1))
+  real(rt)        ,intent(in):: dt, tau             
   integer, intent(in) :: igroup
 
   integer :: i, j, k
-  double precision :: Hg, thetag, dt1
+  real(rt)         :: Hg, thetag, dt1
 
-  dt1 = 1.d0/dt
+  dt1 = 1.e0_rt/dt
   do k=lo(3), hi(3)
   do j=lo(2), hi(2)
   do i=lo(1), hi(1)
@@ -732,6 +741,7 @@ subroutine ca_local_accel_neut( lo, hi,  &
 
   use rad_params_module, only : ngroups, clight, erg2rhoYe
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer,intent(in):: lo(3), hi(3)
@@ -744,22 +754,22 @@ subroutine ca_local_accel_neut( lo, hi,  &
   integer,intent(in)::theY_l1,theY_h1,theY_l2,theY_h2,theY_l3,theY_h3
   integer,intent(in)::mugT_l1,mugT_h1,mugT_l2,mugT_h2,mugT_l3,mugT_h3
   integer,intent(in)::mugY_l1,mugY_h1,mugY_l2,mugY_h2,mugY_l3,mugY_h3
-  double precision           ::Ern ( Ern_l1: Ern_h1, Ern_l2: Ern_h2, Ern_l3: Ern_h3,0:ngroups-1)
-  double precision,intent(in)::Erl ( Erl_l1: Erl_h1, Erl_l2: Erl_h2, Erl_l3: Erl_h3,0:ngroups-1)
-  double precision,intent(in)::kap ( kap_l1: kap_h1, kap_l2: kap_h2, kap_l3: kap_h3,0:ngroups-1)
-  double precision,intent(in)::etaT(etaT_l1:etaT_h1,etaT_l2:etaT_h2,etaT_l3:etaT_h3)
-  double precision,intent(in)::etaY(etaY_l1:etaY_h1,etaY_l2:etaY_h2,etaY_l3:etaY_h3)
-  double precision,intent(in)::theT(theT_l1:theT_h1,theT_l2:theT_h2,theT_l3:theT_h3)
-  double precision,intent(in)::theY(theY_l1:theY_h1,theY_l2:theY_h2,theY_l3:theY_h3)
-  double precision,intent(in)::mugT(mugT_l1:mugT_h1,mugT_l2:mugT_h2,mugT_l3:mugT_h3,0:ngroups-1)
-  double precision,intent(in)::mugY(mugY_l1:mugY_h1,mugY_l2:mugY_h2,mugY_l3:mugY_h3,0:ngroups-1)
-  double precision,intent(in):: dt, tau
+  real(rt)                   ::Ern ( Ern_l1: Ern_h1, Ern_l2: Ern_h2, Ern_l3: Ern_h3,0:ngroups-1)
+  real(rt)        ,intent(in)::Erl ( Erl_l1: Erl_h1, Erl_l2: Erl_h2, Erl_l3: Erl_h3,0:ngroups-1)
+  real(rt)        ,intent(in)::kap ( kap_l1: kap_h1, kap_l2: kap_h2, kap_l3: kap_h3,0:ngroups-1)
+  real(rt)        ,intent(in)::etaT(etaT_l1:etaT_h1,etaT_l2:etaT_h2,etaT_l3:etaT_h3)
+  real(rt)        ,intent(in)::etaY(etaY_l1:etaY_h1,etaY_l2:etaY_h2,etaY_l3:etaY_h3)
+  real(rt)        ,intent(in)::theT(theT_l1:theT_h1,theT_l2:theT_h2,theT_l3:theT_h3)
+  real(rt)        ,intent(in)::theY(theY_l1:theY_h1,theY_l2:theY_h2,theY_l3:theY_h3)
+  real(rt)        ,intent(in)::mugT(mugT_l1:mugT_h1,mugT_l2:mugT_h2,mugT_l3:mugT_h3,0:ngroups-1)
+  real(rt)        ,intent(in)::mugY(mugY_l1:mugY_h1,mugY_l2:mugY_h2,mugY_l3:mugY_h3,0:ngroups-1)
+  real(rt)        ,intent(in):: dt, tau
 
   integer :: i, j, k
-  double precision :: cdt1, rt, ry, p, q, r, s 
-  double precision,dimension(0:ngroups-1)::Hg, Tg, epsilon, kapt, kk
+  real(rt)         :: cdt1, rt, ry, p, q, r, s 
+  real(rt)        ,dimension(0:ngroups-1)::Hg, Tg, epsilon, kapt, kk
 
-  cdt1 = 1.d0/(clight*dt)
+  cdt1 = 1.e0_rt/(clight*dt)
 
   do k = lo(3), hi(3)
   do j = lo(2), hi(2)
@@ -770,16 +780,16 @@ subroutine ca_local_accel_neut( lo, hi,  &
      Hg = mugT(i,j,k,:)*etaT(i,j,k) - mugY(i,j,k,:)*etaY(i,j,k)
      Tg = -mugT(i,j,k,:)*theT(i,j,k) + mugY(i,j,k,:)*theY(i,j,k)
 
-     kapt = kap(i,j,k,:) + (1.d0+tau)*cdt1
+     kapt = kap(i,j,k,:) + (1.e0_rt+tau)*cdt1
      kk = kap(i,j,k,:) / kapt
 
-     p = 1.d0-sum(Hg*kk)
-     q = 1.d0-sum(Tg*erg2rhoYe*kk)
+     p = 1.e0_rt-sum(Hg*kk)
+     q = 1.e0_rt-sum(Tg*erg2rhoYe*kk)
      r = sum(Hg*erg2rhoYe*kk)
      s = sum(Tg*kk)
 
      epsilon = ((r*Tg + q*Hg) * rt + (s*Hg + p*Tg) * ry)  &
-          / (kapt*(p*q-r*s) + 1.d-50)
+          / (kapt*(p*q-r*s) + 1.e-50_rt)
 
      Ern(i,j,k,:) = Ern(i,j,k,:) + epsilon
   end do
@@ -808,6 +818,7 @@ subroutine ca_opac_emis_neut( lo, hi,  &
   use opacity_table_module, only : prep_opacity, get_opacity_emissivity
   use meth_params_module, only : NVAR, URHO
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: lo(3), hi(3)
@@ -823,28 +834,28 @@ subroutine ca_opac_emis_neut( lo, hi,  &
   integer, intent(in) :: djdY_l1, djdY_h1, djdY_l2, djdY_h2, djdY_l3, djdY_h3
   integer, intent(in) :: dkdT_l1, dkdT_h1, dkdT_l2, dkdT_h2, dkdT_l3, dkdT_h3
   integer, intent(in) :: dkdY_l1, dkdY_h1, dkdY_l2, dkdY_h2, dkdY_l3, dkdY_h3
-  double precision,intent(in)::Snew(Snew_l1:Snew_h1,Snew_l2:Snew_h2,Snew_l3:Snew_h3,NVAR)
-  double precision,intent(in)::T   (   T_l1:   T_h1,   T_l2:   T_h2,   T_l3:   T_h3)
-  double precision,intent(in)::Ye  (  Ye_l1:  Ye_h1,  Ye_l2:  Ye_h2,  Ye_l3:  Ye_h3)
-  double precision,intent(in)::Ts  (  Ts_l1:  Ts_h1,  Ts_l2:  Ts_h2,  Ts_l3:  Ts_h3)
-  double precision,intent(in)::Yes ( Yes_l1: Yes_h1, Yes_l2: Yes_h2, Yes_l3: Yes_h3)
-  double precision           ::kpp ( kpp_l1: kpp_h1, kpp_l2: kpp_h2, kpp_l3: kpp_h3,0:ngroups-1)
-  double precision           ::kpr ( kpr_l1: kpr_h1, kpr_l2: kpr_h2, kpr_l3: kpr_h3,0:ngroups-1)
-  double precision           ::jg  (   j_l1:   j_h1,   j_l2:   j_h2,   j_l3:   j_h3,0:ngroups-1)
-  double precision           ::djdT(djdT_l1:djdT_h1,djdT_l2:djdT_h2,djdT_l3:djdT_h3,0:ngroups-1)
-  double precision           ::djdY(djdY_l1:djdY_h1,djdY_l2:djdY_h2,djdY_l3:djdY_h3,0:ngroups-1)
-  double precision           ::dkdT(dkdT_l1:dkdT_h1,dkdT_l2:dkdT_h2,dkdT_l3:dkdT_h3,0:ngroups-1)
-  double precision           ::dkdY(dkdY_l1:dkdY_h1,dkdY_l2:dkdY_h2,dkdY_l3:dkdY_h3,0:ngroups-1)
+  real(rt)        ,intent(in)::Snew(Snew_l1:Snew_h1,Snew_l2:Snew_h2,Snew_l3:Snew_h3,NVAR)
+  real(rt)        ,intent(in)::T   (   T_l1:   T_h1,   T_l2:   T_h2,   T_l3:   T_h3)
+  real(rt)        ,intent(in)::Ye  (  Ye_l1:  Ye_h1,  Ye_l2:  Ye_h2,  Ye_l3:  Ye_h3)
+  real(rt)        ,intent(in)::Ts  (  Ts_l1:  Ts_h1,  Ts_l2:  Ts_h2,  Ts_l3:  Ts_h3)
+  real(rt)        ,intent(in)::Yes ( Yes_l1: Yes_h1, Yes_l2: Yes_h2, Yes_l3: Yes_h3)
+  real(rt)                   ::kpp ( kpp_l1: kpp_h1, kpp_l2: kpp_h2, kpp_l3: kpp_h3,0:ngroups-1)
+  real(rt)                   ::kpr ( kpr_l1: kpr_h1, kpr_l2: kpr_h2, kpr_l3: kpr_h3,0:ngroups-1)
+  real(rt)                   ::jg  (   j_l1:   j_h1,   j_l2:   j_h2,   j_l3:   j_h3,0:ngroups-1)
+  real(rt)                   ::djdT(djdT_l1:djdT_h1,djdT_l2:djdT_h2,djdT_l3:djdT_h3,0:ngroups-1)
+  real(rt)                   ::djdY(djdY_l1:djdY_h1,djdY_l2:djdY_h2,djdY_l3:djdY_h3,0:ngroups-1)
+  real(rt)                   ::dkdT(dkdT_l1:dkdT_h1,dkdT_l2:dkdT_h2,dkdT_l3:dkdT_h3,0:ngroups-1)
+  real(rt)                   ::dkdY(dkdY_l1:dkdY_h1,dkdY_l2:dkdY_h2,dkdY_l3:dkdY_h3,0:ngroups-1)
   integer, intent(in) :: use_dkdT, validStar, lag_opac
 
   integer :: i, j, k, g, inu
-  double precision :: ab, sc, delta, eta, er, der, rho, temp
-  double precision :: ab1, sc1, delta1, eta1
-  double precision :: ab2, sc2, delta2, eta2 
-  double precision :: dT, dYe
-  double precision :: Bg, Bg1, Bg2
+  real(rt)         :: ab, sc, delta, eta, er, der, rho, temp
+  real(rt)         :: ab1, sc1, delta1, eta1
+  real(rt)         :: ab2, sc2, delta2, eta2 
+  real(rt)         :: dT, dYe
+  real(rt)         :: Bg, Bg1, Bg2
   logical :: comp_ab, comp_sc, comp_eta
-  double precision, parameter :: fac = 0.5d0, minfrac = 1.d-8
+  real(rt)        , parameter :: fac = 0.5e0_rt, minfrac = 1.e-8_rt
 
   do k=lo(3), hi(3)
   do j=lo(2), hi(2)
@@ -859,8 +870,8 @@ subroutine ca_opac_emis_neut( lo, hi,  &
         dYe = fac*abs(Yes(i,j,k) - Ye(i,j,k))
         dYe = max(dYe, minfrac*Ye(i,j,k))
      else
-        dT = T(i,j,k) * 1.d-3 + 1.d-50
-        dYe = 1.d-4
+        dT = T(i,j,k) * 1.e-3_rt + 1.e-50_rt
+        dYe = 1.e-4_rt
      end if
 
      do g=0, ngroups-1
@@ -869,8 +880,8 @@ subroutine ca_opac_emis_neut( lo, hi,  &
 
         if (lag_opac .eq. 1) then
 
-           dkdT(i,j,k,g) = 0.d0
-           dkdY(i,j,k,g) = 0.d0              
+           dkdT(i,j,k,g) = 0.e0_rt
+           dkdY(i,j,k,g) = 0.e0_rt              
 
            comp_ab = .true.
            comp_sc = .false.
@@ -889,7 +900,7 @@ subroutine ca_opac_emis_neut( lo, hi,  &
                 rho, Ye(i,j,k)+dye, temp, er, inu, comp_ab, comp_sc, comp_eta)
            Bg2 = eta2 * der / ab2
 
-           djdY(i,j,k,g) = (Bg2-Bg1)*kpp(i,j,k,g)/(2.d0*dye)
+           djdY(i,j,k,g) = (Bg2-Bg1)*kpp(i,j,k,g)/(2.e0_rt*dye)
 
            call get_opacity_emissivity(ab1, sc1, delta1, eta1, &
                 rho, Ye(i,j,k), temp-dT, er, inu, comp_ab, comp_sc, comp_eta)
@@ -899,7 +910,7 @@ subroutine ca_opac_emis_neut( lo, hi,  &
                 rho, Ye(i,j,k), temp+dT, er, inu, comp_ab, comp_sc, comp_eta)
            Bg2 = eta2 * der / ab2
 
-           djdT(i,j,k,g) = (Bg2-Bg1)*kpp(i,j,k,g)/(2.d0*dT)
+           djdT(i,j,k,g) = (Bg2-Bg1)*kpp(i,j,k,g)/(2.e0_rt*dT)
            
         else
 
@@ -910,7 +921,7 @@ subroutine ca_opac_emis_neut( lo, hi,  &
            call get_opacity_emissivity(ab, sc, delta, eta, &
                 rho, Ye(i,j,k), temp, er, inu, comp_ab, comp_sc, comp_eta)
            kpp(i,j,k,g) = ab
-           kpr(i,j,k,g) = ab + sc * (1.d0 - delta/3.d0)
+           kpr(i,j,k,g) = ab + sc * (1.e0_rt - delta/3.e0_rt)
            jg(i,j,k,g) = eta * der 
            
            comp_ab = .true.
@@ -921,22 +932,22 @@ subroutine ca_opac_emis_neut( lo, hi,  &
                 rho, Ye(i,j,k)-dye, temp, er, inu, comp_ab, comp_sc, comp_eta)
            call get_opacity_emissivity(ab2, sc2, delta2, eta2, &
                 rho, Ye(i,j,k)+dye, temp, er, inu, comp_ab, comp_sc, comp_eta)
-           djdY(i,j,k,g) = (eta2-eta1)*der/(2.d0*dye)
-           dkdY(i,j,k,g) = (ab2-ab1)/(2.d0*dye)
+           djdY(i,j,k,g) = (eta2-eta1)*der/(2.e0_rt*dye)
+           dkdY(i,j,k,g) = (ab2-ab1)/(2.e0_rt*dye)
            if (use_dkdT .eq. 0) then
-              djdY(i,j,k,g) = (eta2/ab2 - eta1/ab1)*der/(2.d0*dye) * ab
-              dkdY(i,j,k,g) = 0.d0
+              djdY(i,j,k,g) = (eta2/ab2 - eta1/ab1)*der/(2.e0_rt*dye) * ab
+              dkdY(i,j,k,g) = 0.e0_rt
            end if
            
            call get_opacity_emissivity(ab1, sc1, delta1, eta1, &
                 rho, Ye(i,j,k), temp-dT, er, inu, comp_ab, comp_sc, comp_eta)
            call get_opacity_emissivity(ab2, sc2, delta2, eta2, &
                 rho, Ye(i,j,k), temp+dT, er, inu, comp_ab, comp_sc, comp_eta)
-           djdT(i,j,k,g) = (eta2-eta1)*der/(2.d0*dT)
-           dkdT(i,j,k,g) = (ab2-ab1)/(2.d0*dT)
+           djdT(i,j,k,g) = (eta2-eta1)*der/(2.e0_rt*dT)
+           dkdT(i,j,k,g) = (ab2-ab1)/(2.e0_rt*dT)
            if (use_dkdT .eq. 0) then        
-              djdT(i,j,k,g) = (eta2/ab2 - eta1/ab1)*der/(2.d0*dT) * ab
-              dkdT(i,j,k,g) = 0.d0
+              djdT(i,j,k,g) = (eta2/ab2 - eta1/ab1)*der/(2.e0_rt*dT) * ab
+              dkdT(i,j,k,g) = 0.e0_rt
            end if
 
         end if
@@ -959,6 +970,7 @@ subroutine ca_state_update_neut( lo, hi, &
 
   use meth_params_module, only : NVAR, URHO, UEDEN, UEINT, UTEMP, UFX
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: lo(3), hi(3) 
@@ -967,27 +979,27 @@ subroutine ca_state_update_neut( lo, hi, &
   integer, intent(in) ::    Ye_l1,    Ye_h1,    Ye_l2,    Ye_h2,    Ye_l3,    Ye_h3
   integer, intent(in) ::  temp_l1,  temp_h1,  temp_l2,  temp_h2,  temp_l3,  temp_h3
   integer, intent(in) ::   msk_l1,   msk_h1,   msk_l2,   msk_h2,   msk_l3,   msk_h3
-  double precision,intent(in):: rhoe( rhoe_l1: rhoe_h1, rhoe_l2: rhoe_h2, rhoe_l3: rhoe_h3)
-  double precision,intent(in)::   Ye(   Ye_l1:   Ye_h1,   Ye_l2:   Ye_h2,   Ye_l3:   Ye_h3)
-  double precision,intent(in):: temp( temp_l1: temp_h1, temp_l2: temp_h2, temp_l3: temp_h3)
-  double precision,intent(in)::  msk(  msk_l1:  msk_h1,  msk_l2:  msk_h2,  msk_l3:  msk_h3)
-  double precision           ::state(state_l1:state_h1,state_l2:state_h2,state_l3:state_h3,NVAR)
-  double precision, intent(inout) :: derat, dTrat, dye
+  real(rt)        ,intent(in):: rhoe( rhoe_l1: rhoe_h1, rhoe_l2: rhoe_h2, rhoe_l3: rhoe_h3)
+  real(rt)        ,intent(in)::   Ye(   Ye_l1:   Ye_h1,   Ye_l2:   Ye_h2,   Ye_l3:   Ye_h3)
+  real(rt)        ,intent(in):: temp( temp_l1: temp_h1, temp_l2: temp_h2, temp_l3: temp_h3)
+  real(rt)        ,intent(in)::  msk(  msk_l1:  msk_h1,  msk_l2:  msk_h2,  msk_l3:  msk_h3)
+  real(rt)                   ::state(state_l1:state_h1,state_l2:state_h2,state_l3:state_h3,NVAR)
+  real(rt)        , intent(inout) :: derat, dTrat, dye
 
   integer :: i, j, k
-  double precision :: ei, ek, Told, Yeold
+  real(rt)         :: ei, ek, Told, Yeold
 
   do k=lo(3), hi(3)
   do j=lo(2), hi(2)
   do i=lo(1), hi(1)
      ei = state(i,j,k,UEINT)
-     derat = max(derat, abs((rhoe(i,j,k) - ei)*msk(i,j,k)/ max(ei, 1.d-50)))
+     derat = max(derat, abs((rhoe(i,j,k) - ei)*msk(i,j,k)/ max(ei, 1.e-50_rt)))
      ek = state(i,j,k,UEDEN) - state(i,j,k,UEINT)
      state(i,j,k,UEINT) = rhoe(i,j,k)
      state(i,j,k,UEDEN) = rhoe(i,j,k) + ek
 
      Told = state(i,j,k,UTEMP)
-     dTrat = max(dTrat, abs((temp(i,j,k)-Told)*msk(i,j,k)/ max(Told, 1.d-50)))
+     dTrat = max(dTrat, abs((temp(i,j,k)-Told)*msk(i,j,k)/ max(Told, 1.e-50_rt)))
      state(i,j,k,UTEMP) = temp(i,j,k)
 
      Yeold = state(i,j,k,UFX) / state(i,j,k,URHO)
@@ -1027,6 +1039,7 @@ subroutine ca_update_matter_neut( lo, hi,  &
   use rad_params_module, only : ngroups, erg2rhoYe, clight
   use meth_params_module, only : NVAR, URHO
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer,intent(in)::lo(3),hi(3)
@@ -1051,32 +1064,32 @@ subroutine ca_update_matter_neut( lo, hi,  &
   integer,intent(in)::mugT_l1, mugT_h1, mugT_l2, mugT_h2, mugT_l3, mugT_h3
   integer,intent(in)::mugY_l1, mugY_h1, mugY_l2, mugY_h2, mugY_l3, mugY_h3
   integer,intent(in)::Snew_l1, Snew_h1, Snew_l2, Snew_h2, Snew_l3, Snew_h3
-  double precision           ::re_n(re_n_l1:re_n_h1,re_n_l2:re_n_h2,re_n_l3:re_n_h3)
-  double precision           ::rY_n(rY_n_l1:rY_n_h1,rY_n_l2:rY_n_h2,rY_n_l3:rY_n_h3)
-  double precision           ::Ye_n(Ye_n_l1:Ye_n_h1,Ye_n_l2:Ye_n_h2,Ye_n_l3:Ye_n_h3)
-  double precision,intent(in)::Er_n(Er_n_l1:Er_n_h1,Er_n_l2:Er_n_h2,Er_n_l3:Er_n_h3,0:ngroups-1)
-  double precision,intent(in)::Er_l(Er_l_l1:Er_l_h1,Er_l_l2:Er_l_h2,Er_l_l3:Er_l_h3,0:ngroups-1)
-  double precision,intent(in)::re_s(re_s_l1:re_s_h1,re_s_l2:re_s_h2,re_s_l3:re_s_h3)
-  double precision,intent(in)::rY_s(rY_s_l1:rY_s_h1,rY_s_l2:rY_s_h2,rY_s_l3:rY_s_h3)
-  double precision,intent(in)::re_2(re_2_l1:re_2_h1,re_2_l2:re_2_h2,re_2_l3:re_2_h3)
-  double precision,intent(in)::rY_2(rY_2_l1:rY_2_h1,rY_2_l2:rY_2_h2,rY_2_l3:rY_2_h3)
-  double precision,intent(in)::etaT(etaT_l1:etaT_h1,etaT_l2:etaT_h2,etaT_l3:etaT_h3)
-  double precision,intent(in)::etaY(etaY_l1:etaY_h1,etaY_l2:etaY_h2,etaY_l3:etaY_h3)
-  double precision,intent(in)::eta1(eta1_l1:eta1_h1,eta1_l2:eta1_h2,eta1_l3:eta1_h3)
-  double precision,intent(in)::theT(theT_l1:theT_h1,theT_l2:theT_h2,theT_l3:theT_h3)
-  double precision,intent(in)::theY(theY_l1:theY_h1,theY_l2:theY_h2,theY_l3:theY_h3)
-  double precision,intent(in)::the1(the1_l1:the1_h1,the1_l2:the1_h2,the1_l3:the1_h3)
-  double precision,intent(in):: cpt( cpt_l1: cpt_h1, cpt_l2: cpt_h2, cpt_l3: cpt_h3)
-  double precision,intent(in):: cpy( cpy_l1: cpy_h1, cpy_l2: cpy_h2, cpy_l3: cpy_h3)
-  double precision,intent(in):: kpp( kpp_l1: kpp_h1, kpp_l2: kpp_h2, kpp_l3: kpp_h3,0:ngroups-1)
-  double precision,intent(in)::mugT(mugT_l1:mugT_h1,mugT_l2:mugT_h2,mugT_l3:mugT_h3,0:ngroups-1)
-  double precision,intent(in)::mugY(mugY_l1:mugY_h1,mugY_l2:mugY_h2,mugY_l3:mugY_h3,0:ngroups-1)
-  double precision,intent(in)::Snew(Snew_l1:Snew_h1,Snew_l2:Snew_h2,Snew_l3:Snew_h3,NVAR)
-  double precision,intent(in):: dt, tau
+  real(rt)                   ::re_n(re_n_l1:re_n_h1,re_n_l2:re_n_h2,re_n_l3:re_n_h3)
+  real(rt)                   ::rY_n(rY_n_l1:rY_n_h1,rY_n_l2:rY_n_h2,rY_n_l3:rY_n_h3)
+  real(rt)                   ::Ye_n(Ye_n_l1:Ye_n_h1,Ye_n_l2:Ye_n_h2,Ye_n_l3:Ye_n_h3)
+  real(rt)        ,intent(in)::Er_n(Er_n_l1:Er_n_h1,Er_n_l2:Er_n_h2,Er_n_l3:Er_n_h3,0:ngroups-1)
+  real(rt)        ,intent(in)::Er_l(Er_l_l1:Er_l_h1,Er_l_l2:Er_l_h2,Er_l_l3:Er_l_h3,0:ngroups-1)
+  real(rt)        ,intent(in)::re_s(re_s_l1:re_s_h1,re_s_l2:re_s_h2,re_s_l3:re_s_h3)
+  real(rt)        ,intent(in)::rY_s(rY_s_l1:rY_s_h1,rY_s_l2:rY_s_h2,rY_s_l3:rY_s_h3)
+  real(rt)        ,intent(in)::re_2(re_2_l1:re_2_h1,re_2_l2:re_2_h2,re_2_l3:re_2_h3)
+  real(rt)        ,intent(in)::rY_2(rY_2_l1:rY_2_h1,rY_2_l2:rY_2_h2,rY_2_l3:rY_2_h3)
+  real(rt)        ,intent(in)::etaT(etaT_l1:etaT_h1,etaT_l2:etaT_h2,etaT_l3:etaT_h3)
+  real(rt)        ,intent(in)::etaY(etaY_l1:etaY_h1,etaY_l2:etaY_h2,etaY_l3:etaY_h3)
+  real(rt)        ,intent(in)::eta1(eta1_l1:eta1_h1,eta1_l2:eta1_h2,eta1_l3:eta1_h3)
+  real(rt)        ,intent(in)::theT(theT_l1:theT_h1,theT_l2:theT_h2,theT_l3:theT_h3)
+  real(rt)        ,intent(in)::theY(theY_l1:theY_h1,theY_l2:theY_h2,theY_l3:theY_h3)
+  real(rt)        ,intent(in)::the1(the1_l1:the1_h1,the1_l2:the1_h2,the1_l3:the1_h3)
+  real(rt)        ,intent(in):: cpt( cpt_l1: cpt_h1, cpt_l2: cpt_h2, cpt_l3: cpt_h3)
+  real(rt)        ,intent(in):: cpy( cpy_l1: cpy_h1, cpy_l2: cpy_h2, cpy_l3: cpy_h3)
+  real(rt)        ,intent(in):: kpp( kpp_l1: kpp_h1, kpp_l2: kpp_h2, kpp_l3: kpp_h3,0:ngroups-1)
+  real(rt)        ,intent(in)::mugT(mugT_l1:mugT_h1,mugT_l2:mugT_h2,mugT_l3:mugT_h3,0:ngroups-1)
+  real(rt)        ,intent(in)::mugY(mugY_l1:mugY_h1,mugY_l2:mugY_h2,mugY_l3:mugY_h3,0:ngroups-1)
+  real(rt)        ,intent(in)::Snew(Snew_l1:Snew_h1,Snew_l2:Snew_h2,Snew_l3:Snew_h3,NVAR)
+  real(rt)        ,intent(in):: dt, tau
 
   integer :: i,j,k,g
-  double precision :: cdt, H1, Theta, Thbar1, Hbar 
-  double precision :: dkEE, dkEEY, foo, chg, chgY
+  real(rt)         :: cdt, H1, Theta, Thbar1, Hbar 
+  real(rt)         :: dkEE, dkEEY, foo, chg, chgY
 
   cdt = clight * dt
   do k = lo(3), hi(3)
@@ -1089,8 +1102,8 @@ subroutine ca_update_matter_neut( lo, hi,  &
      Theta = theY(i,j,k) - theT(i,j,k)
      Hbar = sum(erg2rhoYe*(mugT(i,j,k,:)*etaT(i,j,k) - mugY(i,j,k,:)*etaY(i,j,k)))
 
-     dkEE = 0.d0
-     dkEEY = 0.d0
+     dkEE = 0.e0_rt
+     dkEEY = 0.e0_rt
      do g=0, ngroups-1
         foo = kpp(i,j,k,g)*(Er_n(i,j,k,g)-Er_l(i,j,k,g))
         dkEE = dkEE + foo
@@ -1106,8 +1119,8 @@ subroutine ca_update_matter_neut( lo, hi,  &
      re_n(i,j,k) = re_s(i,j,k) + chg
      rY_n(i,j,k) = rY_s(i,j,k) + chgY
 
-     re_n(i,j,k) = (re_n(i,j,k) + tau*re_s(i,j,k)) / (1.d0+tau)
-     rY_n(i,j,k) = (rY_n(i,j,k) + tau*rY_s(i,j,k)) / (1.d0+tau)
+     re_n(i,j,k) = (re_n(i,j,k) + tau*re_s(i,j,k)) / (1.e0_rt+tau)
+     rY_n(i,j,k) = (rY_n(i,j,k) + tau*rY_s(i,j,k)) / (1.e0_rt+tau)
 
      Ye_n(i,j,k) = rY_n(i,j,k) / Snew(i,j,k,URHO)
 
@@ -1137,6 +1150,7 @@ subroutine ca_ncupdate_matter_neut( lo, hi,  &
 
   use rad_params_module, only : ngroups, erg2rhoYe, clight
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer,intent(in)::lo(3),hi(3)
@@ -1153,33 +1167,33 @@ subroutine ca_ncupdate_matter_neut( lo, hi,  &
   integer,intent(in)::thYz_l1, thYz_h1, thYz_l2, thYz_h2, thYz_l3, thYz_h3
   integer,intent(in):: kpp_l1,  kpp_h1,  kpp_l2,  kpp_h2,  kpp_l3,  kpp_h3
   integer,intent(in)::  jg_l1,   jg_h1,   jg_l2,   jg_h2,   jg_l3,   jg_h3
-  double precision           ::Tp_n(Tp_n_l1:Tp_n_h1,Tp_n_l2:Tp_n_h2,Tp_n_l3:Tp_n_h3)
-  double precision           ::Ye_n(Ye_n_l1:Ye_n_h1,Ye_n_l2:Ye_n_h2,Ye_n_l3:Ye_n_h3)
-  double precision,intent(in)::Er_n(Er_n_l1:Er_n_h1,Er_n_l2:Er_n_h2,Er_n_l3:Er_n_h3,0:ngroups-1)
-  double precision,intent(in)::re_s(re_s_l1:re_s_h1,re_s_l2:re_s_h2,re_s_l3:re_s_h3)
-  double precision,intent(in)::rY_s(rY_s_l1:rY_s_h1,rY_s_l2:rY_s_h2,rY_s_l3:rY_s_h3)
-  double precision,intent(in)::re_2(re_2_l1:re_2_h1,re_2_l2:re_2_h2,re_2_l3:re_2_h3)
-  double precision,intent(in)::rY_2(rY_2_l1:rY_2_h1,rY_2_l2:rY_2_h2,rY_2_l3:rY_2_h3)
-  double precision,intent(in)::etTz(etTz_l1:etTz_h1,etTz_l2:etTz_h2,etTz_l3:etTz_h3)
-  double precision,intent(in)::etYz(etYz_l1:etYz_h1,etYz_l2:etYz_h2,etYz_l3:etYz_h3)
-  double precision,intent(in)::thTz(thTz_l1:thTz_h1,thTz_l2:thTz_h2,thTz_l3:thTz_h3)
-  double precision,intent(in)::thYz(thYz_l1:thYz_h1,thYz_l2:thYz_h2,thYz_l3:thYz_h3)
-  double precision,intent(in):: kpp( kpp_l1: kpp_h1, kpp_l2: kpp_h2, kpp_l3: kpp_h3,0:ngroups-1)
-  double precision,intent(in)::  jg(  jg_l1:  jg_h1,  jg_l2:  jg_h2,  jg_l3:  jg_h3,0:ngroups-1)
-  double precision,intent(in) :: dt
+  real(rt)                   ::Tp_n(Tp_n_l1:Tp_n_h1,Tp_n_l2:Tp_n_h2,Tp_n_l3:Tp_n_h3)
+  real(rt)                   ::Ye_n(Ye_n_l1:Ye_n_h1,Ye_n_l2:Ye_n_h2,Ye_n_l3:Ye_n_h3)
+  real(rt)        ,intent(in)::Er_n(Er_n_l1:Er_n_h1,Er_n_l2:Er_n_h2,Er_n_l3:Er_n_h3,0:ngroups-1)
+  real(rt)        ,intent(in)::re_s(re_s_l1:re_s_h1,re_s_l2:re_s_h2,re_s_l3:re_s_h3)
+  real(rt)        ,intent(in)::rY_s(rY_s_l1:rY_s_h1,rY_s_l2:rY_s_h2,rY_s_l3:rY_s_h3)
+  real(rt)        ,intent(in)::re_2(re_2_l1:re_2_h1,re_2_l2:re_2_h2,re_2_l3:re_2_h3)
+  real(rt)        ,intent(in)::rY_2(rY_2_l1:rY_2_h1,rY_2_l2:rY_2_h2,rY_2_l3:rY_2_h3)
+  real(rt)        ,intent(in)::etTz(etTz_l1:etTz_h1,etTz_l2:etTz_h2,etTz_l3:etTz_h3)
+  real(rt)        ,intent(in)::etYz(etYz_l1:etYz_h1,etYz_l2:etYz_h2,etYz_l3:etYz_h3)
+  real(rt)        ,intent(in)::thTz(thTz_l1:thTz_h1,thTz_l2:thTz_h2,thTz_l3:thTz_h3)
+  real(rt)        ,intent(in)::thYz(thYz_l1:thYz_h1,thYz_l2:thYz_h2,thYz_l3:thYz_h3)
+  real(rt)        ,intent(in):: kpp( kpp_l1: kpp_h1, kpp_l2: kpp_h2, kpp_l3: kpp_h3,0:ngroups-1)
+  real(rt)        ,intent(in)::  jg(  jg_l1:  jg_h1,  jg_l2:  jg_h2,  jg_l3:  jg_h3,0:ngroups-1)
+  real(rt)        ,intent(in) :: dt
 
    integer :: i,j,k,g
-   double precision :: cdt1, cpT, cpY, foo, scrch_re, scrch_rY
-   double precision :: dTemp, dYe
-   double precision, parameter :: fac = 0.01d0
+   real(rt)         :: cdt1, cpT, cpY, foo, scrch_re, scrch_rY
+   real(rt)         :: dTemp, dYe
+   real(rt)        , parameter :: fac = 0.01e0_rt
 
-   cdt1 = 1.d0 / (clight * dt)
+   cdt1 = 1.e0_rt / (clight * dt)
    do k = lo(3), hi(3)
    do j = lo(2), hi(2)
    do i = lo(1), hi(1)
 
-      cpT = 0.d0
-      cpY = 0.d0
+      cpT = 0.e0_rt
+      cpY = 0.e0_rt
       do g = 0, ngroups-1
          foo = kpp(i,j,k,g)*Er_n(i,j,k,g) - jg(i,j,k,g)
          cpT = cpT + foo
@@ -1192,11 +1206,11 @@ subroutine ca_ncupdate_matter_neut( lo, hi,  &
       dTemp = etTz(i,j,k)*scrch_re - thTz(i,j,k)*scrch_rY
       dYe   = -etYz(i,j,k)*scrch_re + thYz(i,j,k)*scrch_rY
 
-      if (abs(dTemp/(Tp_n(i,j,k)+1.d-50)) > fac) then
+      if (abs(dTemp/(Tp_n(i,j,k)+1.e-50_rt)) > fac) then
          dTemp = sign(fac*Tp_n(i,j,k), dTemp)
       end if
 
-      if (abs(dYe/(Ye_n(i,j,k)+1.d-50)) > fac) then
+      if (abs(dYe/(Ye_n(i,j,k)+1.e-50_rt)) > fac) then
          dYe = sign(fac*Ye_n(i,j,k), dYe)
       end if
 
@@ -1218,16 +1232,17 @@ subroutine ca_compute_rosseland_neut( lo, hi, &
   use opacity_table_module, only : prep_opacity, get_opacity_emissivity
   use meth_params_module, only : NVAR, URHO, UTEMP, UFX
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: lo(3), hi(3)
   integer, intent(in) ::  kpr_l1,  kpr_h1,  kpr_l2,  kpr_h2,  kpr_l3,  kpr_h3
   integer, intent(in) :: stat_l1, stat_h1, stat_l2, stat_h2, stat_l3, stat_h3 
-  double precision           ::kpr ( kpr_l1: kpr_h1, kpr_l2: kpr_h2, kpr_l3: kpr_h3,0:ngroups-1)
-  double precision,intent(in)::stat(stat_l1:stat_h1,stat_l2:stat_h2,stat_l3:stat_h3,NVAR)
+  real(rt)                   ::kpr ( kpr_l1: kpr_h1, kpr_l2: kpr_h2, kpr_l3: kpr_h3,0:ngroups-1)
+  real(rt)        ,intent(in)::stat(stat_l1:stat_h1,stat_l2:stat_h2,stat_l3:stat_h3,NVAR)
 
   integer :: i, j, k, g, inu
-  double precision :: ab, sc, delta, eta, er, der, rho, temp, Ye
+  real(rt)         :: ab, sc, delta, eta, er, der, rho, temp, Ye
   logical :: comp_ab, comp_sc, comp_eta
 
   comp_ab = .true.
@@ -1249,7 +1264,7 @@ subroutine ca_compute_rosseland_neut( lo, hi, &
         call get_opacity_emissivity(ab, sc, delta, eta, &
              rho, Ye, temp, er, inu, comp_ab, comp_sc, comp_eta)
 
-        kpr(i,j,k,g) = ab + sc * (1.d0 - delta/3.d0)
+        kpr(i,j,k,g) = ab + sc * (1.e0_rt - delta/3.e0_rt)
 
      end do
      end do
@@ -1267,16 +1282,17 @@ subroutine ca_compute_planck_neut( lo, hi,  &
   use opacity_table_module, only : prep_opacity, get_opacity_emissivity
   use meth_params_module, only : NVAR, URHO, UTEMP, UFX
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: lo(3), hi(3)
   integer, intent(in) ::  kpp_l1,  kpp_h1,  kpp_l2,  kpp_h2,  kpp_l3,  kpp_h3
   integer, intent(in) :: stat_l1, stat_h1, stat_l2, stat_h2, stat_l3, stat_h3 
-  double precision           :: kpp( kpp_l1: kpp_h1, kpp_l2: kpp_h2, kpp_l3: kpp_h3,0:ngroups-1)
-  double precision,intent(in)::stat(stat_l1:stat_h1,stat_l2:stat_h2,stat_l3:stat_h3,NVAR)
+  real(rt)                   :: kpp( kpp_l1: kpp_h1, kpp_l2: kpp_h2, kpp_l3: kpp_h3,0:ngroups-1)
+  real(rt)        ,intent(in)::stat(stat_l1:stat_h1,stat_l2:stat_h2,stat_l3:stat_h3,NVAR)
 
   integer :: i, j, k, g, inu
-  double precision :: ab, sc, delta, eta, er, der, rho, temp, Ye
+  real(rt)         :: ab, sc, delta, eta, er, der, rho, temp, Ye
   logical :: comp_ab, comp_sc, comp_eta
   
   comp_ab = .true.

--- a/Source/Radiation/RadSrc_3d/RAD_3D.F90
+++ b/Source/Radiation/RadSrc_3d/RAD_3D.F90
@@ -9,10 +9,11 @@ module rad_module
 
   use rad_util_module, only : FLDlambda
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
-  double precision, parameter :: tiny = 1.e-50_dp_t
-  double precision, parameter :: BIGKR = 1.e25_dp_t
+  real(rt)        , parameter :: tiny = 1.e-50_rt
+  real(rt)        , parameter :: BIGKR = 1.e25_rt
 
 contains
 
@@ -24,11 +25,12 @@ subroutine multrs(d, &
                   DIMS(reg), &
                   r, s) bind(C, name="multrs")
   
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(dbox)
   integer :: DIMDEC(reg)
-  real*8 :: d(DIMV(dbox))
-  real*8 :: r(reg_l1:reg_h1)
-  real*8 :: s(reg_l2:reg_h2)
+  real(rt)         :: d(DIMV(dbox))
+  real(rt)         :: r(reg_l1:reg_h1)
+  real(rt)         :: s(reg_l2:reg_h2)
   integer :: i, j, k
   do k = reg_l3, reg_h3
      do j = reg_l2, reg_h2
@@ -42,16 +44,17 @@ end subroutine multrs
 subroutine sphc(r, s, &
                 DIMS(reg), dx) bind(C, name="sphc")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(reg)
-  real*8 :: r(reg_l1:reg_h1)
-  real*8 :: s(reg_l2:reg_h2)
-  real*8 :: dx(2)
-  real*8 :: h1, h2, d1, d2
+  real(rt)         :: r(reg_l1:reg_h1)
+  real(rt)         :: s(reg_l2:reg_h2)
+  real(rt)         :: dx(2)
+  real(rt)         :: h1, h2, d1, d2
   integer :: i, j
-  h1 = 0.5d0 * dx(1)
-  h2 = 0.5d0 * dx(2)
-  d1 = 1.d0 / (3.d0 * dx(1))
-  d2 = 1.d0 / dx(2)
+  h1 = 0.5e0_rt * dx(1)
+  h2 = 0.5e0_rt * dx(2)
+  d1 = 1.e0_rt / (3.e0_rt * dx(1))
+  d2 = 1.e0_rt / dx(2)
   do i = reg_l1, reg_h1
      r(i) = d1 * ((r(i) + h1)**3 - (r(i) - h1)**3)
   enddo
@@ -63,25 +66,26 @@ end subroutine sphc
 subroutine sphe(r, s, n, &
                 DIMS(reg), dx) bind(C, name="sphe")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(reg)
-  real*8 :: r(reg_l1:reg_h1)
-  real*8 :: s(reg_l2:reg_h2)
+  real(rt)         :: r(reg_l1:reg_h1)
+  real(rt)         :: s(reg_l2:reg_h2)
   integer :: n
-  real*8 :: dx(2)
-  real*8 :: h1, h2, d1, d2
+  real(rt)         :: dx(2)
+  real(rt)         :: h1, h2, d1, d2
   integer :: i, j
   if (n == 0) then
      do i = reg_l1, reg_h1
         r(i) = r(i)**2
      enddo
-     h2 = 0.5d0 * dx(2)
-     d2 = 1.d0 / dx(2)
+     h2 = 0.5e0_rt * dx(2)
+     d2 = 1.e0_rt / dx(2)
      do j = reg_l2, reg_h2
         s(j) = d2 * (cos(s(j) - h2) - cos(s(j) + h2))
      enddo
   else
-     h1 = 0.5d0 * dx(1)
-     d1 = 1.d0 / (3.d0 * dx(1))
+     h1 = 0.5e0_rt * dx(1)
+     d1 = 1.e0_rt / (3.e0_rt * dx(1))
      do i = reg_l1, reg_h1
         r(i) = d1 * ((r(i) + h1)**3 - (r(i) - h1)**3)
      enddo
@@ -96,24 +100,25 @@ subroutine lacoef(a, &
                   DIMS(reg), &
                   fkp, eta, etainv, r, s, c, dt, theta) bind(C, name="lacoef")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(abox)
   integer :: DIMDEC(reg)
-  real*8 :: a(DIMV(abox))
-  real*8 :: fkp(DIMV(abox))
-  real*8 :: eta(DIMV(abox))
-  real*8 :: etainv(DIMV(abox))
-  real*8 :: r(reg_l1:reg_h1)
-  real*8 :: s(reg_l2:reg_h2)
-  real*8 :: c, dt, theta
+  real(rt)         :: a(DIMV(abox))
+  real(rt)         :: fkp(DIMV(abox))
+  real(rt)         :: eta(DIMV(abox))
+  real(rt)         :: etainv(DIMV(abox))
+  real(rt)         :: r(reg_l1:reg_h1)
+  real(rt)         :: s(reg_l2:reg_h2)
+  real(rt)         :: c, dt, theta
   integer :: i, j, k
-  real*8 :: dtm
-  dtm = 1.d0 / dt
+  real(rt)         :: dtm
+  dtm = 1.e0_rt / dt
   do k = reg_l3, reg_h3
      do j = reg_l2, reg_h2
         do i = reg_l1, reg_h1
            a(i,j,k) = r(i) * s(j) * &
                 (fkp(i,j,k) * etainv(i,j,k) * c + dtm) / &
-                (1.d0 - (1.d0 - theta) * eta(i,j,k))
+                (1.e0_rt - (1.e0_rt - theta) * eta(i,j,k))
         enddo
      enddo
   enddo
@@ -126,19 +131,20 @@ subroutine bclim(b, &
                  n, kappar, DIMS(kbox), &
                  r, s, c, dx) bind(C, name="bclim")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(bbox)
   integer :: DIMDEC(reg)
   integer :: DIMDEC(kbox)
   integer :: n
-  real*8 :: b(DIMV(bbox))
-  real*8 :: lambda(DIMV(bbox))
-  real*8 :: kappar(DIMV(kbox))
-  real*8 :: r(reg_l1:reg_h1+1)
-  real*8 :: s(reg_l2:reg_h2+1)
-  real*8 :: c, dx(3)
-  real*8 :: kavg
+  real(rt)         :: b(DIMV(bbox))
+  real(rt)         :: lambda(DIMV(bbox))
+  real(rt)         :: kappar(DIMV(kbox))
+  real(rt)         :: r(reg_l1:reg_h1+1)
+  real(rt)         :: s(reg_l2:reg_h2+1)
+  real(rt)         :: c, dx(3)
+  real(rt)         :: kavg
   integer :: i, j, k
-  real*8 :: kap
+  real(rt)         :: kap
   if (n == 0) then
      do k = reg_l3, reg_h3
         do j = reg_l2, reg_h2
@@ -173,10 +179,11 @@ subroutine flxlim(lambda, &
                   DIMS(rbox), & 
                   DIMS(reg), limiter) bind(C, name="flxlim")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(rbox)
   integer :: DIMDEC(reg)
   integer :: limiter
-  real*8 :: lambda(DIMV(rbox))
+  real(rt)         :: lambda(DIMV(rbox))
   integer :: i, j, k
   do k = reg_l3, reg_h3
      do j = reg_l2, reg_h2
@@ -191,12 +198,13 @@ subroutine eddfac(efact, &
                   DIMS(rbox), &
                   DIMS(reg), limiter, n) bind(C, name="eddfac")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(rbox)
   integer :: DIMDEC(reg)
   integer :: n, limiter
-  real*8 :: efact(DIMV(rbox))
+  real(rt)         :: efact(DIMV(rbox))
   integer :: i, j, k
-  real*8 :: r, lambda
+  real(rt)         :: r, lambda
   integer :: dir(0:2)
   dir(0) = 0
   dir(1) = 0
@@ -219,17 +227,18 @@ subroutine scgrd1(r, &
                   n, kappar, DIMS(kbox), &
                   er, dx) bind(C, name="scgrd1")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(rbox)
   integer :: DIMDEC(reg)
   integer :: DIMDEC(kbox)
   integer :: n
-  real*8 :: r(DIMV(rbox))
-  real*8 :: kappar(DIMV(kbox))
-  real*8 :: er(DIMV(kbox))
-  real*8 :: dx(3)
-  real*8 :: kavg
+  real(rt)         :: r(DIMV(rbox))
+  real(rt)         :: kappar(DIMV(kbox))
+  real(rt)         :: er(DIMV(kbox))
+  real(rt)         :: dx(3)
+  real(rt)         :: kavg
   integer :: i, j, k
-  real*8 :: kap
+  real(rt)         :: kap
   if (n == 0) then
      do k = reg_l3, reg_h3
         do j = reg_l2, reg_h2
@@ -238,11 +247,11 @@ subroutine scgrd1(r, &
               r(i,j,k) = abs(er(i,j,k) - er(i-1,j,k)) / dx(1)
            enddo
            i = reg_l1
-           if (er(i-1,j,k) == -1.d0) then
+           if (er(i-1,j,k) == -1.e0_rt) then
               r(i,j,k) = abs(er(i+1,j,k) - er(i,j,k)) / dx(1)
            endif
            i = reg_h1 + 1
-           if (er(i,j,k) == -1.d0) then
+           if (er(i,j,k) == -1.e0_rt) then
               r(i,j,k) = abs(er(i-1,j,k) - er(i-2,j,k)) / dx(1)
            endif
            !     construct coefficients:
@@ -263,11 +272,11 @@ subroutine scgrd1(r, &
         enddo
         do i = reg_l1, reg_h1
            j = reg_l2
-           if (er(i,j-1,k) == -1.d0) then
+           if (er(i,j-1,k) == -1.e0_rt) then
               r(i,j,k) = abs(er(i,j+1,k) - er(i,j,k)) / dx(2)
            endif
            j = reg_h2 + 1
-           if (er(i,j,k) == -1.d0) then
+           if (er(i,j,k) == -1.e0_rt) then
               r(i,j,k) = abs(er(i,j-1,k) - er(i,j-2,k)) / dx(2)
            endif
         enddo
@@ -292,11 +301,11 @@ subroutine scgrd1(r, &
      do j = reg_l2, reg_h2
         do i = reg_l1, reg_h1
            k = reg_l3
-           if (er(i,j,k-1) == -1.d0) then
+           if (er(i,j,k-1) == -1.e0_rt) then
               r(i,j,k) = abs(er(i,j,k+1) - er(i,j,k)) / dx(3)
            endif
            k = reg_h3 + 1
-           if (er(i,j,k) == -1.d0) then
+           if (er(i,j,k) == -1.e0_rt) then
               r(i,j,k) = abs(er(i,j,k-2) - er(i,j,k-1)) / dx(3)
            endif
         enddo
@@ -320,20 +329,21 @@ subroutine scgrd2(r, &
                   n, kappar, DIMS(kbox), er, &
                   DIMS(dbox), da, db, dx) bind(C, name="scgrd2")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(rbox)
   integer :: DIMDEC(reg)
   integer :: DIMDEC(kbox)
   integer :: DIMDEC(dbox)
   integer :: n
-  real*8 :: r(DIMV(rbox))
-  real*8 :: kappar(DIMV(kbox))
-  real*8 :: er(DIMV(kbox))
-  real*8 :: da(DIMV(dbox))
-  real*8 :: db(DIMV(dbox))
-  real*8 :: dx(3)
-  real*8 :: kavg
+  real(rt)         :: r(DIMV(rbox))
+  real(rt)         :: kappar(DIMV(kbox))
+  real(rt)         :: er(DIMV(kbox))
+  real(rt)         :: da(DIMV(dbox))
+  real(rt)         :: db(DIMV(dbox))
+  real(rt)         :: dx(3)
+  real(rt)         :: kavg
   integer :: i, j, k
-  real*8 :: kap
+  real(rt)         :: kap
   if (n == 0) then
      !     y & z derivatives:
      do k = reg_l3, reg_h3
@@ -349,27 +359,27 @@ subroutine scgrd2(r, &
      do k = reg_l3, reg_h3
         do i = reg_l1 - 1, reg_h1 + 1
            j = reg_l2
-           if (er(i,j-1,k) == -1.d0) then
-              da(i,j,k) = 2.d0 * (er(i,j+1,k) - er(i,j,k))
+           if (er(i,j-1,k) == -1.e0_rt) then
+              da(i,j,k) = 2.e0_rt * (er(i,j+1,k) - er(i,j,k))
            endif
            j = reg_h2
-           if (er(i,j+1,k) == -1.d0) then
-              da(i,j,k) = 2.d0 * (er(i,j,k) - er(i,j-1,k))
+           if (er(i,j+1,k) == -1.e0_rt) then
+              da(i,j,k) = 2.e0_rt * (er(i,j,k) - er(i,j-1,k))
            endif
         enddo
         do j = reg_l2, reg_h2
            i = reg_l1 - 1
            !     (check at j-1 and j+1.  if value at j is bad it will not be used at all.)
-           if (er(i,j-1,k) == -1.d0) then
-              da(i,j,k) = 2.d0 * (er(i,j+1,k) - er(i,j,k))
-           else if (er(i,j+1,k) == -1.d0) then
-              da(i,j,k) = 2.d0 * (er(i,j,k) - er(i,j-1,k))
+           if (er(i,j-1,k) == -1.e0_rt) then
+              da(i,j,k) = 2.e0_rt * (er(i,j+1,k) - er(i,j,k))
+           else if (er(i,j+1,k) == -1.e0_rt) then
+              da(i,j,k) = 2.e0_rt * (er(i,j,k) - er(i,j-1,k))
            endif
            i = reg_h1 + 1
-           if (er(i,j-1,k) == -1.d0) then
-              da(i,j,k) = 2.d0 * (er(i,j+1,k) - er(i,j,k))
-           else if (er(i,j+1,k) == -1.d0) then
-              da(i,j,k) = 2.d0 * (er(i,j,k) - er(i,j-1,k))
+           if (er(i,j-1,k) == -1.e0_rt) then
+              da(i,j,k) = 2.e0_rt * (er(i,j+1,k) - er(i,j,k))
+           else if (er(i,j+1,k) == -1.e0_rt) then
+              da(i,j,k) = 2.e0_rt * (er(i,j,k) - er(i,j-1,k))
            endif
         enddo
      enddo
@@ -378,12 +388,12 @@ subroutine scgrd2(r, &
      do j = reg_l2, reg_h2
         do i = reg_l1-1, reg_h1 + 1
            k = reg_l3
-           if (er(i,j,k-1) == -1.d0) then
-              db(i,j,k) = 2.d0 * (er(i,j,k+1) - er(i,j,k))
+           if (er(i,j,k-1) == -1.e0_rt) then
+              db(i,j,k) = 2.e0_rt * (er(i,j,k+1) - er(i,j,k))
            endif
            k = reg_h3
-           if (er(i,j,k+1) == -1.d0) then
-              db(i,j,k) = 2.d0 * (er(i,j,k) - er(i,j,k-1))
+           if (er(i,j,k+1) == -1.e0_rt) then
+              db(i,j,k) = 2.e0_rt * (er(i,j,k) - er(i,j,k-1))
            endif
         enddo
      enddo
@@ -391,16 +401,16 @@ subroutine scgrd2(r, &
         do j = reg_l2, reg_h2
            i = reg_l1 - 1
            !     (check at k-1 and k+1.  if value at k is bad it will not be used at all.)
-           if (er(i,j,k-1) == -1.d0) then
-              db(i,j,k) = 2.d0 * (er(i,j,k+1) - er(i,j,k))
-           else if (er(i,j,k+1) == -1.d0) then
-              db(i,j,k) = 2.d0 * (er(i,j,k) - er(i,j,k-1))
+           if (er(i,j,k-1) == -1.e0_rt) then
+              db(i,j,k) = 2.e0_rt * (er(i,j,k+1) - er(i,j,k))
+           else if (er(i,j,k+1) == -1.e0_rt) then
+              db(i,j,k) = 2.e0_rt * (er(i,j,k) - er(i,j,k-1))
            endif
            i = reg_h1 + 1
-           if (er(i,j,k-1) == -1.d0) then
-              db(i,j,k) = 2.d0 * (er(i,j,k+1) - er(i,j,k))
-           else if (er(i,j,k+1) == -1.d0) then
-              db(i,j,k) = 2.d0 * (er(i,j,k) - er(i,j,k-1))
+           if (er(i,j,k-1) == -1.e0_rt) then
+              db(i,j,k) = 2.e0_rt * (er(i,j,k+1) - er(i,j,k))
+           else if (er(i,j,k+1) == -1.e0_rt) then
+              db(i,j,k) = 2.e0_rt * (er(i,j,k) - er(i,j,k-1))
            endif
         enddo
      enddo
@@ -410,21 +420,21 @@ subroutine scgrd2(r, &
            do i = reg_l1, reg_h1 + 1
               r(i,j,k) = ((er(i,j,k) - er(i-1,j,k)) / dx(1)) ** 2 &
                    + ((da(i-1,j,k) + da(i,j,k)) / &
-                   (4.d0 * dx(2))) ** 2 &
+                   (4.e0_rt * dx(2))) ** 2 &
                    + ((db(i-1,j,k) + db(i,j,k)) / &
-                   (4.d0 * dx(3))) ** 2
+                   (4.e0_rt * dx(3))) ** 2
            enddo
            i = reg_l1
-           if (er(i-1,j,k) == -1.d0) then
+           if (er(i-1,j,k) == -1.e0_rt) then
               r(i,j,k) = ((er(i+1,j,k) - er(i,j,k)) / dx(1)) ** 2 &
-                   + (da(i,j,k) / (2.d0 * dx(2))) ** 2 &
-                   + (db(i,j,k) / (2.d0 * dx(3))) ** 2
+                   + (da(i,j,k) / (2.e0_rt * dx(2))) ** 2 &
+                   + (db(i,j,k) / (2.e0_rt * dx(3))) ** 2
            endif
            i = reg_h1 + 1
-           if (er(i,j,k) == -1.d0) then
+           if (er(i,j,k) == -1.e0_rt) then
               r(i,j,k) = ((er(i-1,j,k) - er(i-2,j,k)) / dx(1)) ** 2 &
-                   + (da(i-1,j,k) / (2.d0 * dx(2))) ** 2 &
-                   + (db(i-1,j,k) / (2.d0 * dx(3))) ** 2
+                   + (da(i-1,j,k) / (2.e0_rt * dx(2))) ** 2 &
+                   + (db(i-1,j,k) / (2.e0_rt * dx(3))) ** 2
            endif
            !     construct scaled gradient
            do i = reg_l1, reg_h1 + 1
@@ -449,27 +459,27 @@ subroutine scgrd2(r, &
      do k = reg_l3, reg_h3
         do j = reg_l2-1, reg_h2+1
            i = reg_l1
-           if (er(i-1,j,k) == -1.d0) then
-              da(i,j,k) = 2.d0 * (er(i+1,j,k) - er(i,j,k))
+           if (er(i-1,j,k) == -1.e0_rt) then
+              da(i,j,k) = 2.e0_rt * (er(i+1,j,k) - er(i,j,k))
            endif
            i = reg_h1
-           if (er(i+1,j,k) == -1.d0) then
-              da(i,j,k) = 2.d0 * (er(i,j,k) - er(i-1,j,k))
+           if (er(i+1,j,k) == -1.e0_rt) then
+              da(i,j,k) = 2.e0_rt * (er(i,j,k) - er(i-1,j,k))
            endif
         enddo
         do i = reg_l1, reg_h1
            j = reg_l2-1
            !     (check at i-1 and i+1.  if value at i is bad it will not be used at all.)
-           if (er(i-1,j,k) == -1.d0) then
-              da(i,j,k) = 2.d0 * (er(i+1,j,k) - er(i,j,k))
-           else if (er(i+1,j,k) == -1.d0) then
-              da(i,j,k) = 2.d0 * (er(i,j,k) - er(i-1,j,k))
+           if (er(i-1,j,k) == -1.e0_rt) then
+              da(i,j,k) = 2.e0_rt * (er(i+1,j,k) - er(i,j,k))
+           else if (er(i+1,j,k) == -1.e0_rt) then
+              da(i,j,k) = 2.e0_rt * (er(i,j,k) - er(i-1,j,k))
            endif
            j = reg_h2+1
-           if (er(i-1,j,k) == -1.d0) then
-              da(i,j,k) = 2.d0 * (er(i+1,j,k) - er(i,j,k))
-           else if (er(i+1,j,k) == -1.d0) then
-              da(i,j,k) = 2.d0 * (er(i,j,k) - er(i-1,j,k))
+           if (er(i-1,j,k) == -1.e0_rt) then
+              da(i,j,k) = 2.e0_rt * (er(i+1,j,k) - er(i,j,k))
+           else if (er(i+1,j,k) == -1.e0_rt) then
+              da(i,j,k) = 2.e0_rt * (er(i,j,k) - er(i-1,j,k))
            endif
         enddo
      enddo
@@ -478,12 +488,12 @@ subroutine scgrd2(r, &
      do j = reg_l2-1, reg_h2+1
         do i = reg_l1, reg_h1
            k = reg_l3
-           if (er(i,j,k-1) == -1.d0) then
-              db(i,j,k) = 2.d0 * (er(i,j,k+1) - er(i,j,k))
+           if (er(i,j,k-1) == -1.e0_rt) then
+              db(i,j,k) = 2.e0_rt * (er(i,j,k+1) - er(i,j,k))
            endif
            k = reg_h3
-           if (er(i,j,k+1) == -1.d0) then
-              db(i,j,k) = 2.d0 * (er(i,j,k) - er(i,j,k-1))
+           if (er(i,j,k+1) == -1.e0_rt) then
+              db(i,j,k) = 2.e0_rt * (er(i,j,k) - er(i,j,k-1))
            endif
         enddo
      enddo
@@ -491,16 +501,16 @@ subroutine scgrd2(r, &
         do i = reg_l1, reg_h1
            j = reg_l2-1
            !     (check at k-1 and k+1.  if value at k is bad it will not be used at all.)
-           if (er(i,j,k-1) == -1.d0) then
-              db(i,j,k) = 2.d0 * (er(i,j,k+1) - er(i,j,k))
-           else if (er(i,j,k+1) == -1.d0) then
-              db(i,j,k) = 2.d0 * (er(i,j,k) - er(i,j,k-1))
+           if (er(i,j,k-1) == -1.e0_rt) then
+              db(i,j,k) = 2.e0_rt * (er(i,j,k+1) - er(i,j,k))
+           else if (er(i,j,k+1) == -1.e0_rt) then
+              db(i,j,k) = 2.e0_rt * (er(i,j,k) - er(i,j,k-1))
            endif
            j = reg_h2+1
-           if (er(i,j,k-1) == -1.d0) then
-              db(i,j,k) = 2.d0 * (er(i,j,k+1) - er(i,j,k))
-           else if (er(i,j,k+1) == -1.d0) then
-              db(i,j,k) = 2.d0 * (er(i,j,k) - er(i,j,k-1))
+           if (er(i,j,k-1) == -1.e0_rt) then
+              db(i,j,k) = 2.e0_rt * (er(i,j,k+1) - er(i,j,k))
+           else if (er(i,j,k+1) == -1.e0_rt) then
+              db(i,j,k) = 2.e0_rt * (er(i,j,k) - er(i,j,k-1))
            endif
         enddo
      enddo
@@ -511,23 +521,23 @@ subroutine scgrd2(r, &
            do i = reg_l1, reg_h1
               r(i,j,k) = ((er(i,j,k) - er(i,j-1,k)) / dx(2)) ** 2 &
                    + ((da(i,j-1,k) + da(i,j,k)) / &
-                   (4.d0 * dx(1))) ** 2 &
+                   (4.e0_rt * dx(1))) ** 2 &
                    + ((db(i,j-1,k) + db(i,j,k)) / &
-                   (4.d0 * dx(3))) ** 2
+                   (4.e0_rt * dx(3))) ** 2
            enddo
         enddo
         do i = reg_l1, reg_h1
            j = reg_l2
-           if (er(i,j-1,k) == -1.d0) then
+           if (er(i,j-1,k) == -1.e0_rt) then
               r(i,j,k) = ((er(i,j+1,k) - er(i,j,k)) / dx(2)) ** 2 &
-                   + (da(i,j,k) / (2.d0 * dx(1))) ** 2 &
-                   + (db(i,j,k) / (2.d0 * dx(3))) ** 2
+                   + (da(i,j,k) / (2.e0_rt * dx(1))) ** 2 &
+                   + (db(i,j,k) / (2.e0_rt * dx(3))) ** 2
            endif
            j = reg_h2 + 1
-           if (er(i,j,k) == -1.d0) then
+           if (er(i,j,k) == -1.e0_rt) then
               r(i,j,k) = ((er(i,j-1,k) - er(i,j-2,k)) / dx(2)) ** 2 &
-                   + (da(i,j-1,k) / (2.d0 * dx(1))) ** 2 &
-                   + (db(i,j-1,k) / (2.d0 * dx(3))) ** 2
+                   + (da(i,j-1,k) / (2.e0_rt * dx(1))) ** 2 &
+                   + (db(i,j-1,k) / (2.e0_rt * dx(3))) ** 2
            endif
         enddo
         !     construct scaled gradient
@@ -554,12 +564,12 @@ subroutine scgrd2(r, &
      do k = reg_l3-1, reg_h3+1
         do j = reg_l2, reg_h2
            i = reg_l1
-           if (er(i-1,j,k) == -1.d0) then
-              da(i,j,k) = 2.d0 * (er(i+1,j,k) - er(i,j,k))
+           if (er(i-1,j,k) == -1.e0_rt) then
+              da(i,j,k) = 2.e0_rt * (er(i+1,j,k) - er(i,j,k))
            endif
            i = reg_h1
-           if (er(i+1,j,k) == -1.d0) then
-              da(i,j,k) = 2.0d0 * (er(i,j,k) - er(i-1,j,k))
+           if (er(i+1,j,k) == -1.e0_rt) then
+              da(i,j,k) = 2.0e0_rt * (er(i,j,k) - er(i-1,j,k))
            endif
         enddo
      enddo
@@ -567,16 +577,16 @@ subroutine scgrd2(r, &
         do i = reg_l1, reg_h1
            k = reg_l3 - 1
            !     (check at i-1 and i+1.  if value at i is bad it will not be used at all.)
-           if (er(i-1,j,k) == -1.d0) then
-              da(i,j,k) = 2.d0 * (er(i+1,j,k) - er(i,j,k))
-           else if (er(i+1,j,k) == -1.d0) then
-              da(i,j,k) = 2.0d0 * (er(i,j,k) - er(i-1,j,k))
+           if (er(i-1,j,k) == -1.e0_rt) then
+              da(i,j,k) = 2.e0_rt * (er(i+1,j,k) - er(i,j,k))
+           else if (er(i+1,j,k) == -1.e0_rt) then
+              da(i,j,k) = 2.0e0_rt * (er(i,j,k) - er(i-1,j,k))
            endif
            k = reg_h3 + 1
-           if (er(i-1,j,k) == -1.d0) then
-              da(i,j,k) = 2.d0 * (er(i+1,j,k) - er(i,j,k))
-           else if (er(i+1,j,k) == -1.d0) then
-              da(i,j,k) = 2.0d0 * (er(i,j,k) - er(i-1,j,k))
+           if (er(i-1,j,k) == -1.e0_rt) then
+              da(i,j,k) = 2.e0_rt * (er(i+1,j,k) - er(i,j,k))
+           else if (er(i+1,j,k) == -1.e0_rt) then
+              da(i,j,k) = 2.0e0_rt * (er(i,j,k) - er(i-1,j,k))
            endif
         enddo
      enddo
@@ -585,12 +595,12 @@ subroutine scgrd2(r, &
      do k = reg_l3-1, reg_h3+1
         do i = reg_l1, reg_h1
            j = reg_l2
-           if (er(i,j-1,k) == -1.d0) then
-              db(i,j,k) = 2.d0 * (er(i,j+1,k) - er(i,j,k))
+           if (er(i,j-1,k) == -1.e0_rt) then
+              db(i,j,k) = 2.e0_rt * (er(i,j+1,k) - er(i,j,k))
            endif
            j = reg_h2
-           if (er(i,j+1,k) == -1.d0) then
-              db(i,j,k) = 2.d0 * (er(i,j,k) - er(i,j-1,k))
+           if (er(i,j+1,k) == -1.e0_rt) then
+              db(i,j,k) = 2.e0_rt * (er(i,j,k) - er(i,j-1,k))
            endif
         enddo
      enddo
@@ -598,16 +608,16 @@ subroutine scgrd2(r, &
         do i = reg_l1, reg_h1
            k = reg_l3 - 1
            !     (check at j-1 and j+1.  if value at j is bad it will not be used at all.)
-           if (er(i,j-1,k) == -1.d0) then
-              db(i,j,k) = 2.d0 * (er(i,j+1,k) - er(i,j,k))
-           else if (er(i,j+1,k) == -1.d0) then
-              db(i,j,k) = 2.d0 * (er(i,j,k) - er(i,j-1,k))
+           if (er(i,j-1,k) == -1.e0_rt) then
+              db(i,j,k) = 2.e0_rt * (er(i,j+1,k) - er(i,j,k))
+           else if (er(i,j+1,k) == -1.e0_rt) then
+              db(i,j,k) = 2.e0_rt * (er(i,j,k) - er(i,j-1,k))
            endif
            k = reg_h3 + 1
-           if (er(i,j-1,k) == -1.d0) then
-              db(i,j,k) = 2.d0 * (er(i,j+1,k) - er(i,j,k))
-           else if (er(i,j+1,k) == -1.d0) then
-              db(i,j,k) = 2.d0 * (er(i,j,k) - er(i,j-1,k))
+           if (er(i,j-1,k) == -1.e0_rt) then
+              db(i,j,k) = 2.e0_rt * (er(i,j+1,k) - er(i,j,k))
+           else if (er(i,j+1,k) == -1.e0_rt) then
+              db(i,j,k) = 2.e0_rt * (er(i,j,k) - er(i,j-1,k))
            endif
         enddo
      enddo
@@ -618,9 +628,9 @@ subroutine scgrd2(r, &
            do i = reg_l1, reg_h1
               r(i,j,k) = ((er(i,j,k) - er(i,j,k-1)) / dx(3)) ** 2 &
                    + ((da(i,j,k) + da(i,j,k-1)) / &
-                   (4.d0 * dx(1))) ** 2 &
+                   (4.e0_rt * dx(1))) ** 2 &
                    + ((db(i,j,k) + db(i,j,k-1)) / &
-                   (4.d0 * dx(2))) ** 2
+                   (4.e0_rt * dx(2))) ** 2
            enddo
         enddo
      enddo
@@ -628,16 +638,16 @@ subroutine scgrd2(r, &
      do j = reg_l2, reg_h2
         do i = reg_l1, reg_h1
            k = reg_l3
-           if (er(i,j,k-1) == -1.d0) then
+           if (er(i,j,k-1) == -1.e0_rt) then
               r(i,j,k) = ((er(i,j,k+1) - er(i,j,k)) / dx(3)) ** 2 &
-                   + (da(i,j,k) / (2.d0 * dx(1))) ** 2 &
-                   + (db(i,j,k) / (2.d0 * dx(2))) ** 2
+                   + (da(i,j,k) / (2.e0_rt * dx(1))) ** 2 &
+                   + (db(i,j,k) / (2.e0_rt * dx(2))) ** 2
            endif
            k = reg_h3+1
-           if (er(i,j,k) == -1.d0) then
+           if (er(i,j,k) == -1.e0_rt) then
               r(i,j,k) = ((er(i,j,k-1) - er(i,j,k-2)) / dx(3)) ** 2 &
-                   + (da(i,j,k-1) / (2.d0 * dx(1))) ** 2 &
-                   + (db(i,j,k-1) / (2.d0 * dx(2))) ** 2
+                   + (da(i,j,k-1) / (2.e0_rt * dx(1))) ** 2 &
+                   + (db(i,j,k-1) / (2.e0_rt * dx(2))) ** 2
            endif
         enddo
      enddo
@@ -661,20 +671,21 @@ subroutine scgrd3(r, &
                   n, kappar, DIMS(kbox), er, &
                   DIMS(dbox), da, db, dx) bind(C, name="scgrd3")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(rbox)
   integer :: DIMDEC(reg)
   integer :: DIMDEC(kbox)
   integer :: DIMDEC(dbox)
   integer :: n
-  real*8 :: r(DIMV(rbox))
-  real*8 :: kappar(DIMV(kbox))
-  real*8 :: er(DIMV(kbox))
-  real*8 :: da(DIMV(dbox))
-  real*8 :: db(DIMV(dbox))
-  real*8 :: dx(3)
-  real*8 :: kavg
+  real(rt)         :: r(DIMV(rbox))
+  real(rt)         :: kappar(DIMV(kbox))
+  real(rt)         :: er(DIMV(kbox))
+  real(rt)         :: da(DIMV(dbox))
+  real(rt)         :: db(DIMV(dbox))
+  real(rt)         :: dx(3)
+  real(rt)         :: kavg
   integer :: i
-  real*8 :: kap
+  real(rt)         :: kap
   print *, "scgrd3 not implemented in 3d"
   stop
 end subroutine scgrd3
@@ -686,38 +697,39 @@ subroutine lrhs(rhs, &
                 ero, DIMS(ebox), edot, &
                 r, s, dt, sigma, c, theta) bind(C, name="lrhs")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(rbox)
   integer :: DIMDEC(ebox)
   integer :: DIMDEC(reg)
-  real*8 :: rhs(DIMV(rbox))
-  real*8 :: temp(DIMV(rbox))
-  real*8 :: fkp(DIMV(rbox))
-  real*8 :: eta(DIMV(rbox))
-  real*8 :: etainv(DIMV(rbox))
-  real*8 :: frhoem(DIMV(rbox))
-  real*8 :: frhoes(DIMV(rbox))
-  real*8 :: dfo(DIMV(rbox))
-  real*8 :: ero(DIMV(ebox))
-  real*8 :: edot(DIMV(rbox))
-  real*8 :: r(reg_l1:reg_h1)
-  real*8 :: s(reg_l2:reg_h2)
-  real*8 :: dt, sigma, c, theta
+  real(rt)         :: rhs(DIMV(rbox))
+  real(rt)         :: temp(DIMV(rbox))
+  real(rt)         :: fkp(DIMV(rbox))
+  real(rt)         :: eta(DIMV(rbox))
+  real(rt)         :: etainv(DIMV(rbox))
+  real(rt)         :: frhoem(DIMV(rbox))
+  real(rt)         :: frhoes(DIMV(rbox))
+  real(rt)         :: dfo(DIMV(rbox))
+  real(rt)         :: ero(DIMV(ebox))
+  real(rt)         :: edot(DIMV(rbox))
+  real(rt)         :: r(reg_l1:reg_h1)
+  real(rt)         :: s(reg_l2:reg_h2)
+  real(rt)         :: dt, sigma, c, theta
   integer :: i, j, k
-  real*8 :: dtm, ek, bs, es, ekt
-  dtm = 1.d0 / dt
+  real(rt)         :: dtm, ek, bs, es, ekt
+  dtm = 1.e0_rt / dt
   do k = reg_l3, reg_h3
      do j = reg_l2, reg_h2
         do i = reg_l1, reg_h1
            ek = fkp(i,j,k) * eta(i,j,k)
            bs = etainv(i,j,k) * &
-                &               4.d0 * sigma * fkp(i,j,k) * temp(i,j,k)**4
+                &               4.e0_rt * sigma * fkp(i,j,k) * temp(i,j,k)**4
            es = eta(i,j,k) * (frhoem(i,j,k) - frhoes(i,j,k))
-           ekt = (1.d0 - theta) * eta(i,j,k)
+           ekt = (1.e0_rt - theta) * eta(i,j,k)
            rhs(i,j,k) = (rhs(i,j,k) + r(i) * s(j) * &
                 (bs + dtm * (ero(i,j,k) + es) + &
                 ek * c * edot(i,j,k) - &
                 ekt * dfo(i,j,k))) / &
-                (1.d0 - ekt)
+                (1.e0_rt - ekt)
         enddo
      enddo
   enddo
@@ -727,21 +739,22 @@ subroutine anatw2(test, &
                   DIMS(reg), &
                   temp, p, xf, Tc, dx, xlo, lo) bind(C, name="anatw2")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(reg)
-  real*8 :: test(DIMV(reg), 0:1)
-  real*8 :: temp(DIMV(reg))
-  real*8 :: p, xf, Tc, dx(3), xlo(3)
+  real(rt)         :: test(DIMV(reg), 0:1)
+  real(rt)         :: temp(DIMV(reg))
+  real(rt)         :: p, xf, Tc, dx(3), xlo(3)
   integer :: lo(3)
   integer :: i, j, k
-  real*8 :: x, y, z, r2
+  real(rt)         :: x, y, z, r2
   do k = reg_l3, reg_h3
-     z = xlo(3) + dx(3) * ((k-lo(3)) + 0.5d0)
+     z = xlo(3) + dx(3) * ((k-lo(3)) + 0.5e0_rt)
      do j = reg_l2, reg_h2
-        y = xlo(2) + dx(2) * ((j-lo(2)) + 0.5d0)
+        y = xlo(2) + dx(2) * ((j-lo(2)) + 0.5e0_rt)
         do i = reg_l1, reg_h1
-           x  = xlo(1) + dx(1) * ((i-lo(1)) + 0.5d0)
+           x  = xlo(1) + dx(1) * ((i-lo(1)) + 0.5e0_rt)
            r2 = x*x + y*y + z*z
-           test(i,j,k,0) = Tc * max((1.d0-r2/xf**2), 0.d0)**(1.d0/p)
+           test(i,j,k,0) = Tc * max((1.e0_rt-r2/xf**2), 0.e0_rt)**(1.e0_rt/p)
            test(i,j,k,1) = temp(i,j,k) - test(i,j,k,0)
         enddo
      enddo
@@ -754,17 +767,18 @@ subroutine cfrhoe(DIMS(reg), &
                   state, &
                   DIMS(sb)) bind(C, name="cfrhoe")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(reg)
   integer :: DIMDEC(fb)
   integer :: DIMDEC(sb)
-  real*8 :: frhoe(DIMV(fb))
-  real*8 :: state(DIMV(sb), NVAR)
-  !      real*8 kin
+  real(rt)         :: frhoe(DIMV(fb))
+  real(rt)         :: state(DIMV(sb), NVAR)
+  !      real(rt)         kin
   integer :: i, j, k
   do k = reg_l3, reg_h3
      do j = reg_l2, reg_h2
         do i = reg_l1, reg_h1
-           !               kin = 0.5d0 * (state(i,j,k,XMOM)   ** 2 +
+           !               kin = 0.5e0_rt * (state(i,j,k,XMOM)   ** 2 +
            !     @                        state(i,j,k,XMOM+1) ** 2 +
            !     @                        state(i,j,k,XMOM+2) ** 2) /
            !     @                       state(i,j,k,DEN)
@@ -782,33 +796,34 @@ subroutine gtemp(DIMS(reg), &
                  const, em, en, &
                  state, DIMS(sb)) bind(C, name="gtemp")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(reg)
   integer :: DIMDEC(tb)
   integer :: DIMDEC(sb)
-  real*8 :: temp(DIMV(tb))
-  real*8 :: const(0:1), em(0:1), en(0:1)
-  real*8 :: state(DIMV(sb), NVAR)
-  real*8 :: alpha, teff, ex, frhoal
+  real(rt)         :: temp(DIMV(tb))
+  real(rt)         :: const(0:1), em(0:1), en(0:1)
+  real(rt)         :: state(DIMV(sb), NVAR)
+  real(rt)         :: alpha, teff, ex, frhoal
   integer :: i, j, k
-  if (en(0) >= 1.d0) then
+  if (en(0) >= 1.e0_rt) then
      print *, "Bad exponent for cv calculation"
      stop
   endif
-  ex = 1.d0 / (1.d0 - en(0))
+  ex = 1.e0_rt / (1.e0_rt - en(0))
   do k = reg_l3, reg_h3
      do j = reg_l2, reg_h2
         do i = reg_l1, reg_h1
-           if (em(0) == 0.d0) then
+           if (em(0) == 0.e0_rt) then
               alpha = const(0)
            else
               alpha = const(0) * state(i,j,k, URHO) ** em(0)
            endif
            frhoal = state(i,j,k, URHO) * alpha + tiny
-           if (en(0) == 0.d0) then
+           if (en(0) == 0.e0_rt) then
               temp(i,j,k) = temp(i,j,k) / frhoal
            else
               teff = max(temp(i,j,k), tiny)
-              temp(i,j,k) = ((1.d0 - en(0)) * teff / frhoal) ** ex
+              temp(i,j,k) = ((1.e0_rt - en(0)) * teff / frhoal) ** ex
            endif
         enddo
      enddo
@@ -823,26 +838,27 @@ subroutine gcv(DIMS(reg), &
                const, em, en, tf, &
                state, DIMS(sbox)) bind(C, name="gcv")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(reg)
   integer :: DIMDEC(cbox)
   integer :: DIMDEC(tbox)
   integer :: DIMDEC(sbox)
-  real*8 :: cv(DIMV(cbox))
-  real*8 :: temp(DIMV(tbox))
-  real*8 :: const(0:1), em(0:1), en(0:1), tf(0:1)
-  real*8 :: state(DIMV(sbox), NVAR)
-  real*8 :: alpha, teff, frhoal
+  real(rt)         :: cv(DIMV(cbox))
+  real(rt)         :: temp(DIMV(tbox))
+  real(rt)         :: const(0:1), em(0:1), en(0:1), tf(0:1)
+  real(rt)         :: state(DIMV(sbox), NVAR)
+  real(rt)         :: alpha, teff, frhoal
   integer :: i, j, k
   do k = reg_l3, reg_h3
      do j = reg_l2, reg_h2
         do i = reg_l1, reg_h1
-           if (em(0) == 0.d0) then
+           if (em(0) == 0.e0_rt) then
               alpha = const(0)
            else
               alpha = const(0) * state(i,j,k, URHO) ** em(0)
            endif
            frhoal = state(i,j,k, URHO) * alpha + tiny
-           if (en(0) == 0.d0) then
+           if (en(0) == 0.e0_rt) then
               cv(i,j,k) = alpha
            else
               teff = max(temp(i,j,k), tiny)
@@ -862,20 +878,21 @@ subroutine cexch(DIMS(reg), &
                  fkp , DIMS(kbox), &
                  sigma, c) bind(C, name="cexch")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(reg)
   integer :: DIMDEC(xbox)
   integer :: DIMDEC(ebox)
   integer :: DIMDEC(kbox)
-  real*8 :: exch(DIMV(xbox))
-  real*8 :: er  (DIMV(ebox))
-  real*8 :: fkp (DIMV(kbox))
-  real*8 :: sigma, c
+  real(rt)         :: exch(DIMV(xbox))
+  real(rt)         :: er  (DIMV(ebox))
+  real(rt)         :: fkp (DIMV(kbox))
+  real(rt)         :: sigma, c
   integer :: i, j, k
   do k = reg_l3, reg_h3
      do j = reg_l2, reg_h2
         do i = reg_l1, reg_h1
            exch(i,j,k) = fkp(i,j,k) * &
-                (4.d0 * sigma * exch(i,j,k)**4 &
+                (4.e0_rt * sigma * exch(i,j,k)**4 &
                 - c * er(i,j,k))
         enddo
      enddo
@@ -891,6 +908,7 @@ subroutine ceta2(DIMS(reg), &
                  er, DIMS(ebox), &
                  dtemp, dtime, sigma, c, underr, lagpla) bind(C, name="ceta2")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(reg)
   integer :: DIMDEC(etab)
   integer :: DIMDEC(sb)
@@ -898,20 +916,20 @@ subroutine ceta2(DIMS(reg), &
   integer :: DIMDEC(cb)
   integer :: DIMDEC(fb)
   integer :: DIMDEC(ebox)
-  real*8 :: eta(DIMV(etab))
-  real*8 :: etainv(DIMV(etab))
-  real*8 :: frho(DIMV(sb))
-  real*8 :: temp(DIMV(tb))
-  real*8 :: cv(DIMV(cb))
-  real*8 :: fkp(DIMV(fb))
-  real*8 :: er(DIMV(ebox))
-  real*8 :: dtemp, dtime, sigma, c, underr
+  real(rt)         :: eta(DIMV(etab))
+  real(rt)         :: etainv(DIMV(etab))
+  real(rt)         :: frho(DIMV(sb))
+  real(rt)         :: temp(DIMV(tb))
+  real(rt)         :: cv(DIMV(cb))
+  real(rt)         :: fkp(DIMV(fb))
+  real(rt)         :: er(DIMV(ebox))
+  real(rt)         :: dtemp, dtime, sigma, c, underr
   integer :: lagpla
-  real*8 :: d, frc, fac0, fac1, fac2
+  real(rt)         :: d, frc, fac0, fac1, fac2
   integer :: i, j, k
-  fac1 = 16.d0 * sigma * dtime
+  fac1 = 16.e0_rt * sigma * dtime
   if (lagpla == 0) then
-     fac0 = 0.25d0 * fac1 / dtemp
+     fac0 = 0.25e0_rt * fac1 / dtemp
      fac2 = dtime * c / dtemp
   endif
   do k = reg_l3, reg_h3
@@ -937,8 +955,8 @@ subroutine ceta2(DIMS(reg), &
            frc = frho(i,j,k) * cv(i,j,k) + tiny
            eta(i,j,k) = d / (d + frc)
            etainv(i,j,k) = underr * frc / (d + frc)
-           eta(i,j,k) = 1.d0 - etainv(i,j,k)
-           !               eta(i,j,k) = 1.d0 - underr * (1.d0 - eta(i,j,k))
+           eta(i,j,k) = 1.e0_rt - etainv(i,j,k)
+           !               eta(i,j,k) = 1.e0_rt - underr * (1.e0_rt - eta(i,j,k))
         enddo
      enddo
   enddo
@@ -949,27 +967,28 @@ subroutine ceup(DIMS(reg), relres, absres, &
                 frhoem, eta, etainv, dfo, dfn, exch, &
                 dt, theta) bind(C, name="ceup")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(reg)
   integer :: DIMDEC(grd)
-  real*8 :: frhoes(DIMV(grd))
-  real*8 :: frhoem(DIMV(grd))
-  real*8 :: eta(DIMV(grd))
-  real*8 :: etainv(DIMV(grd))
-  real*8 :: dfo(DIMV(grd))
-  real*8 :: dfn(DIMV(grd))
-  real*8 :: exch(DIMV(grd))
-  real*8 :: dt, theta, relres, absres
-  real*8 :: tmp, chg, tot
+  real(rt)         :: frhoes(DIMV(grd))
+  real(rt)         :: frhoem(DIMV(grd))
+  real(rt)         :: eta(DIMV(grd))
+  real(rt)         :: etainv(DIMV(grd))
+  real(rt)         :: dfo(DIMV(grd))
+  real(rt)         :: dfn(DIMV(grd))
+  real(rt)         :: exch(DIMV(grd))
+  real(rt)         :: dt, theta, relres, absres
+  real(rt)         :: tmp, chg, tot
   integer :: i, j, k
   do k = reg_l3, reg_h3
      do j = reg_l2, reg_h2
         do i = reg_l1, reg_h1
-           chg = 0.d0
-           tot = 0.d0
+           chg = 0.e0_rt
+           tot = 0.e0_rt
            tmp = eta(i,j,k) * frhoes(i,j,k) + &
                 etainv(i,j,k) * &
                 (frhoem(i,j,k) - &
-                dt * ((1.d0 - theta) * &
+                dt * ((1.e0_rt - theta) * &
                 (dfo(i,j,k) - dfn(i,j,k)) + &
                 exch(i,j,k)))
            chg = abs(tmp - frhoes(i,j,k))
@@ -987,28 +1006,29 @@ subroutine ceupdterm(DIMS(reg), relres, absres, &
                      frhoem, eta, etainv, dfo, dfn, exch, dterm, &
                      dt, theta) bind(C, name="ceupdterm")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(reg)
   integer :: DIMDEC(grd)
-  real*8 :: frhoes(DIMV(grd))
-  real*8 :: frhoem(DIMV(grd))
-  real*8 :: eta(DIMV(grd))
-  real*8 :: etainv(DIMV(grd))
-  real*8 :: dfo(DIMV(grd))
-  real*8 :: dfn(DIMV(grd))
-  real*8 :: exch(DIMV(grd))
-  real*8 :: dterm(DIMV(grd))
-  real*8 :: dt, theta, relres, absres
-  real*8 :: tmp, chg, tot
+  real(rt)         :: frhoes(DIMV(grd))
+  real(rt)         :: frhoem(DIMV(grd))
+  real(rt)         :: eta(DIMV(grd))
+  real(rt)         :: etainv(DIMV(grd))
+  real(rt)         :: dfo(DIMV(grd))
+  real(rt)         :: dfn(DIMV(grd))
+  real(rt)         :: exch(DIMV(grd))
+  real(rt)         :: dterm(DIMV(grd))
+  real(rt)         :: dt, theta, relres, absres
+  real(rt)         :: tmp, chg, tot
   integer :: i, j, k
   do k = reg_l3, reg_h3
      do j = reg_l2, reg_h2
         do i = reg_l1, reg_h1
-           chg = 0.d0
-           tot = 0.d0
+           chg = 0.e0_rt
+           tot = 0.e0_rt
            tmp = eta(i,j,k) * frhoes(i,j,k) + &
                 etainv(i,j,k) * &
                 (frhoem(i,j,k) - &
-                dt * ((1.d0 - theta) * &
+                dt * ((1.e0_rt - theta) * &
                 (dfo(i,j,k) - dfn(i,j,k)) + &
                 exch(i,j,k))) &
                 + dt * dterm(i,j,k)
@@ -1031,45 +1051,46 @@ subroutine nceup(DIMS(reg), relres, absres, &
                  state, DIMS(sb), &
                  sigma, c, dt, theta) bind(C, name="nceup")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(reg)
   integer :: DIMDEC(grd)
   integer :: DIMDEC(sb)
   integer :: DIMDEC(ebox)
-  real*8 :: frhoes(DIMV(grd))
-  real*8 :: frhoem(DIMV(grd))
-  real*8 :: eta(DIMV(grd))
-  real*8 :: etainv(DIMV(grd))
-  real*8 :: er(DIMV(ebox))
-  real*8 :: dfo(DIMV(grd))
-  real*8 :: dfn(DIMV(grd))
-  real*8 :: temp(DIMV(grd))
-  real*8 :: fkp(DIMV(grd))
-  real*8 :: cv(DIMV(reg))
-  real*8 :: state(DIMV(sb), NVAR)
-  real*8 :: sigma, c, dt, theta, relres, absres
-  real*8 :: tmp, chg, tot, exch, b, db, dbdt, frhocv
+  real(rt)         :: frhoes(DIMV(grd))
+  real(rt)         :: frhoem(DIMV(grd))
+  real(rt)         :: eta(DIMV(grd))
+  real(rt)         :: etainv(DIMV(grd))
+  real(rt)         :: er(DIMV(ebox))
+  real(rt)         :: dfo(DIMV(grd))
+  real(rt)         :: dfn(DIMV(grd))
+  real(rt)         :: temp(DIMV(grd))
+  real(rt)         :: fkp(DIMV(grd))
+  real(rt)         :: cv(DIMV(reg))
+  real(rt)         :: state(DIMV(sb), NVAR)
+  real(rt)         :: sigma, c, dt, theta, relres, absres
+  real(rt)         :: tmp, chg, tot, exch, b, db, dbdt, frhocv
   integer :: i, j, k
   do k = reg_l3, reg_h3
      do j = reg_l2, reg_h2
         do i = reg_l1, reg_h1
-           chg = 0.d0
-           tot = 0.d0
+           chg = 0.e0_rt
+           tot = 0.e0_rt
            frhocv = state(i,j,k, URHO) * cv(i,j,k)
-           dbdt = 16.d0 * sigma * temp(i,j,k)**3
-           b = 4.d0 * sigma * temp(i,j,k)**4
+           dbdt = 16.e0_rt * sigma * temp(i,j,k)**3
+           b = 4.e0_rt * sigma * temp(i,j,k)**4
            exch = fkp(i,j,k) * (b - c * er(i,j,k))
            tmp = eta(i,j,k) * frhoes(i,j,k) + etainv(i,j,k) * &
                 (frhoem(i,j,k) - &
-                dt * ((1.d0 - theta) * &
+                dt * ((1.e0_rt - theta) * &
                 (dfo(i,j,k) - dfn(i,j,k)) + &
                 exch))
 #if 1
            if (frhocv > tiny .AND. tmp > frhoes(i,j,k)) then
               db = (tmp - frhoes(i,j,k)) * dbdt / frhocv
-              if (b + db <= 0.d0) then
+              if (b + db <= 0.e0_rt) then
                  print *, i, j, k, b, db, b+db
               endif
-              tmp = ((b + db) / (4.d0 * sigma))**0.25d0
+              tmp = ((b + db) / (4.e0_rt * sigma))**0.25e0_rt
               tmp = frhoes(i,j,k) + frhocv * (tmp - temp(i,j,k))
            endif
 #endif
@@ -1087,17 +1108,18 @@ subroutine cetot(DIMS(reg), &
                  state, DIMS(sb), &
                  frhoe, DIMS(fb)) bind(C, name="cetot")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(reg)
   integer :: DIMDEC(sb)
   integer :: DIMDEC(fb)
-  real*8 :: state(DIMV(sb), NVAR)
-  real*8 :: frhoe(DIMV(fb))
-  real*8 :: kin
+  real(rt)         :: state(DIMV(sb), NVAR)
+  real(rt)         :: frhoe(DIMV(fb))
+  real(rt)         :: kin
   integer :: i, j, k
   do k = reg_l3, reg_h3
      do j = reg_l2, reg_h2
         do i = reg_l1, reg_h1
-           !               kin = 0.5d0 * (state(i,j,k,XMOM)   ** 2 +
+           !               kin = 0.5e0_rt * (state(i,j,k,XMOM)   ** 2 +
            !     @                        state(i,j,k,XMOM+1) ** 2 +
            !     @                        state(i,j,k,XMOM+2) ** 2) /
            !     @                       state(i,j,k,DEN)
@@ -1116,16 +1138,17 @@ subroutine fkpn(DIMS(reg), &
                 temp, DIMS(tb), &
                 state, DIMS(sb)) bind(C, name="fkpn")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(reg)
   integer :: DIMDEC(fb)
   integer :: DIMDEC(tb)
   integer :: DIMDEC(sb)
-  real*8 :: fkp(DIMV(fb))
-  real*8 :: const(0:1), em(0:1), en(0:1), tf(0:1)
-  real*8 :: ep(0:1), nu
-  real*8 :: temp(DIMV(tb))
-  real*8 :: state(DIMV(sb), NVAR)
-  real*8 :: teff
+  real(rt)         :: fkp(DIMV(fb))
+  real(rt)         :: const(0:1), em(0:1), en(0:1), tf(0:1)
+  real(rt)         :: ep(0:1), nu
+  real(rt)         :: temp(DIMV(tb))
+  real(rt)         :: state(DIMV(sb), NVAR)
+  real(rt)         :: teff
   integer :: i, j, k
   do k = reg_l3, reg_h3
      do j = reg_l2, reg_h2
@@ -1149,17 +1172,18 @@ subroutine rosse1(DIMS(reg), &
                   temp, DIMS(tb), &
                   state, DIMS(sb)) bind(C, name="rosse1")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(reg)
   integer :: DIMDEC(kbox)
   integer :: DIMDEC(tb)
   integer :: DIMDEC(sb)
-  real*8 :: kappar(DIMV(kbox))
-  real*8 :: const(0:1), em(0:1), en(0:1), tf(0:1)
-  real*8 :: ep(0:1), nu
-  real*8 :: temp(DIMV(tb))
-  real*8 :: state(DIMV(sb), NVAR)
-  real*8 :: kfloor
-  real*8 :: kf, teff
+  real(rt)         :: kappar(DIMV(kbox))
+  real(rt)         :: const(0:1), em(0:1), en(0:1), tf(0:1)
+  real(rt)         :: ep(0:1), nu
+  real(rt)         :: temp(DIMV(tb))
+  real(rt)         :: state(DIMV(sb), NVAR)
+  real(rt)         :: kfloor
+  real(rt)         :: kf, teff
   integer :: i, j, k
   do k = reg_l3, reg_h3
      do j = reg_l2, reg_h2
@@ -1187,18 +1211,19 @@ subroutine rosse1s(DIMS(reg), &
                    temp, DIMS(tb), &
                    state, DIMS(sb)) bind(C, name="rosse1s")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(reg)
   integer :: DIMDEC(kbox)
   integer :: DIMDEC(tb)
   integer :: DIMDEC(sb)
-  real*8 :: kappar(DIMV(kbox))
-  real*8 :: const(0:1), em(0:1), en(0:1), tf(0:1)
-  real*8 :: ep(0:1), nu
-  real*8 :: sconst(0:1), sem(0:1), sen(0:1), sep(0:1)
-  real*8 :: temp(DIMV(tb))
-  real*8 :: state(DIMV(sb), NVAR)
-  real*8 :: kfloor
-  real*8 :: kf, teff, sct
+  real(rt)         :: kappar(DIMV(kbox))
+  real(rt)         :: const(0:1), em(0:1), en(0:1), tf(0:1)
+  real(rt)         :: ep(0:1), nu
+  real(rt)         :: sconst(0:1), sem(0:1), sen(0:1), sep(0:1)
+  real(rt)         :: temp(DIMV(tb))
+  real(rt)         :: state(DIMV(sb), NVAR)
+  real(rt)         :: kfloor
+  real(rt)         :: kf, teff, sct
   integer :: i, j, k
   do k = reg_l3, reg_h3
      do j = reg_l2, reg_h2
@@ -1224,11 +1249,12 @@ subroutine nfloor(dest, &
                   DIMS(reg), &
                   nflr, flr, nvar) bind(C, name="nfloor")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(dbox)
   integer :: DIMDEC(reg)
   integer :: nvar, nflr
-  real*8 :: dest(DIMV(dbox), 0:nvar-1)
-  real*8 :: flr
+  real(rt)         :: dest(DIMV(dbox), 0:nvar-1)
+  real(rt)         :: flr
   integer :: i, j, k, n
   nflr = 0
   do n = 0, nvar-1
@@ -1257,22 +1283,23 @@ subroutine lacoefmgfld(a, &
                        r, s, &
                        dt, c) bind(C, name="lacoefmgfld")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(abox)
   integer :: DIMDEC(reg)
   integer :: DIMDEC(kbox)
 
-  real*8 :: a(DIMV(abox))
-  real*8 :: kappa(DIMV(kbox))
-  real*8 :: r(reg_l1:reg_h1)
-  real*8 :: s(reg_l2:reg_h2)
-  real*8 :: dt, c
+  real(rt)         :: a(DIMV(abox))
+  real(rt)         :: kappa(DIMV(kbox))
+  real(rt)         :: r(reg_l1:reg_h1)
+  real(rt)         :: s(reg_l2:reg_h2)
+  real(rt)         :: dt, c
 
   integer :: i, j, k
 
   do k = reg_l3, reg_h3
      do j = reg_l2, reg_h2
         do i = reg_l1, reg_h1
-           a(i,j,k) = c*kappa(i,j,k) + 1.d0/dt
+           a(i,j,k) = c*kappa(i,j,k) + 1.e0_rt/dt
         enddo
      enddo
   enddo
@@ -1289,10 +1316,11 @@ subroutine rfface(fine, &
                   DIMS(cbox), &
                   idim, irat) bind(C, name="rfface")
 
+  use bl_fort_module, only : rt => c_real
   integer :: DIMDEC(fbox)
   integer :: DIMDEC(cbox)
-  real*8 :: fine(DIMV(fbox))
-  real*8 :: crse(DIMV(cbox))
+  real(rt)         :: fine(DIMV(fbox))
+  real(rt)         :: crse(DIMV(cbox))
   integer :: idim, irat(0:2)
   integer :: i, j, k
   integer :: rfac
@@ -1325,18 +1353,19 @@ subroutine bextrp( &
                   f, fbox_l1, fbox_l2, fbox_l3, fbox_h1, fbox_h2, fbox_h3, &
                   reg_l1, reg_l2, reg_l3, reg_h1, reg_h2, reg_h3) bind(C, name="bextrp")
 
+  use bl_fort_module, only : rt => c_real
   integer :: fbox_l1, fbox_l2, fbox_l3, fbox_h1, fbox_h2, fbox_h3
   integer ::  reg_l1,  reg_l2,  reg_l3,  reg_h1,  reg_h2,  reg_h3
-  real*8 :: f(fbox_l1:fbox_h1,fbox_l2:fbox_h2,fbox_l3:fbox_h3)
+  real(rt)         :: f(fbox_l1:fbox_h1,fbox_l2:fbox_h2,fbox_l3:fbox_h3)
   integer :: i, j, k
 
   !     i direction first:
   do k = reg_l3, reg_h3
      do j = reg_l2, reg_h2
         i = reg_l1
-        f(i-1,j,k) = 2.d0 * f(i,j,k) - f(i+1,j,k)
+        f(i-1,j,k) = 2.e0_rt * f(i,j,k) - f(i+1,j,k)
         i = reg_h1
-        f(i+1,j,k) = 2.d0 * f(i,j,k) - f(i-1,j,k)
+        f(i+1,j,k) = 2.e0_rt * f(i,j,k) - f(i-1,j,k)
      enddo
   enddo
 
@@ -1344,9 +1373,9 @@ subroutine bextrp( &
   do k = reg_l3, reg_h3
      do i = reg_l1 - 1, reg_h1 + 1
         j = reg_l2
-        f(i,j-1,k) = 2.d0 * f(i,j,k) - f(i,j+1,k)
+        f(i,j-1,k) = 2.e0_rt * f(i,j,k) - f(i,j+1,k)
         j = reg_h2
-        f(i,j+1,k) = 2.d0 * f(i,j,k) - f(i,j-1,k)
+        f(i,j+1,k) = 2.e0_rt * f(i,j,k) - f(i,j-1,k)
      enddo
   enddo
 
@@ -1354,9 +1383,9 @@ subroutine bextrp( &
   do j = reg_l2 - 1, reg_h2 + 1
      do i = reg_l1 - 1, reg_h1 + 1
         k = reg_l3
-        f(i,j,k-1) = 2.d0 * f(i,j,k) - f(i,j,k+1)
+        f(i,j,k-1) = 2.e0_rt * f(i,j,k) - f(i,j,k+1)
         k = reg_h3
-        f(i,j,k+1) = 2.d0 * f(i,j,k) - f(i,j,k-1)
+        f(i,j,k+1) = 2.e0_rt * f(i,j,k) - f(i,j,k-1)
      enddo
   enddo
 
@@ -1370,20 +1399,21 @@ subroutine lbcoefna(bcoef, &
                     spec, sboxl0, sboxl1, sboxl2, sboxh0, sboxh1, sboxh2, &
                     idim) bind(C, name="lbcoefna")
 
+  use bl_fort_module, only : rt => c_real
   integer :: idim
   integer ::  reg_l1,  reg_l2,  reg_l3,  reg_h1,  reg_h2,  reg_h3
   integer :: bboxl0, bboxl1, bboxl2, bboxh0, bboxh1, bboxh2
   integer :: sboxl0, sboxl1, sboxl2, sboxh0, sboxh1, sboxh2
-  real*8 :: bcoef(bboxl0:bboxh0,bboxl1:bboxh1,bboxl2:bboxh2)
-  real*8 :: bcgrp(bboxl0:bboxh0,bboxl1:bboxh1,bboxl2:bboxh2)
-  real*8 :: spec(sboxl0:sboxh0,sboxl1:sboxh1,sboxl2:sboxh2)
+  real(rt)         :: bcoef(bboxl0:bboxh0,bboxl1:bboxh1,bboxl2:bboxh2)
+  real(rt)         :: bcgrp(bboxl0:bboxh0,bboxl1:bboxh1,bboxl2:bboxh2)
+  real(rt)         :: spec(sboxl0:sboxh0,sboxl1:sboxh1,sboxl2:sboxh2)
   integer :: i, j, k
   if (idim == 0) then
      do k = reg_l3, reg_h3
         do j = reg_l2, reg_h2
            do i = reg_l1, reg_h1
               bcoef(i,j,k) = bcoef(i,j,k) &
-                   + 0.5d0 * (spec(i-1,j,k) + spec(i,j,k)) * bcgrp(i,j,k)
+                   + 0.5e0_rt * (spec(i-1,j,k) + spec(i,j,k)) * bcgrp(i,j,k)
            enddo
         enddo
      enddo
@@ -1392,7 +1422,7 @@ subroutine lbcoefna(bcoef, &
         do j = reg_l2, reg_h2
            do i = reg_l1, reg_h1
               bcoef(i,j,k) = bcoef(i,j,k) &
-                   + 0.5d0 * (spec(i,j-1,k) + spec(i,j,k)) * bcgrp(i,j,k)
+                   + 0.5e0_rt * (spec(i,j-1,k) + spec(i,j,k)) * bcgrp(i,j,k)
            enddo
         enddo
      enddo
@@ -1401,7 +1431,7 @@ subroutine lbcoefna(bcoef, &
         do j = reg_l2, reg_h2
            do i = reg_l1, reg_h1
               bcoef(i,j,k) = bcoef(i,j,k) &
-                   + 0.5d0 * (spec(i,j,k-1) + spec(i,j,k)) * bcgrp(i,j,k)
+                   + 0.5e0_rt * (spec(i,j,k-1) + spec(i,j,k)) * bcgrp(i,j,k)
            enddo
         enddo
      enddo
@@ -1417,14 +1447,15 @@ subroutine ljupna( &
                   accel, aboxl0, aboxl1, aboxl2, aboxh0, aboxh1, aboxh2, &
                   nTotal) bind(C, name="ljupna")
 
+  use bl_fort_module, only : rt => c_real
   integer :: nTotal
   integer ::  reg_l1,  reg_l2,  reg_l3,  reg_h1,  reg_h2,  reg_h3
   integer :: jboxl0, jboxl1, jboxl2, jboxh0, jboxh1, jboxh2
   integer :: sboxl0, sboxl1, sboxl2, sboxh0, sboxh1, sboxh2
   integer :: aboxl0, aboxl1, aboxl2, aboxh0, aboxh1, aboxh2
-  real*8 :: jnew(jboxl0:jboxh0,jboxl1:jboxh1,jboxl2:jboxh2,0:nTotal-1)
-  real*8 :: spec(sboxl0:sboxh0,sboxl1:sboxh1,sboxl2:sboxh2,0:nTotal-1)
-  real*8 :: accel(aboxl0:aboxh0,aboxl1:aboxh1,aboxl2:aboxh2)
+  real(rt)         :: jnew(jboxl0:jboxh0,jboxl1:jboxh1,jboxl2:jboxh2,0:nTotal-1)
+  real(rt)         :: spec(sboxl0:sboxh0,sboxl1:sboxh1,sboxl2:sboxh2,0:nTotal-1)
+  real(rt)         :: accel(aboxl0:aboxh0,aboxl1:aboxh1,aboxl2:aboxh2)
 
   integer :: i, j, k, n
   do n = 0, nTotal - 1

--- a/Source/Radiation/RadSrc_3d/RadBndry_3d.f90
+++ b/Source/Radiation/RadSrc_3d/RadBndry_3d.f90
@@ -15,15 +15,16 @@ subroutine rbndry(  &
 
   use rad_params_module, only : ngroups
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: b_l1,b_l2,b_l3,b_h1,b_h2,b_h3
   integer, intent(in) :: d_l1,d_l2,d_l3,d_h1,d_h2,d_h3 ! computational domain index
   integer, intent(in) :: dir         ! 0: x    1: y    2: z-direction
   integer, intent(in) :: face        ! 0: low  1: high
-  double precision, intent(out) :: bf(b_l1:b_h1,b_l2:b_h2,b_l3:b_h3,0:ngroups-1)
-  double precision, intent(in) :: dx(3), xlo(3), t
+  real(rt)        , intent(out) :: bf(b_l1:b_h1,b_l2:b_h2,b_l3:b_h3,0:ngroups-1)
+  real(rt)        , intent(in) :: dx(3), xlo(3), t
 
-  bf = 0.5d0
+  bf = 0.5e0_rt
 
 end subroutine rbndry

--- a/Source/Radiation/RadSrc_3d/RadEOS_3d.f90
+++ b/Source/Radiation/RadSrc_3d/RadEOS_3d.f90
@@ -9,24 +9,25 @@ subroutine ca_compute_c_v(lo, hi, &
   use network, only : nspec, naux
   use meth_params_module, only : NVAR, URHO, UFS, UFX
 
+  use bl_fort_module, only : rt => c_real
   implicit none
   integer, intent(in)          :: lo(3), hi(3)
   integer, intent(in)          :: cv_l1, cv_l2, cv_l3, cv_h1, cv_h2, cv_h3
   integer, intent(in)          :: temp_l1, temp_l2, temp_l3, temp_h1, temp_h2, temp_h3
   integer, intent(in)          :: state_l1, state_l2, state_l3, state_h1, state_h2, state_h3
-  double precision             :: cv(cv_l1:cv_h1,cv_l2:cv_h2,cv_l3:cv_h3)
-  double precision, intent(in) :: temp(temp_l1:temp_h1,temp_l2:temp_h2,temp_l3:temp_h3)
-  double precision, intent(in) :: state(state_l1:state_h1,state_l2:state_h2,state_l3:state_h3,NVAR)
+  real(rt)                     :: cv(cv_l1:cv_h1,cv_l2:cv_h2,cv_l3:cv_h3)
+  real(rt)        , intent(in) :: temp(temp_l1:temp_h1,temp_l2:temp_h2,temp_l3:temp_h3)
+  real(rt)        , intent(in) :: state(state_l1:state_h1,state_l2:state_h2,state_l3:state_h3,NVAR)
 
   integer           :: i, j, k
-  double precision :: rhoInv
+  real(rt)         :: rhoInv
   type(eos_t) :: eos_state
 
   do k = lo(3), hi(3)
      do j = lo(2), hi(2)
         do i = lo(1), hi(1)
 
-           rhoInv = 1.d0 / state(i,j,k,URHO)
+           rhoInv = 1.e0_rt / state(i,j,k,URHO)
            eos_state % rho = state(i,j,k,URHO)
            eos_state % T   =  temp(i,j,k)
            eos_state % xn  = state(i,j,k,UFS:UFS+nspec-1) * rhoInv
@@ -53,24 +54,25 @@ subroutine ca_get_rhoe(lo, hi, &
   use network, only : nspec, naux
   use meth_params_module, only : NVAR, URHO, UFS, UFX
   
+  use bl_fort_module, only : rt => c_real
   implicit none
   integer         , intent(in) :: lo(3), hi(3)
   integer         , intent(in) :: rhoe_l1, rhoe_l2, rhoe_l3, rhoe_h1, rhoe_h2, rhoe_h3
   integer         , intent(in) :: temp_l1, temp_l2, temp_l3, temp_h1, temp_h2, temp_h3
   integer         , intent(in) :: state_l1, state_l2, state_l3, state_h1, state_h2, state_h3
-  double precision, intent(in) :: temp(temp_l1:temp_h1,temp_l2:temp_h2,temp_l3:temp_h3)
-  double precision, intent(in) :: state(state_l1:state_h1,state_l2:state_h2,state_l3:state_h3,NVAR)
-  double precision             :: rhoe(rhoe_l1:rhoe_h1,rhoe_l2:rhoe_h2,rhoe_l3:rhoe_h3)
+  real(rt)        , intent(in) :: temp(temp_l1:temp_h1,temp_l2:temp_h2,temp_l3:temp_h3)
+  real(rt)        , intent(in) :: state(state_l1:state_h1,state_l2:state_h2,state_l3:state_h3,NVAR)
+  real(rt)                     :: rhoe(rhoe_l1:rhoe_h1,rhoe_l2:rhoe_h2,rhoe_l3:rhoe_h3)
   
   integer          :: i, j, k
-  double precision :: rhoInv
+  real(rt)         :: rhoInv
   type(eos_t) :: eos_state  
 
   do k = lo(3), hi(3)
      do j = lo(2), hi(2)
         do i = lo(1), hi(1)
 
-           rhoInv = 1.d0 / state(i,j,k,URHO)
+           rhoInv = 1.e0_rt / state(i,j,k,URHO)
            eos_state % rho = state(i,j,k,URHO)
            eos_state % T   =  temp(i,j,k)
            eos_state % xn  = state(i,j,k,UFS:UFS+nspec-1) * rhoInv
@@ -97,24 +99,25 @@ subroutine ca_compute_temp_given_rhoe(lo,hi,  &
   use eos_module
   use meth_params_module, only : NVAR, URHO, UTEMP, UFS, UFX, small_temp, allow_negative_energy
 
+  use bl_fort_module, only : rt => c_real
   implicit none
   integer         , intent(in) :: lo(3),hi(3)
   integer         , intent(in) :: temp_l1, temp_l2, temp_l3, temp_h1, temp_h2, temp_h3, &
                                  state_l1,state_l2,state_l3,state_h1,state_h2,state_h3
-  double precision, intent(in) :: state(state_l1:state_h1,state_l2:state_h2,state_l3:state_h3,NVAR)
-  double precision :: temp(temp_l1:temp_h1,temp_l2:temp_h2,temp_l3:temp_h3) ! temp contains rhoe as input
+  real(rt)        , intent(in) :: state(state_l1:state_h1,state_l2:state_h2,state_l3:state_h3,NVAR)
+  real(rt)         :: temp(temp_l1:temp_h1,temp_l2:temp_h2,temp_l3:temp_h3) ! temp contains rhoe as input
 
   integer :: i, j, k
-  double precision :: rhoInv
+  real(rt)         :: rhoInv
   type (eos_t) :: eos_state
 
   do k = lo(3),hi(3)
   do j = lo(2),hi(2)
   do i = lo(1),hi(1)
-     if (allow_negative_energy.eq.0 .and. temp(i,j,k).le.0.d0) then
+     if (allow_negative_energy.eq.0 .and. temp(i,j,k).le.0.e0_rt) then
         temp(i,j,k) = small_temp
      else
-        rhoInv = 1.d0 / state(i,j,k,URHO)
+        rhoInv = 1.e0_rt / state(i,j,k,URHO)
         eos_state % rho = state(i,j,k,URHO)
         eos_state % T   = state(i,j,k,UTEMP)
         eos_state % e   =  temp(i,j,k)*rhoInv 
@@ -140,33 +143,34 @@ subroutine ca_compute_temp_given_cv(lo,hi,  &
 
   use meth_params_module, only : NVAR, URHO
 
+  use bl_fort_module, only : rt => c_real
   implicit none
   integer         , intent(in) :: lo(3),hi(3)
   integer         , intent(in) :: temp_l1, temp_l2, temp_l3, temp_h1, temp_h2, temp_h3, &
                                  state_l1,state_l2,state_l3,state_h1,state_h2,state_h3
-  double precision, intent(in) :: state(state_l1:state_h1,state_l2:state_h2,state_l3:state_h3,NVAR)
-  double precision :: temp(temp_l1:temp_h1,temp_l2:temp_h2,temp_l3:temp_h3) ! temp contains rhoe as input
-  double precision, intent(in) :: const_c_v, c_v_exp_m, c_v_exp_n
+  real(rt)        , intent(in) :: state(state_l1:state_h1,state_l2:state_h2,state_l3:state_h3,NVAR)
+  real(rt)         :: temp(temp_l1:temp_h1,temp_l2:temp_h2,temp_l3:temp_h3) ! temp contains rhoe as input
+  real(rt)        , intent(in) :: const_c_v, c_v_exp_m, c_v_exp_n
 
   integer :: i, j, k
-  double precision :: ex, alpha, rhoal, teff
+  real(rt)         :: ex, alpha, rhoal, teff
 
-  ex = 1.d0 / (1.d0 - c_v_exp_n)
+  ex = 1.e0_rt / (1.e0_rt - c_v_exp_n)
 
   do k=lo(3), hi(3)
      do j=lo(2), hi(2)
         do i=lo(1), hi(1)
-           if (c_v_exp_m .eq. 0.d0) then
+           if (c_v_exp_m .eq. 0.e0_rt) then
               alpha = const_c_v
            else
               alpha = const_c_v * state(i,j,k,URHO) ** c_v_exp_m
            endif
-           rhoal = state(i,j,k,URHO) * alpha + 1.d-50
-           if (c_v_exp_n .eq. 0.d0) then
+           rhoal = state(i,j,k,URHO) * alpha + 1.e-50_rt
+           if (c_v_exp_n .eq. 0.e0_rt) then
               temp(i,j,k) = temp(i,j,k) / rhoal
            else
-              teff = max(temp(i,j,k), 1.d-50)
-              temp(i,j,k) = ((1.d0 - c_v_exp_n) * teff / rhoal) ** ex
+              teff = max(temp(i,j,k), 1.e-50_rt)
+              temp(i,j,k) = ((1.e0_rt - c_v_exp_n) * teff / rhoal) ** ex
            endif
         end do
      end do
@@ -191,30 +195,31 @@ subroutine ca_compute_temp_given_reye(lo, hi, &
   use meth_params_module, only : NVAR, URHO, UMX, UMY, UFS, UFX, &
        small_temp, allow_negative_energy
   
+  use bl_fort_module, only : rt => c_real
   implicit none
   integer         , intent(in) :: lo(3), hi(3)
   integer         , intent(in) ::  temp_l1, temp_l2, temp_l3, temp_h1, temp_h2, temp_h3
   integer         , intent(in) ::    re_l1,   re_l2,   re_l3,   re_h1,   re_h2,   re_h3
   integer         , intent(in) ::    ye_l1,   ye_l2,   ye_l3,   ye_h1,   ye_h2,   ye_h3
   integer         , intent(in) :: state_l1,state_l2,state_l3,state_h1,state_h2,state_h3
-  double precision, intent(in) :: state(state_l1:state_h1,state_l2:state_h2,state_l3:state_h3,NVAR)
-  double precision, intent(in) ::  rhoe(   re_l1:   re_h1,   re_l2:   re_h2,   re_l3:   re_h3)
-  double precision, intent(in) ::    ye(   ye_l1:   ye_h1,   ye_l2:   ye_h2,   ye_l3:   ye_h3)
-  double precision             ::  temp( temp_l1: temp_h1, temp_l2: temp_h2, temp_l3: temp_h3)
+  real(rt)        , intent(in) :: state(state_l1:state_h1,state_l2:state_h2,state_l3:state_h3,NVAR)
+  real(rt)        , intent(in) ::  rhoe(   re_l1:   re_h1,   re_l2:   re_h2,   re_l3:   re_h3)
+  real(rt)        , intent(in) ::    ye(   ye_l1:   ye_h1,   ye_l2:   ye_h2,   ye_l3:   ye_h3)
+  real(rt)                     ::  temp( temp_l1: temp_h1, temp_l2: temp_h2, temp_l3: temp_h3)
   
   integer          :: i, j, k
-  double precision :: rhoInv
+  real(rt)         :: rhoInv
   type (eos_t) :: eos_state
 
   do k = lo(3), hi(3)
      do j = lo(2), hi(2)
         do i = lo(1), hi(1)
 
-           if(allow_negative_energy.eq.0 .and. rhoe(i,j,k).le.0.d0) then
+           if(allow_negative_energy.eq.0 .and. rhoe(i,j,k).le.0.e0_rt) then
               temp(i,j,k) = small_temp
            else
 
-              rhoInv = 1.d0 / state(i,j,k,URHO)
+              rhoInv = 1.e0_rt / state(i,j,k,URHO)
               eos_state % rho = state(i,j,k,URHO)
               ! set initial guess of temperature
               eos_state % T = temp(i,j,k)
@@ -228,7 +233,7 @@ subroutine ca_compute_temp_given_reye(lo, hi, &
               
               temp(i,j,k) = eos_state % T
 
-              if(temp(i,j,k).lt.0.d0) then
+              if(temp(i,j,k).lt.0.e0_rt) then
                  print*,'negative temp in compute_temp_given_reye ', temp(i,j,k)
                  call bl_error("Error:: ca_compute_temp_given_reye")
               endif
@@ -252,6 +257,7 @@ subroutine ca_compute_reye_given_ty(lo, hi, &
   use eos_module
   use meth_params_module, only : NVAR, URHO, UFS, UFX
   
+  use bl_fort_module, only : rt => c_real
   implicit none
   integer         , intent(in) :: lo(3), hi(3)
   integer         , intent(in) :: re_l1, re_h1, re_l2, re_h2, re_l3, re_h3
@@ -259,21 +265,21 @@ subroutine ca_compute_reye_given_ty(lo, hi, &
   integer         , intent(in) :: temp_l1, temp_h1, temp_l2, temp_h2, temp_l3, temp_h3
   integer         , intent(in) :: ye_l1, ye_h1, ye_l2, ye_h2, ye_l3, ye_h3
   integer         , intent(in) :: state_l1, state_h1, state_l2, state_h2, state_l3, state_h3
-  double precision, intent(in) :: state(state_l1:state_h1,state_l2:state_h2,state_l3:state_h3,NVAR)
-  double precision             :: rhoe(re_l1:re_h1,re_l2:re_h2,re_l3:re_h3)
-  double precision             :: rhoY(rY_l1:rY_h1,rY_l2:rY_h2,rY_l3:rY_h3)
-  double precision, intent(in) :: ye(ye_l1:ye_h1,ye_l2:ye_h2,ye_l3:ye_h3)
-  double precision, intent(in) :: temp(temp_l1:temp_h1,temp_l2:temp_h2,temp_l3:temp_h3)
+  real(rt)        , intent(in) :: state(state_l1:state_h1,state_l2:state_h2,state_l3:state_h3,NVAR)
+  real(rt)                     :: rhoe(re_l1:re_h1,re_l2:re_h2,re_l3:re_h3)
+  real(rt)                     :: rhoY(rY_l1:rY_h1,rY_l2:rY_h2,rY_l3:rY_h3)
+  real(rt)        , intent(in) :: ye(ye_l1:ye_h1,ye_l2:ye_h2,ye_l3:ye_h3)
+  real(rt)        , intent(in) :: temp(temp_l1:temp_h1,temp_l2:temp_h2,temp_l3:temp_h3)
   
   integer          :: i, j, k
-  double precision :: rhoInv
+  real(rt)         :: rhoInv
   type (eos_t) :: eos_state
 
   do k = lo(3), hi(3)
      do j = lo(2), hi(2)
         do i = lo(1), hi(1)
 
-           rhoInv = 1.d0 / state(i,j,k,URHO)
+           rhoInv = 1.e0_rt / state(i,j,k,URHO)
            eos_state % rho = state(i,j,k,URHO)
            eos_state % T   =  temp(i,j,k)
            eos_state % xn  = state(i,j,k,UFS:UFS+nspec-1) * rhoInv

--- a/Source/Radiation/RadSrc_3d/RadPlotvar_3d.f90
+++ b/Source/Radiation/RadSrc_3d/RadPlotvar_3d.f90
@@ -6,6 +6,7 @@ subroutine ca_er_com2lab(lo, hi, &
      Elab, El_l1, El_l2, El_l3, El_h1, El_h2, El_h3, ier, npv)
   use meth_params_module, only : NVAR, URHO, UMX, UMY, UMZ
   use rad_params_module, only : ngroups, clight, nnuspec, ng0, ng1, dlognu
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: lo(3), hi(3)
@@ -13,34 +14,34 @@ subroutine ca_er_com2lab(lo, hi, &
   integer, intent(in) :: Ec_l1, Ec_l2, Ec_l3, Ec_h1, Ec_h2, Ec_h3
   integer, intent(in) ::  F_l1,  F_l2,  F_l3,  F_h1,  F_h2,  F_h3, iflx, nflx
   integer, intent(in) :: El_l1, El_l2, El_l3, El_h1, El_h2, El_h3, ier, npv
-  double precision,intent(in)   ::Snew( S_l1: S_h1, S_l2: S_h2, S_l3: S_h3,NVAR)
-  double precision,intent(in)   ::Ecom(Ec_l1:Ec_h1,Ec_l2:Ec_h2,Ec_l3:Ec_h3,0:ngroups-1)
-  double precision,intent(in)   ::F   ( F_l1: F_h1, F_l2: F_h2, F_l3: F_h3,0:nflx-1)
-  double precision,intent(inout)::Elab(El_l1:El_h1,El_l2:El_h2,El_l3:El_h3,0:npv-1)
+  real(rt)        ,intent(in)   ::Snew( S_l1: S_h1, S_l2: S_h2, S_l3: S_h3,NVAR)
+  real(rt)        ,intent(in)   ::Ecom(Ec_l1:Ec_h1,Ec_l2:Ec_h2,Ec_l3:Ec_h3,0:ngroups-1)
+  real(rt)        ,intent(in)   ::F   ( F_l1: F_h1, F_l2: F_h2, F_l3: F_h3,0:nflx-1)
+  real(rt)        ,intent(inout)::Elab(El_l1:El_h1,El_l2:El_h2,El_l3:El_h3,0:npv-1)
 
   integer :: i, j, k, g, ifx, ify, ifz
-  double precision :: rhoInv, c2, vxc2, vyc2, vzc2
-  double precision :: nufnux(-1:ngroups), nufnuy(-1:ngroups), nufnuz(-1:ngroups)
-  double precision :: dlognuInv(0:ngroups-1)
+  real(rt)         :: rhoInv, c2, vxc2, vyc2, vzc2
+  real(rt)         :: nufnux(-1:ngroups), nufnuy(-1:ngroups), nufnuz(-1:ngroups)
+  real(rt)         :: dlognuInv(0:ngroups-1)
 
   ifx = iflx
   ify = iflx + ngroups
   ifz = iflx + ngroups*2
 
-  c2 = 1.d0/clight**2
+  c2 = 1.e0_rt/clight**2
 
-  if (ngroups > 1) dlognuInv = 1.d0/dlognu
+  if (ngroups > 1) dlognuInv = 1.e0_rt/dlognu
 
   do k = lo(3), hi(3)
   do j = lo(2), hi(2)
   do i = lo(1), hi(1)
-     rhoInv = 1.d0/Snew(i,j,k,URHO)
+     rhoInv = 1.e0_rt/Snew(i,j,k,URHO)
      vxc2 = Snew(i,j,k,UMX)*rhoInv*c2
      vyc2 = Snew(i,j,k,UMY)*rhoInv*c2
      vzc2 = Snew(i,j,k,UMZ)*rhoInv*c2
      
      do g = 0, ngroups-1
-        Elab(i,j,k,g+ier) = Ecom(i,j,k,g) + 2.d0*(vxc2*F(i,j,k,ifx+g) &
+        Elab(i,j,k,g+ier) = Ecom(i,j,k,g) + 2.e0_rt*(vxc2*F(i,j,k,ifx+g) &
              &                                  + vyc2*F(i,j,k,ify+g) &
              &                                  + vzc2*F(i,j,k,ifz+g))
      end do
@@ -61,9 +62,9 @@ subroutine ca_er_com2lab(lo, hi, &
            nufnuz(ngroups) = -nufnuz(ngroups-1)              
            do g=0,ngroups-1
               Elab(i,j,k,g+ier) = Elab(i,j,k,g+ier) &
-                   - vxc2*0.5d0*(nufnux(g+1)-nufnux(g-1)) &
-                   - vyc2*0.5d0*(nufnuy(g+1)-nufnuy(g-1)) &
-                   - vzc2*0.5d0*(nufnuz(g+1)-nufnuz(g-1))
+                   - vxc2*0.5e0_rt*(nufnux(g+1)-nufnux(g-1)) &
+                   - vyc2*0.5e0_rt*(nufnuy(g+1)-nufnuy(g-1)) &
+                   - vzc2*0.5e0_rt*(nufnuz(g+1)-nufnuz(g-1))
            end do
            
         else
@@ -81,9 +82,9 @@ subroutine ca_er_com2lab(lo, hi, &
            nufnuz(ng0) = -nufnuz(ng0-1)              
            do g=0,ng0-1
               Elab(i,j,k,g+ier) = Elab(i,j,k,g+ier) &
-                   - vxc2*0.5d0*(nufnux(g+1)-nufnux(g-1)) &
-                   - vyc2*0.5d0*(nufnuy(g+1)-nufnuy(g-1)) &
-                   - vzc2*0.5d0*(nufnuz(g+1)-nufnuz(g-1))
+                   - vxc2*0.5e0_rt*(nufnux(g+1)-nufnux(g-1)) &
+                   - vyc2*0.5e0_rt*(nufnuy(g+1)-nufnuy(g-1)) &
+                   - vzc2*0.5e0_rt*(nufnuz(g+1)-nufnuz(g-1))
            end do
            
            if (nnuspec >= 2) then
@@ -101,9 +102,9 @@ subroutine ca_er_com2lab(lo, hi, &
               nufnuz(ng0+ng1) = -nufnuz(ng0+ng1-1)              
               do g=ng0,ng0+ng1-1
                  Elab(i,j,k,g+ier) = Elab(i,j,k,g+ier) &
-                      - vxc2*0.5d0*(nufnux(g+1)-nufnux(g-1)) &
-                      - vyc2*0.5d0*(nufnuy(g+1)-nufnuy(g-1)) &
-                      - vzc2*0.5d0*(nufnuz(g+1)-nufnuz(g-1))
+                      - vxc2*0.5e0_rt*(nufnux(g+1)-nufnux(g-1)) &
+                      - vyc2*0.5e0_rt*(nufnuy(g+1)-nufnuy(g-1)) &
+                      - vzc2*0.5e0_rt*(nufnuz(g+1)-nufnuz(g-1))
               end do
               
            end if
@@ -123,9 +124,9 @@ subroutine ca_er_com2lab(lo, hi, &
               nufnuz(ngroups) = -nufnuz(ngroups-1)              
               do g=ng0+ng1,ngroups-1
                  Elab(i,j,k,g+ier) = Elab(i,j,k,g+ier) &
-                      - vxc2*0.5d0*(nufnux(g+1)-nufnux(g-1)) &
-                      - vyc2*0.5d0*(nufnuy(g+1)-nufnuy(g-1)) &
-                      - vzc2*0.5d0*(nufnuz(g+1)-nufnuz(g-1))
+                      - vxc2*0.5e0_rt*(nufnux(g+1)-nufnux(g-1)) &
+                      - vyc2*0.5e0_rt*(nufnuy(g+1)-nufnuy(g-1)) &
+                      - vzc2*0.5e0_rt*(nufnuz(g+1)-nufnuz(g-1))
               end do
               
            end if
@@ -146,26 +147,27 @@ subroutine ca_compute_fcc(lo, hi, &
      Eddf, Eddf_l1, Eddf_l2, Eddf_l3, Eddf_h1, Eddf_h2, Eddf_h3)
   use rad_params_module, only : ngroups
   use fluxlimiter_module, only : Edd_factor
+  use bl_fort_module, only : rt => c_real
   implicit none
   integer, intent(in) :: lo(3), hi(3)
   integer, intent(in) :: lamx_l1, lamx_l2, lamx_l3, lamx_h1, lamx_h2, lamx_h3
   integer, intent(in) :: lamy_l1, lamy_l2, lamy_l3, lamy_h1, lamy_h2, lamy_h3
   integer, intent(in) :: lamz_l1, lamz_l2, lamz_l3, lamz_h1, lamz_h2, lamz_h3, nlam
   integer, intent(in) :: Eddf_l1, Eddf_l2, Eddf_l3, Eddf_h1, Eddf_h2, Eddf_h3
-  double precision,intent(in   )::lamx(lamx_l1:lamx_h1,lamx_l2:lamx_h2,lamx_l3:lamx_h3,0:nlam-1)
-  double precision,intent(in   )::lamy(lamy_l1:lamy_h1,lamy_l2:lamy_h2,lamy_l3:lamy_h3,0:nlam-1)
-  double precision,intent(in   )::lamz(lamz_l1:lamz_h1,lamz_l2:lamz_h2,lamz_l3:lamz_h3,0:nlam-1)
-  double precision,intent(inout)::Eddf(Eddf_l1:Eddf_h1,Eddf_l2:Eddf_h2,Eddf_l3:Eddf_h3,0:ngroups-1)
+  real(rt)        ,intent(in   )::lamx(lamx_l1:lamx_h1,lamx_l2:lamx_h2,lamx_l3:lamx_h3,0:nlam-1)
+  real(rt)        ,intent(in   )::lamy(lamy_l1:lamy_h1,lamy_l2:lamy_h2,lamy_l3:lamy_h3,0:nlam-1)
+  real(rt)        ,intent(in   )::lamz(lamz_l1:lamz_h1,lamz_l2:lamz_h2,lamz_l3:lamz_h3,0:nlam-1)
+  real(rt)        ,intent(inout)::Eddf(Eddf_l1:Eddf_h1,Eddf_l2:Eddf_h2,Eddf_l3:Eddf_h3,0:ngroups-1)
 
   integer :: i, j, k, g, ilam
-  double precision :: lamcc
+  real(rt)         :: lamcc
 
   do g=0,ngroups-1
      ilam = min(g,nlam-1)
      do k = lo(3), hi(3)
         do j = lo(2), hi(2)
            do i = lo(1), hi(1)
-              lamcc = (1.d0/6.d0)*(lamx(i,j,k,ilam)+lamx(i+1,j,k,ilam) &
+              lamcc = (1.e0_rt/6.e0_rt)*(lamx(i,j,k,ilam)+lamx(i+1,j,k,ilam) &
                    +               lamy(i,j,k,ilam)+lamy(i,j+1,k,ilam) &
                    +               lamz(i,j,k,ilam)+lamz(i,j,k+1,ilam))
               Eddf(i,j,k,g) = Edd_factor(lamcc)
@@ -184,26 +186,27 @@ subroutine ca_transform_flux (lo, hi, flag, &
      Fo,   Fo_l1, Fo_l2, Fo_l3, Fo_h1, Fo_h2, Fo_h3, ifo, nfo)
   use meth_params_module, only : NVAR, URHO, UMX, UMY, UMZ
   use rad_params_module, only : ngroups, nnuspec, ng0, ng1, dlognu
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: lo(3), hi(3)
-  double precision, intent(in) :: flag
+  real(rt)        , intent(in) :: flag
   integer, intent(in) ::  S_l1,  S_l2,  S_l3,  S_h1,  S_h2,  S_h3
   integer, intent(in) ::  f_l1,  f_l2,  f_l3,  f_h1,  f_h2,  f_h3
   integer, intent(in) :: Er_l1, Er_l2, Er_l3, Er_h1, Er_h2, Er_h3
   integer, intent(in) :: Fi_l1, Fi_l2, Fi_l3, Fi_h1, Fi_h2, Fi_h3, ifi, nfi
   integer, intent(in) :: Fo_l1, Fo_l2, Fo_l3, Fo_h1, Fo_h2, Fo_h3, ifo, nfo
-  double precision,intent(in   )::Snew( S_l1: S_h1, S_l2: S_h2, S_l3: S_h3,NVAR)
-  double precision,intent(in   )::   f( f_l1: f_h1, f_l2: f_h2, f_l3: f_h3,0:ngroups-1)
-  double precision,intent(in   )::  Er(Er_l1:Er_h1,Er_l2:Er_h2,Er_l3:Er_h3,0:ngroups-1)
-  double precision,intent(in   )::  Fi(Fi_l1:Fi_h1,Fi_l2:Fi_h2,Fi_l3:Fi_h3,0:nfi-1)
-  double precision,intent(inout)::  Fo(Fo_l1:Fo_h1,Fo_l2:Fo_h2,Fo_l3:Fo_h3,0:nfo-1)
+  real(rt)        ,intent(in   )::Snew( S_l1: S_h1, S_l2: S_h2, S_l3: S_h3,NVAR)
+  real(rt)        ,intent(in   )::   f( f_l1: f_h1, f_l2: f_h2, f_l3: f_h3,0:ngroups-1)
+  real(rt)        ,intent(in   )::  Er(Er_l1:Er_h1,Er_l2:Er_h2,Er_l3:Er_h3,0:ngroups-1)
+  real(rt)        ,intent(in   )::  Fi(Fi_l1:Fi_h1,Fi_l2:Fi_h2,Fi_l3:Fi_h3,0:nfi-1)
+  real(rt)        ,intent(inout)::  Fo(Fo_l1:Fo_h1,Fo_l2:Fo_h2,Fo_l3:Fo_h3,0:nfo-1)
 
   integer :: i, j, k, g, ifix, ifiy, ifiz, ifox, ifoy, ifoz
-  double precision :: rhoInv,  vx, vy, vz, f1, f2, nx, ny, nz, foo, vdotn
-  double precision :: nuvpnux(-1:ngroups), nuvpnuy(-1:ngroups), nuvpnuz(-1:ngroups)
-  double precision :: dlognuInv(0:ngroups-1)
-  double precision :: vdotpx(0:ngroups-1), vdotpy(0:ngroups-1), vdotpz(0:ngroups-1)
+  real(rt)         :: rhoInv,  vx, vy, vz, f1, f2, nx, ny, nz, foo, vdotn
+  real(rt)         :: nuvpnux(-1:ngroups), nuvpnuy(-1:ngroups), nuvpnuz(-1:ngroups)
+  real(rt)         :: dlognuInv(0:ngroups-1)
+  real(rt)         :: vdotpx(0:ngroups-1), vdotpy(0:ngroups-1), vdotpz(0:ngroups-1)
 
   ifix = ifi
   ifiy = ifi + ngroups
@@ -213,27 +216,27 @@ subroutine ca_transform_flux (lo, hi, flag, &
   ifoy = ifo + ngroups
   ifoz = ifo + ngroups*2
 
-  if (ngroups > 1) dlognuInv = 1.d0/dlognu
+  if (ngroups > 1) dlognuInv = 1.e0_rt/dlognu
 
   do k = lo(3), hi(3)
   do j = lo(2), hi(2)
   do i = lo(1), hi(1)
-     rhoInv = 1.d0/Snew(i,j,k,URHO)
+     rhoInv = 1.e0_rt/Snew(i,j,k,URHO)
      vx = Snew(i,j,k,UMX)*rhoInv*flag
      vy = Snew(i,j,k,UMY)*rhoInv*flag
      vz = Snew(i,j,k,UMZ)*rhoInv*flag
 
      do g = 0, ngroups-1
-        f1 = (1.d0-f(i,j,k,g))
-        f2 = (3.d0*f(i,j,k,g)-1.d0)
-        foo = 1.d0/sqrt(Fi(i,j,k,ifix+g)**2+Fi(i,j,k,ifiy+g)**2+Fi(i,j,k,ifiz+g)**2+1.d-50)
+        f1 = (1.e0_rt-f(i,j,k,g))
+        f2 = (3.e0_rt*f(i,j,k,g)-1.e0_rt)
+        foo = 1.e0_rt/sqrt(Fi(i,j,k,ifix+g)**2+Fi(i,j,k,ifiy+g)**2+Fi(i,j,k,ifiz+g)**2+1.e-50_rt)
         nx = Fi(i,j,k,ifix+g)*foo
         ny = Fi(i,j,k,ifiy+g)*foo
         nz = Fi(i,j,k,ifiz+g)*foo
         vdotn = vx*nx+vy*ny+vz*vz
-        vdotpx(g) = 0.5d0*Er(i,j,k,g)*(f1*vx + f2*vdotn*nx)
-        vdotpy(g) = 0.5d0*Er(i,j,k,g)*(f1*vy + f2*vdotn*ny)
-        vdotpz(g) = 0.5d0*Er(i,j,k,g)*(f1*vz + f2*vdotn*nz)
+        vdotpx(g) = 0.5e0_rt*Er(i,j,k,g)*(f1*vx + f2*vdotn*nx)
+        vdotpy(g) = 0.5e0_rt*Er(i,j,k,g)*(f1*vy + f2*vdotn*ny)
+        vdotpz(g) = 0.5e0_rt*Er(i,j,k,g)*(f1*vz + f2*vdotn*nz)
         Fo(i,j,k,ifox+g) = Fi(i,j,k,ifix+g) + vx*Er(i,j,k,g) + vdotpx(g)
         Fo(i,j,k,ifoy+g) = Fi(i,j,k,ifiy+g) + vy*Er(i,j,k,g) + vdotpy(g)
         Fo(i,j,k,ifoz+g) = Fi(i,j,k,ifiz+g) + vz*Er(i,j,k,g) + vdotpz(g)
@@ -254,9 +257,9 @@ subroutine ca_transform_flux (lo, hi, flag, &
            nuvpnuy(ngroups) = -nuvpnuy(ngroups-1)              
            nuvpnuz(ngroups) = -nuvpnuz(ngroups-1)              
            do g=0,ngroups-1
-              Fo(i,j,k,ifox+g) = Fo(i,j,k,ifox+g) - 0.5d0*(nuvpnux(g+1)-nuvpnux(g-1))
-              Fo(i,j,k,ifoy+g) = Fo(i,j,k,ifoy+g) - 0.5d0*(nuvpnuy(g+1)-nuvpnuy(g-1))
-              Fo(i,j,k,ifoz+g) = Fo(i,j,k,ifoz+g) - 0.5d0*(nuvpnuz(g+1)-nuvpnuz(g-1))
+              Fo(i,j,k,ifox+g) = Fo(i,j,k,ifox+g) - 0.5e0_rt*(nuvpnux(g+1)-nuvpnux(g-1))
+              Fo(i,j,k,ifoy+g) = Fo(i,j,k,ifoy+g) - 0.5e0_rt*(nuvpnuy(g+1)-nuvpnuy(g-1))
+              Fo(i,j,k,ifoz+g) = Fo(i,j,k,ifoz+g) - 0.5e0_rt*(nuvpnuz(g+1)-nuvpnuz(g-1))
            end do
 
         else
@@ -273,9 +276,9 @@ subroutine ca_transform_flux (lo, hi, flag, &
            nuvpnuy(ng0) = -nuvpnuy(ng0-1)              
            nuvpnuz(ng0) = -nuvpnuz(ng0-1)              
            do g=0,ng0-1
-              Fo(i,j,k,ifox+g) = Fo(i,j,k,ifox+g) - 0.5d0*(nuvpnux(g+1)-nuvpnux(g-1))
-              Fo(i,j,k,ifoy+g) = Fo(i,j,k,ifoy+g) - 0.5d0*(nuvpnuy(g+1)-nuvpnuy(g-1))
-              Fo(i,j,k,ifoz+g) = Fo(i,j,k,ifoz+g) - 0.5d0*(nuvpnuz(g+1)-nuvpnuz(g-1))
+              Fo(i,j,k,ifox+g) = Fo(i,j,k,ifox+g) - 0.5e0_rt*(nuvpnux(g+1)-nuvpnux(g-1))
+              Fo(i,j,k,ifoy+g) = Fo(i,j,k,ifoy+g) - 0.5e0_rt*(nuvpnuy(g+1)-nuvpnuy(g-1))
+              Fo(i,j,k,ifoz+g) = Fo(i,j,k,ifoz+g) - 0.5e0_rt*(nuvpnuz(g+1)-nuvpnuz(g-1))
            end do
 
            if (nnuspec >= 2) then
@@ -292,9 +295,9 @@ subroutine ca_transform_flux (lo, hi, flag, &
               nuvpnuy(ng0+ng1) = -nuvpnuy(ng0+ng1-1)              
               nuvpnuz(ng0+ng1) = -nuvpnuz(ng0+ng1-1)              
               do g=ng0,ng0+ng1-1
-                 Fo(i,j,k,ifox+g) = Fo(i,j,k,ifox+g) - 0.5d0*(nuvpnux(g+1)-nuvpnux(g-1))
-                 Fo(i,j,k,ifoy+g) = Fo(i,j,k,ifoy+g) - 0.5d0*(nuvpnuy(g+1)-nuvpnuy(g-1))
-                 Fo(i,j,k,ifoz+g) = Fo(i,j,k,ifoz+g) - 0.5d0*(nuvpnuz(g+1)-nuvpnuz(g-1))
+                 Fo(i,j,k,ifox+g) = Fo(i,j,k,ifox+g) - 0.5e0_rt*(nuvpnux(g+1)-nuvpnux(g-1))
+                 Fo(i,j,k,ifoy+g) = Fo(i,j,k,ifoy+g) - 0.5e0_rt*(nuvpnuy(g+1)-nuvpnuy(g-1))
+                 Fo(i,j,k,ifoz+g) = Fo(i,j,k,ifoz+g) - 0.5e0_rt*(nuvpnuz(g+1)-nuvpnuz(g-1))
               end do
 
            end if
@@ -313,9 +316,9 @@ subroutine ca_transform_flux (lo, hi, flag, &
               nuvpnuy(ngroups) = -nuvpnuy(ngroups-1)              
               nuvpnuz(ngroups) = -nuvpnuz(ngroups-1)              
               do g=ng0+ng1,ngroups-1
-                 Fo(i,j,k,ifox+g) = Fo(i,j,k,ifox+g) - 0.5d0*(nuvpnux(g+1)-nuvpnux(g-1))
-                 Fo(i,j,k,ifoy+g) = Fo(i,j,k,ifoy+g) - 0.5d0*(nuvpnuy(g+1)-nuvpnuy(g-1))
-                 Fo(i,j,k,ifoz+g) = Fo(i,j,k,ifoz+g) - 0.5d0*(nuvpnuz(g+1)-nuvpnuz(g-1))
+                 Fo(i,j,k,ifox+g) = Fo(i,j,k,ifox+g) - 0.5e0_rt*(nuvpnux(g+1)-nuvpnux(g-1))
+                 Fo(i,j,k,ifoy+g) = Fo(i,j,k,ifoy+g) - 0.5e0_rt*(nuvpnuy(g+1)-nuvpnuy(g-1))
+                 Fo(i,j,k,ifoz+g) = Fo(i,j,k,ifoz+g) - 0.5e0_rt*(nuvpnuz(g+1)-nuvpnuz(g-1))
               end do
 
            end if

--- a/Source/Radiation/RadSrc_3d/filt_prim_3d.f90
+++ b/Source/Radiation/RadSrc_3d/filt_prim_3d.f90
@@ -12,26 +12,27 @@ subroutine ca_filt_prim(lo, hi, &
        UFA, UFS, UFX, small_temp, small_dens, nadv
   use filter_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: lo(3), hi(3), domlo(3), domhi(3), level
   integer, intent(in) :: filt_T, S
-  double precision, intent(in) :: delta(3), xlo(3), problo(3), time
+  real(rt)        , intent(in) :: delta(3), xlo(3), problo(3), time
   integer, intent(in) ::   Stmp_l1,Stmp_h1,Stmp_l2,Stmp_h2,Stmp_l3,Stmp_h3
   integer, intent(in) ::   Snew_l1,Snew_h1,Snew_l2,Snew_h2,Snew_l3,Snew_h3
   integer, intent(in) ::   mask_l1,mask_h1,mask_l2,mask_h2,mask_l3,mask_h3
-  double precision :: Stmp(Stmp_l1:Stmp_h1,Stmp_l2:Stmp_h2,Stmp_l3:Stmp_h3,NVAR)
-  double precision :: Snew(Snew_l1:Snew_h1,Snew_l2:Snew_h2,Snew_l3:Snew_h3,NVAR)
-  double precision :: mask(mask_l1:mask_h1,mask_l2:mask_h2,mask_l3:mask_h3)
-  ! mask has three possible values: -1.d0, 0.d0, and 1.d0.
-  ! -1.d0 appears only in cells that are covered by neither this level nor the finer level.
+  real(rt)         :: Stmp(Stmp_l1:Stmp_h1,Stmp_l2:Stmp_h2,Stmp_l3:Stmp_h3,NVAR)
+  real(rt)         :: Snew(Snew_l1:Snew_h1,Snew_l2:Snew_h2,Snew_l3:Snew_h3,NVAR)
+  real(rt)         :: mask(mask_l1:mask_h1,mask_l2:mask_h2,mask_l3:mask_h3)
+  ! mask has three possible values: -1.e0_rt, 0.e0_rt, and 1.e0_rt.
+  ! -1.e0_rt appears only in cells that are covered by neither this level nor the finer level.
   !       It can only appear in ghost cells. 
-  !  0.d0 appears only in cells that are covered by only this level, but not the finer level.
-  !  1.d0 appears only in cells that are covered by the finer level.
+  !  0.e0_rt appears only in cells that are covered by only this level, but not the finer level.
+  !  1.e0_rt appears only in cells that are covered by the finer level.
   !       It can appear in either valid cells or ghost cells. 
 
   integer :: i,j,k
-  double precision :: p, e, X(nspec+naux)
+  real(rt)         :: p, e, X(nspec+naux)
 
   ! this is a stub -- a problem can override this in its own directory
   ! to implement filtering

--- a/Source/Radiation/RadSrc_3d/trace_ppm_rad_3d.f90
+++ b/Source/Radiation/RadSrc_3d/trace_ppm_rad_3d.f90
@@ -3,6 +3,7 @@
 
 module trace_ppm_rad_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   private
@@ -27,6 +28,7 @@ contains
     use rad_params_module, only : ngroups
     use bl_constants_module
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer, intent(in) :: qd_lo(3), qd_hi(3)
@@ -34,30 +36,30 @@ contains
     integer, intent(in) :: ilo1, ilo2, ihi1, ihi2
     integer, intent(in) :: kc,k3d
 
-    double precision, intent(in) ::     q(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),NQ)
-    double precision, intent(inout) ::  qaux(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),NQAUX)
-    double precision, intent(in) :: flatn(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3))
+    real(rt)        , intent(in) ::     q(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),NQ)
+    real(rt)        , intent(inout) ::  qaux(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),NQAUX)
+    real(rt)        , intent(in) :: flatn(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3))
 
-    double precision, intent(in) :: Ip(ilo1-1:ihi1+1,ilo2-1:ihi2+1,1:2,1:3,1:3,NQ)
-    double precision, intent(in) :: Im(ilo1-1:ihi1+1,ilo2-1:ihi2+1,1:2,1:3,1:3,NQ)
+    real(rt)        , intent(in) :: Ip(ilo1-1:ihi1+1,ilo2-1:ihi2+1,1:2,1:3,1:3,NQ)
+    real(rt)        , intent(in) :: Im(ilo1-1:ihi1+1,ilo2-1:ihi2+1,1:2,1:3,1:3,NQ)
 
-    double precision, intent(in) :: Ip_src(ilo1-1:ihi1+1,ilo2-1:ihi2+1,1:2,1:3,1:3,NQ)
-    double precision, intent(in) :: Im_src(ilo1-1:ihi1+1,ilo2-1:ihi2+1,1:2,1:3,1:3,NQ)
-
-
-    double precision, intent(inout) :: qxm(qs_lo(1):qs_hi(1),qs_lo(2):qs_hi(2),qs_lo(3):qs_hi(3),NQ)
-    double precision, intent(inout) :: qxp(qs_lo(1):qs_hi(1),qs_lo(2):qs_hi(2),qs_lo(3):qs_hi(3),NQ)
-    double precision, intent(inout) :: qym(qs_lo(1):qs_hi(1),qs_lo(2):qs_hi(2),qs_lo(3):qs_hi(3),NQ)
-    double precision, intent(inout) :: qyp(qs_lo(1):qs_hi(1),qs_lo(2):qs_hi(2),qs_lo(3):qs_hi(3),NQ)
+    real(rt)        , intent(in) :: Ip_src(ilo1-1:ihi1+1,ilo2-1:ihi2+1,1:2,1:3,1:3,NQ)
+    real(rt)        , intent(in) :: Im_src(ilo1-1:ihi1+1,ilo2-1:ihi2+1,1:2,1:3,1:3,NQ)
 
 
-    double precision, intent(in) :: dt
+    real(rt)        , intent(inout) :: qxm(qs_lo(1):qs_hi(1),qs_lo(2):qs_hi(2),qs_lo(3):qs_hi(3),NQ)
+    real(rt)        , intent(inout) :: qxp(qs_lo(1):qs_hi(1),qs_lo(2):qs_hi(2),qs_lo(3):qs_hi(3),NQ)
+    real(rt)        , intent(inout) :: qym(qs_lo(1):qs_hi(1),qs_lo(2):qs_hi(2),qs_lo(3):qs_hi(3),NQ)
+    real(rt)        , intent(inout) :: qyp(qs_lo(1):qs_hi(1),qs_lo(2):qs_hi(2),qs_lo(3):qs_hi(3),NQ)
+
+
+    real(rt)        , intent(in) :: dt
 
     ! Local variables
     integer :: i, j, g
     integer :: n, ipassive
 
-    double precision :: hdt
+    real(rt)         :: hdt
 
     ! To allow for easy integration of radiation, we adopt the
     ! following conventions:
@@ -77,32 +79,32 @@ contains
     ! for pure hydro, we will only consider:
     !   rho, u, v, w, ptot, rhoe_g, cc, h_g
 
-    double precision :: cc, csq, cgassq, Clag
-    double precision :: rho, u, v, w, p, rhoe_g, h_g, tau
-    double precision :: ptot, gam_g, game
+    real(rt)         :: cc, csq, cgassq, Clag
+    real(rt)         :: rho, u, v, w, p, rhoe_g, h_g, tau
+    real(rt)         :: ptot, gam_g, game
 
-    double precision :: drho, dptot, drhoe_g
-    double precision :: de, dge, dtau
-    double precision :: dup, dvp, dptotp
-    double precision :: dum, dvm, dptotm
+    real(rt)         :: drho, dptot, drhoe_g
+    real(rt)         :: de, dge, dtau
+    real(rt)         :: dup, dvp, dptotp
+    real(rt)         :: dum, dvm, dptotm
 
-    double precision :: rho_ref, u_ref, v_ref, p_ref, rhoe_g_ref, h_g_ref
-    double precision :: tau_ref
-    double precision :: ptot_ref
+    real(rt)         :: rho_ref, u_ref, v_ref, p_ref, rhoe_g_ref, h_g_ref
+    real(rt)         :: tau_ref
+    real(rt)         :: ptot_ref
 
-    double precision :: gam_ref, game_ref, gfactor
+    real(rt)         :: gam_ref, game_ref, gfactor
 
-    double precision :: alpham, alphap, alpha0r, alpha0e_g
+    real(rt)         :: alpham, alphap, alpha0r, alpha0e_g
 
-    double precision :: tau_s, e_s
+    real(rt)         :: tau_s, e_s
 
-    double precision, dimension(0:ngroups-1) :: er, der, alphar, qrtmp,hr
-    double precision, dimension(0:ngroups-1) :: lam0, lamp, lamm
+    real(rt)        , dimension(0:ngroups-1) :: er, der, alphar, qrtmp,hr
+    real(rt)        , dimension(0:ngroups-1) :: lam0, lamp, lamm
 
-    double precision, dimension(0:ngroups-1) :: er_ref
+    real(rt)        , dimension(0:ngroups-1) :: er_ref
 
 
-    double precision :: er_foo
+    real(rt)         :: er_foo
 
     if (ppm_type == 0) then
        print *,'Oops -- shouldnt be in tracexy_ppm with ppm_type = 0'
@@ -1057,6 +1059,7 @@ contains
     use rad_params_module, only : ngroups
     use bl_constants_module
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer, intent(in) :: qd_lo(3), qd_hi(3)
@@ -1064,28 +1067,28 @@ contains
     integer, intent(in) :: ilo1, ilo2, ihi1, ihi2
     integer, intent(in) :: km, kc, k3d
 
-    double precision, intent(in) ::     q(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),NQ)
-    double precision, intent(in) ::  qaux(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),NQAUX)
-    double precision, intent(in) :: flatn(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3))
+    real(rt)        , intent(in) ::     q(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),NQ)
+    real(rt)        , intent(in) ::  qaux(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),NQAUX)
+    real(rt)        , intent(in) :: flatn(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3))
 
-    double precision, intent(in) :: Ip(ilo1-1:ihi1+1,ilo2-1:ihi2+1,1:2,1:3,1:3,NQ)
-    double precision, intent(in) :: Im(ilo1-1:ihi1+1,ilo2-1:ihi2+1,1:2,1:3,1:3,NQ)
+    real(rt)        , intent(in) :: Ip(ilo1-1:ihi1+1,ilo2-1:ihi2+1,1:2,1:3,1:3,NQ)
+    real(rt)        , intent(in) :: Im(ilo1-1:ihi1+1,ilo2-1:ihi2+1,1:2,1:3,1:3,NQ)
 
-    double precision, intent(in) :: Ip_src(ilo1-1:ihi1+1,ilo2-1:ihi2+1,1:2,1:3,1:3,NQ)
-    double precision, intent(in) :: Im_src(ilo1-1:ihi1+1,ilo2-1:ihi2+1,1:2,1:3,1:3,NQ)
-
-
-    double precision, intent(inout) :: qzm(qs_lo(1):qs_hi(1),qs_lo(2):qs_hi(2),qs_lo(3):qs_hi(3),NQ)
-    double precision, intent(inout) :: qzp(qs_lo(1):qs_hi(1),qs_lo(2):qs_hi(2),qs_lo(3):qs_hi(3),NQ)
+    real(rt)        , intent(in) :: Ip_src(ilo1-1:ihi1+1,ilo2-1:ihi2+1,1:2,1:3,1:3,NQ)
+    real(rt)        , intent(in) :: Im_src(ilo1-1:ihi1+1,ilo2-1:ihi2+1,1:2,1:3,1:3,NQ)
 
 
-    double precision, intent(in) :: dt
+    real(rt)        , intent(inout) :: qzm(qs_lo(1):qs_hi(1),qs_lo(2):qs_hi(2),qs_lo(3):qs_hi(3),NQ)
+    real(rt)        , intent(inout) :: qzp(qs_lo(1):qs_hi(1),qs_lo(2):qs_hi(2),qs_lo(3):qs_hi(3),NQ)
+
+
+    real(rt)        , intent(in) :: dt
 
     !     Local variables
     integer :: i, j, g
     integer :: n, ipassive
 
-    double precision :: hdt
+    real(rt)         :: hdt
 
     ! To allow for easy integration of radiation, we adopt the
     ! following conventions:
@@ -1105,31 +1108,31 @@ contains
     ! for pure hydro, we will only consider:
     !   rho, u, v, w, ptot, rhoe_g, cc, h_g
 
-    double precision :: cc, csq, cgassq, Clag
-    double precision :: rho, u, v, w, p, rhoe_g, h_g, tau
-    double precision :: ptot, gam_g, game
+    real(rt)         :: cc, csq, cgassq, Clag
+    real(rt)         :: rho, u, v, w, p, rhoe_g, h_g, tau
+    real(rt)         :: ptot, gam_g, game
 
-    double precision :: drho, dptot, drhoe_g
-    double precision :: de, dge, dtau
-    double precision :: dwp, dptotp
-    double precision :: dwm, dptotm
+    real(rt)         :: drho, dptot, drhoe_g
+    real(rt)         :: de, dge, dtau
+    real(rt)         :: dwp, dptotp
+    real(rt)         :: dwm, dptotm
 
-    double precision :: rho_ref, w_ref, p_ref, rhoe_g_ref, h_g_ref
-    double precision :: tau_ref
-    double precision :: ptot_ref
+    real(rt)         :: rho_ref, w_ref, p_ref, rhoe_g_ref, h_g_ref
+    real(rt)         :: tau_ref
+    real(rt)         :: ptot_ref
 
-    double precision :: gam_g_ref, game_ref, gfactor
+    real(rt)         :: gam_g_ref, game_ref, gfactor
 
-    double precision :: alpham, alphap, alpha0r, alpha0e_g
+    real(rt)         :: alpham, alphap, alpha0r, alpha0e_g
 
-    double precision :: tau_s, e_s
+    real(rt)         :: tau_s, e_s
 
-    double precision, dimension(0:ngroups-1) :: er, der, alphar, qrtmp,hr
-    double precision, dimension(0:ngroups-1) :: lam0, lamp, lamm
+    real(rt)        , dimension(0:ngroups-1) :: er, der, alphar, qrtmp,hr
+    real(rt)        , dimension(0:ngroups-1) :: lam0, lamp, lamm
 
-    double precision, dimension(0:ngroups-1) :: er_ref
+    real(rt)        , dimension(0:ngroups-1) :: er_ref
 
-    double precision :: er_foo
+    real(rt)         :: er_foo
 
     if (ppm_type == 0) then
        print *,'Oops -- shouldnt be in tracez_ppm with ppm_type = 0'

--- a/Source/Radiation/RadSrc_nd/RadDerive_nd.f90
+++ b/Source/Radiation/RadSrc_nd/RadDerive_nd.f90
@@ -11,17 +11,18 @@
         use rad_params_module, only: hplanck, mev2erg
         use rad_params_module, only: radtoE
 
+        use bl_fort_module, only : rt => c_real
         implicit none
 
         integer n_lo(3),n_hi(3),nv
         integer d_lo(3),d_hi(3),ncomp
         integer lo(3), hi(3), domlo(3), domhi(3)
-        double precision neut(n_lo(1):n_hi(1),n_lo(2):n_hi(2),n_lo(3):n_hi(3),nv)
-        double precision dat(d_lo(1):d_hi(1),d_lo(2):d_hi(2),d_lo(3):d_hi(3),ncomp)
-        double precision dx(3), xlo(3), time, dt
+        real(rt)         neut(n_lo(1):n_hi(1),n_lo(2):n_hi(2),n_lo(3):n_hi(3),nv)
+        real(rt)         dat(d_lo(1):d_hi(1),d_lo(2):d_hi(2),d_lo(3):d_hi(3),ncomp)
+        real(rt)         dx(3), xlo(3), time, dt
         integer bc(3,2,ncomp), level, grid_no
 
-        double precision :: spectrum_energy_factor
+        real(rt)         :: spectrum_energy_factor
         integer          :: i,j,k,n
 
         spectrum_energy_factor = radtoE / (hplanck / mev2erg)
@@ -50,19 +51,20 @@
         use rad_params_module, only: hplanck, avogadro
         use rad_params_module, only: radtoE
 
+        use bl_fort_module, only : rt => c_real
         implicit none
 
         integer y_lo(3),y_hi(3),nv
         integer d_lo(3),d_hi(3),ncomp
         integer lo(3), hi(3), domlo(3), domhi(3)
-        double precision rhoyl(y_lo(1):y_hi(1),y_lo(2):y_hi(2),y_lo(3):y_hi(3),nv)
-        double precision dat(d_lo(1):d_hi(1),d_lo(2):d_hi(2),d_lo(3):d_hi(3),ncomp)
-        double precision dx(3), xlo(3), time, dt
+        real(rt)         rhoyl(y_lo(1):y_hi(1),y_lo(2):y_hi(2),y_lo(3):y_hi(3),nv)
+        real(rt)         dat(d_lo(1):d_hi(1),d_lo(2):d_hi(2),d_lo(3):d_hi(3),ncomp)
+        real(rt)         dx(3), xlo(3), time, dt
         integer bc(3,2,ncomp), level, grid_no
 
         integer          :: i,j,k,n
 
-        double precision :: fac
+        real(rt)         :: fac
 
         fac = radtoE / (hplanck * avogadro)
 
@@ -94,19 +96,20 @@
         use rad_params_module, only: hplanck, avogadro
         use rad_params_module, only: radtoE
 
+        use bl_fort_module, only : rt => c_real
         implicit none
 
         integer y_lo(3),y_hi(3),nv
         integer d_lo(3),d_hi(3),ncomp
         integer lo(3), hi(3), domlo(3), domhi(3)
-        double precision yl(y_lo(1):y_hi(1),y_lo(2):y_hi(2),y_lo(3):y_hi(3),nv)
-        double precision dat(d_lo(1):d_hi(1),d_lo(2):d_hi(2),d_lo(3):d_hi(3),ncomp)
-        double precision dx(3), xlo(3), time, dt
+        real(rt)         yl(y_lo(1):y_hi(1),y_lo(2):y_hi(2),y_lo(3):y_hi(3),nv)
+        real(rt)         dat(d_lo(1):d_hi(1),d_lo(2):d_hi(2),d_lo(3):d_hi(3),ncomp)
+        real(rt)         dx(3), xlo(3), time, dt
         integer bc(3,2,ncomp), level, grid_no
 
         integer          :: i,j,k,n
 
-        double precision :: fac
+        real(rt)         :: fac
 
         fac = radtoE / (hplanck * avogadro)
 
@@ -139,19 +142,20 @@
         use rad_params_module, only: hplanck, avogadro
         use rad_params_module, only: radtoE
 
+        use bl_fort_module, only : rt => c_real
         implicit none
 
         integer y_lo(3),y_hi(3),nv
         integer d_lo(3),d_hi(3),ncomp
         integer lo(3), hi(3), domlo(3), domhi(3)
-        double precision y(y_lo(1):y_hi(1),y_lo(2):y_hi(2),y_lo(3):y_hi(3),nv)
-        double precision dat(d_lo(1):d_hi(1),d_lo(2):d_hi(2),d_lo(3):d_hi(3),ncomp)
-        double precision dx(3), xlo(3), time, dt
+        real(rt)         y(y_lo(1):y_hi(1),y_lo(2):y_hi(2),y_lo(3):y_hi(3),nv)
+        real(rt)         dat(d_lo(1):d_hi(1),d_lo(2):d_hi(2),d_lo(3):d_hi(3),ncomp)
+        real(rt)         dx(3), xlo(3), time, dt
         integer bc(3,2,ncomp), level, grid_no
 
         integer          :: i,j,k,n
 
-        double precision :: fac
+        real(rt)         :: fac
 
         fac = radtoE / (hplanck * avogadro)
 
@@ -159,7 +163,7 @@
         do j = lo(2),hi(2)
         do i = lo(1),hi(1)
 
-           y(i,j,k,1) = 0.d0
+           y(i,j,k,1) = 0.e0_rt
            do n = 0, ng0-1
               y(i,j,k,1) = y(i,j,k,1) + fac * dat(i,j,k,3+n) / nugroup(n)
            enddo
@@ -181,19 +185,20 @@
         use rad_params_module, only: hplanck, avogadro
         use rad_params_module, only: radtoE
 
+        use bl_fort_module, only : rt => c_real
         implicit none
 
         integer y_lo(3),y_hi(3),nv
         integer d_lo(3),d_hi(3),ncomp
         integer lo(3), hi(3), domlo(3), domhi(3)
-        double precision y(y_lo(1):y_hi(1),y_lo(2):y_hi(2),y_lo(3):y_hi(3),nv)
-        double precision dat(d_lo(1):d_hi(1),d_lo(2):d_hi(2),d_lo(3):d_hi(3),ncomp)
-        double precision dx(3), xlo(3), time, dt
+        real(rt)         y(y_lo(1):y_hi(1),y_lo(2):y_hi(2),y_lo(3):y_hi(3),nv)
+        real(rt)         dat(d_lo(1):d_hi(1),d_lo(2):d_hi(2),d_lo(3):d_hi(3),ncomp)
+        real(rt)         dx(3), xlo(3), time, dt
         integer bc(3,2,ncomp), level, grid_no
 
         integer          :: i,j,k,n
 
-        double precision :: fac
+        real(rt)         :: fac
 
         fac = radtoE / (hplanck * avogadro)
 
@@ -201,7 +206,7 @@
         do j = lo(2),hi(2)
         do i = lo(1),hi(1)
 
-           y(i,j,k,1) = 0.d0
+           y(i,j,k,1) = 0.e0_rt
            do n = ng0, ng0 + ng1 - 1
               y(i,j,k,1) = y(i,j,k,1) + fac * dat(i,j,k,3+n) / nugroup(n)
            enddo
@@ -221,14 +226,15 @@
 
         use rad_params_module, only: radtoE
 
+        use bl_fort_module, only : rt => c_real
         implicit none
 
         integer Et_lo(3),Et_hi(3),ncomp_Et
         integer Er_lo(3),Er_hi(3),ncomp_Er
         integer lo(3), hi(3), domlo(3), domhi(3)
-        double precision Et(Et_lo(1):Et_hi(1),Et_lo(2):Et_hi(2),Et_lo(3):Et_hi(3),ncomp_Et)
-        double precision Er(Er_lo(1):Er_hi(1),Er_lo(2):Er_hi(2),Er_lo(3):Er_hi(3),ncomp_Er)
-        double precision dx(3), xlo(3), time, dt
+        real(rt)         Et(Et_lo(1):Et_hi(1),Et_lo(2):Et_hi(2),Et_lo(3):Et_hi(3),ncomp_Et)
+        real(rt)         Er(Er_lo(1):Er_hi(1),Er_lo(2):Er_hi(2),Er_lo(3):Er_hi(3),ncomp_Er)
+        real(rt)         dx(3), xlo(3), time, dt
         integer bc(3,2,ncomp_Er), level, grid_no
       
         integer :: i, j, k, g
@@ -236,7 +242,7 @@
         do k = lo(3), hi(3)
            do j = lo(2), hi(2)
               do i = lo(1), hi(1)
-                 Et(i,j,k,1) = 0.d0
+                 Et(i,j,k,1) = 0.e0_rt
               end do
            end do
         end do
@@ -261,15 +267,16 @@
 
         use rad_params_module, only: radtoE, ng0
 
+        use bl_fort_module, only : rt => c_real
         implicit none
 
         integer Enue_lo(3),Enue_hi(3),ncomp_Enue
         integer Er_lo(3),Er_hi(3),ncomp_Er
         integer lo(3), hi(3), domlo(3), domhi(3)
-        double precision Enue(Enue_lo(1):Enue_hi(1),Enue_lo(2):Enue_hi(2),Enue_lo(3):Enue_hi(3),&
+        real(rt)         Enue(Enue_lo(1):Enue_hi(1),Enue_lo(2):Enue_hi(2),Enue_lo(3):Enue_hi(3),&
              ncomp_Enue)
-        double precision Er(Er_lo(1):Er_hi(1),Er_lo(2):Er_hi(2),Er_lo(3):Er_hi(3),ncomp_Er)
-        double precision dx(3), xlo(3), time, dt
+        real(rt)         Er(Er_lo(1):Er_hi(1),Er_lo(2):Er_hi(2),Er_lo(3):Er_hi(3),ncomp_Er)
+        real(rt)         dx(3), xlo(3), time, dt
         integer bc(3,2,ncomp_Er), level, grid_no
       
         integer :: i, j, k, g
@@ -277,7 +284,7 @@
         do k = lo(3), hi(3)
            do j = lo(2), hi(2)
               do i = lo(1), hi(1)
-                 Enue(i,j,k,1) = 0.d0
+                 Enue(i,j,k,1) = 0.e0_rt
               end do
            end do
         end do
@@ -302,15 +309,16 @@
 
         use rad_params_module, only: radtoE, ng0, ng1
 
+        use bl_fort_module, only : rt => c_real
         implicit none
 
         integer Enuae_lo(3),Enuae_hi(3),ncomp_Enuae
         integer Er_lo(3),Er_hi(3),ncomp_Er
         integer lo(3), hi(3), domlo(3), domhi(3)
-        double precision Enuae(Enuae_lo(1):Enuae_hi(1),Enuae_lo(2):Enuae_hi(2),Enuae_lo(3):Enuae_hi(3),&
+        real(rt)         Enuae(Enuae_lo(1):Enuae_hi(1),Enuae_lo(2):Enuae_hi(2),Enuae_lo(3):Enuae_hi(3),&
              ncomp_Enuae)
-        double precision Er(Er_lo(1):Er_hi(1),Er_lo(2):Er_hi(2),Er_lo(3):Er_hi(3),ncomp_Er)
-        double precision dx(3), xlo(3), time, dt
+        real(rt)         Er(Er_lo(1):Er_hi(1),Er_lo(2):Er_hi(2),Er_lo(3):Er_hi(3),ncomp_Er)
+        real(rt)         dx(3), xlo(3), time, dt
         integer bc(3,2,ncomp_Er), level, grid_no
       
         integer :: i, j, k, g
@@ -318,7 +326,7 @@
         do k = lo(3), hi(3)
            do j = lo(2), hi(2)
               do i = lo(1), hi(1)
-                 Enuae(i,j,k,1) = 0.d0
+                 Enuae(i,j,k,1) = 0.e0_rt
               end do
            end do
         end do

--- a/Source/Radiation/RadSrc_nd/RadHydro_nd.f90
+++ b/Source/Radiation/RadSrc_nd/RadHydro_nd.f90
@@ -1,31 +1,33 @@
 module radhydro_nd_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, parameter :: rk_order = 3
   logical, parameter :: use_WENO = .false.
 
-  double precision, parameter :: cfl = 0.5d0
+  real(rt)        , parameter :: cfl = 0.5e0_rt
 
-  double precision, parameter :: onethird=1.d0/3.d0, twothirds=2.d0/3.d0, onesixth=1.d0/6.d0
+  real(rt)        , parameter :: onethird=1.e0_rt/3.e0_rt, twothirds=2.e0_rt/3.e0_rt, onesixth=1.e0_rt/6.e0_rt
 
   ! RK5
-  double precision, parameter :: B1=0.5d0, B2=1.d0/16.d0, B3=0.5d0, B4=9.d0/16.d0, &
-       B5=8.d0/7.d0, B6=7.d0/90.d0
-  double precision, parameter :: C20=5.d0/8.d0 , C21=3.d0/8.d0
-  double precision, parameter :: C40=17.d0/8.d0 , C41=9.d0/8.d0 , C42=-3.d0 , C43=0.75d0
-  double precision, parameter :: C50=-5.d0/21.d0 , C51=2.d0/7.d0 , C52=0.d0 , &
-       C53=4.d0 , C54=-64.d0/21.d0
-  double precision, parameter :: C60=-8.d0/27.d0 , C61=-1.d0/5.d0 , C62=32.d0/45.d0 , &
-       C63=-32.d0/45.d0, C64=32.d0/27.d0 , C65=14.d0/45.d0
+  real(rt)        , parameter :: B1=0.5e0_rt, B2=1.e0_rt/16.e0_rt, B3=0.5e0_rt, B4=9.e0_rt/16.e0_rt, &
+       B5=8.e0_rt/7.e0_rt, B6=7.e0_rt/90.e0_rt
+  real(rt)        , parameter :: C20=5.e0_rt/8.e0_rt , C21=3.e0_rt/8.e0_rt
+  real(rt)        , parameter :: C40=17.e0_rt/8.e0_rt , C41=9.e0_rt/8.e0_rt , C42=-3.e0_rt , C43=0.75e0_rt
+  real(rt)        , parameter :: C50=-5.e0_rt/21.e0_rt , C51=2.e0_rt/7.e0_rt , C52=0.e0_rt , &
+       C53=4.e0_rt , C54=-64.e0_rt/21.e0_rt
+  real(rt)        , parameter :: C60=-8.e0_rt/27.e0_rt , C61=-1.e0_rt/5.e0_rt , C62=32.e0_rt/45.e0_rt , &
+       C63=-32.e0_rt/45.e0_rt, C64=32.e0_rt/27.e0_rt , C65=14.e0_rt/45.e0_rt
 
   contains
 
     subroutine advect_in_fspace(ustar, af, dt, nstep_fsp)
       use rad_params_module, only : ngroups, nnuspec, ng0, ng1, dlognu
-      double precision, intent(inout) :: ustar(0:ngroups-1)
-      double precision, intent(in) :: af(0:ngroups-1)
-      double precision, intent(in) :: dt
+      use bl_fort_module, only : rt => c_real
+      real(rt)        , intent(inout) :: ustar(0:ngroups-1)
+      real(rt)        , intent(in) :: af(0:ngroups-1)
+      real(rt)        , intent(in) :: dt
       integer, intent(inout) :: nstep_fsp
       integer :: ng2
 
@@ -60,19 +62,20 @@ module radhydro_nd_module
     end subroutine advect_in_fspace
 
     subroutine update_one_species(n, u, a, dx, tend, nstepmax)
+      use bl_fort_module, only : rt => c_real
       integer, intent(in) :: n
-      double precision, intent(inout) :: u(0:n-1)
-      double precision, intent(in) :: a(0:n-1), dx(0:n-1)
-      double precision, intent(in) :: tend
+      real(rt)        , intent(inout) :: u(0:n-1)
+      real(rt)        , intent(in) :: a(0:n-1), dx(0:n-1)
+      real(rt)        , intent(in) :: tend
       integer, intent(inout) :: nstepmax
 
-      double precision :: dt, acfl
-      double precision :: f(0:n), u1(0:n-1), u2(0:n-1), u3(0:n-1), u4(0:n-1), u5(0:n-1)
+      real(rt)         :: dt, acfl
+      real(rt)         :: f(0:n), u1(0:n-1), u2(0:n-1), u3(0:n-1), u4(0:n-1), u5(0:n-1)
       integer :: i, istep, nstep
 
-      dt = 1.d50
+      dt = 1.e50_rt
       do i=0, n-1
-         acfl = 1.d-50 + abs(a(i))
+         acfl = 1.e-50_rt + abs(a(i))
          dt = min(dt, dx(i)/acfl*cfl)
       end do
 
@@ -96,14 +99,14 @@ module radhydro_nd_module
                  + B6 * dt * dudt(u5,a,dx,n)
          else if (rk_order .eq. 4) then
             ! RK4
-            u1 = u + 0.5d0*dt*dudt(u,a,dx,n)
-            u2 = u + 0.5d0*dt*dudt(u1,a,dx,n)
+            u1 = u + 0.5e0_rt*dt*dudt(u,a,dx,n)
+            u2 = u + 0.5e0_rt*dt*dudt(u1,a,dx,n)
             u3 = u + dt*dudt(u2,a,dx,n)
-            u = onethird*(u1+2.d0*u2+u3-u) + onesixth*dt*dudt(u3,a,dx,n)
+            u = onethird*(u1+2.e0_rt*u2+u3-u) + onesixth*dt*dudt(u3,a,dx,n)
          else if (rk_order .eq. 3) then
             ! RK3
             u1 = u + dt * dudt(u,a,dx,n)
-            u1 = 0.75d0*u + 0.25d0*(u1 + dt*dudt(u1,a,dx,n))
+            u1 = 0.75e0_rt*u + 0.25e0_rt*(u1 + dt*dudt(u1,a,dx,n))
             u = onethird*u + twothirds*(u1 + dt*dudt(u1,a,dx,n))
          else
             ! first-order
@@ -116,14 +119,15 @@ module radhydro_nd_module
     end subroutine update_one_species
 
     function dudt(u,a,dx,n)
+      use bl_fort_module, only : rt => c_real
       integer, intent(in) :: n
-      double precision, intent(in) :: u(0:n-1), a(0:n-1), dx(0:n-1)
-      double precision :: dudt(0:n-1)
+      real(rt)        , intent(in) :: u(0:n-1), a(0:n-1), dx(0:n-1)
+      real(rt)         :: dudt(0:n-1)
 
       integer :: i
-      double precision :: f(0:n), ag(-2:n+1), ug(-2:n+1)
-      double precision :: ul, ur, al, ar, fl, fr, r, a_plus, a_minus
-      double precision :: fg(-2:n+1), fp(5), fm(5), fpw, fmw, alpha
+      real(rt)         :: f(0:n), ag(-2:n+1), ug(-2:n+1)
+      real(rt)         :: ul, ur, al, ar, fl, fr, r, a_plus, a_minus
+      real(rt)         :: fg(-2:n+1), fp(5), fm(5), fpw, fmw, alpha
 
       if (use_WENO) then
 
@@ -142,16 +146,16 @@ module radhydro_nd_module
          fg = ag*ug
          ag = abs(ag)
 
-         f(0) = 0.d0
+         f(0) = 0.e0_rt
          do i=1,n-1
             alpha = maxval(ag(i-3:i+2))
-            fp = 0.5d0 * (fg(i-3:i+1) + alpha*ug(i-3:i+1))
-            fm = 0.5d0 * (fg(i-2:i+2) - alpha*ug(i-2:i+2))
+            fp = 0.5e0_rt * (fg(i-3:i+1) + alpha*ug(i-3:i+1))
+            fm = 0.5e0_rt * (fg(i-2:i+2) - alpha*ug(i-2:i+2))
             call weno5(fp(1),fp(2),fp(3),fp(4),fp(5),fpw)
             call weno5(fm(5),fm(4),fm(3),fm(2),fm(1),fmw)
             f(i) = fpw + fmw
          end do
-         f(n) = 0.d0
+         f(n) = 0.e0_rt
 
       else
 
@@ -163,30 +167,30 @@ module radhydro_nd_module
          ug(0:n-1) = u(0:n-1)
          ug(n) = u(n-1)
 
-         f(0) = 0.d0
+         f(0) = 0.e0_rt
          do i=1,n-1
-            r = (ug(i-1)-ug(i-2)) / (ug(i)-ug(i-1) + 1.d-50)
-            ul = ug(i-1) + 0.5d0 * (ug(i)-ug(i-1)) * MC(r)
+            r = (ug(i-1)-ug(i-2)) / (ug(i)-ug(i-1) + 1.e-50_rt)
+            ul = ug(i-1) + 0.5e0_rt * (ug(i)-ug(i-1)) * MC(r)
 
-            r = (ag(i-1)-ag(i-2)) / (ag(i)-ag(i-1) + 1.d-50)
-            al = ag(i-1) + 0.5d0 * (ag(i)-ag(i-1)) * MC(r)
+            r = (ag(i-1)-ag(i-2)) / (ag(i)-ag(i-1) + 1.e-50_rt)
+            al = ag(i-1) + 0.5e0_rt * (ag(i)-ag(i-1)) * MC(r)
 
             fl = al*ul
 
-            r = (ug(i) - ug(i-1)) / (ug(i+1) - ug(i) + 1.d-50)
-            ur = ug(i) - 0.5d0 * (ug(i+1) - ug(i)) * MC(r)
+            r = (ug(i) - ug(i-1)) / (ug(i+1) - ug(i) + 1.e-50_rt)
+            ur = ug(i) - 0.5e0_rt * (ug(i+1) - ug(i)) * MC(r)
 
-            r = (ag(i) - ag(i-1)) / (ag(i+1) - ag(i) + 1.d-50)
-            ar = ag(i) - 0.5d0 * (ag(i+1) - ag(i)) * MC(r)
+            r = (ag(i) - ag(i-1)) / (ag(i+1) - ag(i) + 1.e-50_rt)
+            ar = ag(i) - 0.5e0_rt * (ag(i+1) - ag(i)) * MC(r)
 
             fr = ar*ur
 
-            a_plus = max(0.d0, al, ar)
-            a_minus = max(0.d0, -al, -ar)
+            a_plus = max(0.e0_rt, al, ar)
+            a_minus = max(0.e0_rt, -al, -ar)
             f(i) = (a_plus*fl + a_minus*fr - a_plus*a_minus*(ur-ul)) &
-                 / (a_plus + a_minus + 1.d-50)
+                 / (a_plus + a_minus + 1.e-50_rt)
          end do
-         f(n) = 0.d0
+         f(n) = 0.e0_rt
 
       end if
 
@@ -197,67 +201,69 @@ module radhydro_nd_module
     end function dudt
 
     ! function dm3(x,y,z)
-    !   double precision :: x, y, z, dm3
-    !   dm3 = 0.25d0 * (sign(1.0d0,x)+sign(1.0d0,y)) * abs(sign(1.0d0,x)+sign(1.0d0,z)) &
+    !   real(rt)         :: x, y, z, dm3
+    !   dm3 = 0.25e0_rt * (sign(1.0e0_rt,x)+sign(1.0e0_rt,y)) * abs(sign(1.0e0_rt,x)+sign(1.0e0_rt,z)) &
     !        * min(abs(x),abs(y),abs(z))
     ! end function dm3
 
     ! function superbee(r)
-    !   double precision, intent(in) :: r
-    !   double precision :: superbee
-    !   superbee = max(0.d0, min(2.d0*r,1.d0), min(r,2.d0))
+    !   real(rt)        , intent(in) :: r
+    !   real(rt)         :: superbee
+    !   superbee = max(0.e0_rt, min(2.e0_rt*r,1.e0_rt), min(r,2.e0_rt))
     ! end function superbee
 
     function MC(r)
-      double precision, intent(in) :: r
-      double precision :: MC
-      MC = max(0.d0, min(2.d0*r, 0.5d0*(1.d0+r), 2.d0))
+      use bl_fort_module, only : rt => c_real
+      real(rt)        , intent(in) :: r
+      real(rt)         :: MC
+      MC = max(0.e0_rt, min(2.e0_rt*r, 0.5e0_rt*(1.e0_rt+r), 2.e0_rt))
     end function MC
 
     ! function minmod(r)
-    !   double precision, intent(in) :: r
-    !   double precision :: minmod
-    !   minmod = max(0.d0, min(1.d0, r))
+    !   real(rt)        , intent(in) :: r
+    !   real(rt)         :: minmod
+    !   minmod = max(0.e0_rt, min(1.e0_rt, r))
     ! end function MINMOD
 
     subroutine weno5(vm2, vm1, v, vp1, vp2, v_weno5)
 
+      use bl_fort_module, only : rt => c_real
       implicit none
 
-      double precision, intent(in) :: vm2, vm1, v, vp1, vp2
-      double precision, intent(out) :: v_weno5
+      real(rt)        , intent(in) :: vm2, vm1, v, vp1, vp2
+      real(rt)        , intent(out) :: v_weno5
 
-      double precision, parameter :: epsw=1.0d-6, b1=13.d0/12.d0, b2=1.d0/6.d0
+      real(rt)        , parameter :: epsw=1.0e-6_rt, b1=13.e0_rt/12.e0_rt, b2=1.e0_rt/6.e0_rt
 
-      double precision :: djm1, ejm1, dj, ej, djp1, ejp1, dis0, dis1, dis2, &
+      real(rt)         :: djm1, ejm1, dj, ej, djp1, ejp1, dis0, dis1, dis2, &
            q30, q31, q32, d01, d02, a1ba0, a2ba0, w0, w1, w2
 
-      djm1 = vm2 - 2.d0*vm1 + v
-      ejm1 = vm2 - 4.d0*vm1 + 3.d0*v
-      dj   = vm1 - 2.d0*v + vp1
+      djm1 = vm2 - 2.e0_rt*vm1 + v
+      ejm1 = vm2 - 4.e0_rt*vm1 + 3.e0_rt*v
+      dj   = vm1 - 2.e0_rt*v + vp1
       ej   = vm1 - vp1
-      djp1 = v - 2.d0*vp1 + vp2
-      ejp1 = 3.d0*v - 4.d0*vp1 + vp2
+      djp1 = v - 2.e0_rt*vp1 + vp2
+      ejp1 = 3.e0_rt*v - 4.e0_rt*vp1 + vp2
 
-      dis0 = b1*djm1*djm1 + 0.25d0*ejm1*ejm1 + epsw
-      dis1 = b1*dj*dj     + 0.25d0*ej*ej     + epsw
-      dis2 = b1*djp1*djp1 + 0.25d0*ejp1*ejp1 + epsw
+      dis0 = b1*djm1*djm1 + 0.25e0_rt*ejm1*ejm1 + epsw
+      dis1 = b1*dj*dj     + 0.25e0_rt*ej*ej     + epsw
+      dis2 = b1*djp1*djp1 + 0.25e0_rt*ejp1*ejp1 + epsw
 
-      q30 = 2.d0*vm2 - 7.d0*vm1 + 11.d0*v
-      q31 = -vm1 + 5.d0*v + 2.d0*vp1
-      q32 = 2.d0*v + 5.d0*vp1 - vp2
+      q30 = 2.e0_rt*vm2 - 7.e0_rt*vm1 + 11.e0_rt*v
+      q31 = -vm1 + 5.e0_rt*v + 2.e0_rt*vp1
+      q32 = 2.e0_rt*v + 5.e0_rt*vp1 - vp2
 
       d01 = dis0 / dis1
       d02 = dis0 / dis2
-      a1ba0 = 6.d0 * d01 * d01
-      a2ba0 = 3.d0 * d02 * d02
-      w0 = 1.d0 / (1.d0 + a1ba0 + a2ba0)
+      a1ba0 = 6.e0_rt * d01 * d01
+      a2ba0 = 3.e0_rt * d02 * d02
+      w0 = 1.e0_rt / (1.e0_rt + a1ba0 + a2ba0)
       w1 = a1ba0 * w0
-      w2 = 1.d0 - w0 - w1
+      w2 = 1.e0_rt - w0 - w1
 
-      if (w0.lt.1.0d-10) w0 = 0.d0
-      if (w1.lt.1.0d-10) w1 = 0.d0
-      if (w2.lt.1.0d-10) w2 = 0.d0
+      if (w0.lt.1.0e-10_rt) w0 = 0.e0_rt
+      if (w1.lt.1.0e-10_rt) w1 = 0.e0_rt
+      if (w2.lt.1.0e-10_rt) w2 = 0.e0_rt
 
       v_weno5 = b2*(w0*q30 + w1*q31 + w2*q32)
 
@@ -270,59 +276,60 @@ module radhydro_nd_module
       ! reference: Larsen, Levermore, Pomraning, and Sanderson, 1985, JCP, 61, 359
       use rad_params_module, only : ngroups, xnu, nugroup, dlognu
       use fundamental_constants_module, only : k_B, m_e, c_light, hplanck
-      double precision, intent(in) :: temp, ks, dt
-      double precision, intent(inout) :: u(ngroups)
+      use bl_fort_module, only : rt => c_real
+      real(rt)        , intent(in) :: temp, ks, dt
+      real(rt)        , intent(inout) :: u(ngroups)
       integer, intent(in), optional :: pt_index(:)
 
       integer :: i
-      double precision :: theta, sigmadt
+      real(rt)         :: theta, sigmadt
       integer :: N, NRHS, LDB, INFO
-      double precision :: DL(ngroups-1), D(ngroups), DU(ngroups-1)
-      double precision :: B(ngroups,1)
-      double precision :: ah(2:ngroups), uxh(2:ngroups), bh(2:ngroups), cc(ngroups)
+      real(rt)         :: DL(ngroups-1), D(ngroups), DU(ngroups-1)
+      real(rt)         :: B(ngroups,1)
+      real(rt)         :: ah(2:ngroups), uxh(2:ngroups), bh(2:ngroups), cc(ngroups)
 
-      double precision, save :: tfac, gamma
-      double precision, allocatable, save :: x(:), xh(:), dlognuinv(:)
+      real(rt)        , save :: tfac, gamma
+      real(rt)        , allocatable, save :: x(:), xh(:), dlognuinv(:)
       logical, save :: first_call = .true.
 !$omp threadprivate(tfac,gamma,x,xh,dlognuinv,first_call)
 
       if (first_call) then
          first_call = .false.
          tfac = k_B/(m_e*c_light**2)
-         gamma = hplanck**2/(8.d0*3.141596565968186d0*(m_e*c_light)**3)
+         gamma = hplanck**2/(8.e0_rt*3.141596565968186e0_rt*(m_e*c_light)**3)
          allocate(x(ngroups))
          allocate(xh(2:ngroups))
          allocate(dlognuinv(ngroups))
          x = nugroup(0:ngroups-1) * (hplanck/(m_e*c_light**2))
          xh = xnu(1:ngroups-1) * (hplanck/(m_e*c_light**2))
-         dlognuinv = 1.d0/dlognu
+         dlognuinv = 1.e0_rt/dlognu
       end if
 
       theta = temp*tfac
       sigmadt = ks*c_light*dt
 
       do i = 2, ngroups
-         uxh(i) = 0.5d0*(u(i-1)/x(i-1)+u(i)/x(i))
-         bh(i) = exp(min(150.d0,(x(i)-x(i-1))/theta))
-         ah(i) = sigmadt*(xh(i)**2+gamma*uxh(i))**2 / (bh(i)-1.d0)
+         uxh(i) = 0.5e0_rt*(u(i-1)/x(i-1)+u(i)/x(i))
+         bh(i) = exp(min(150.e0_rt,(x(i)-x(i-1))/theta))
+         ah(i) = sigmadt*(xh(i)**2+gamma*uxh(i))**2 / (bh(i)-1.e0_rt)
       end do
 
       do i = 1, ngroups
-         cc(i) = 1.d0 / (x(i)**3+gamma*u(i))
+         cc(i) = 1.e0_rt / (x(i)**3+gamma*u(i))
       end do
 
       B(:,1) = u
       i = 1
-      D (i  ) = 1.d0 + dlognuinv(i)*cc(i  )*ah(i+1)
+      D (i  ) = 1.e0_rt + dlognuinv(i)*cc(i  )*ah(i+1)
       DU(i  ) =       -dlognuinv(i)*cc(i+1)*ah(i+1)*bh(i+1)
       do i = 2, ngroups-1
          DL(i-1) =       -dlognuinv(i)*cc(i-1)*ah(i)
-         D (i  ) = 1.d0 + dlognuinv(i)*cc(i  )*(ah(i)*bh(i)+ah(i+1))
+         D (i  ) = 1.e0_rt + dlognuinv(i)*cc(i  )*(ah(i)*bh(i)+ah(i+1))
          DU(i  ) =       -dlognuinv(i)*cc(i+1)*ah(i+1)*bh(i+1)
       end do
       i = ngroups
       DL(i-1) =       -dlognuinv(i)*cc(i-1)*ah(i)
-      D (i  ) = 1.d0 + dlognuinv(i)*cc(i  )*ah(i)*bh(i)
+      D (i  ) = 1.e0_rt + dlognuinv(i)*cc(i  )*ah(i)*bh(i)
 
       ! if (pt_index(1) .eq. 32) then
       !    print *, 'DL = ', DL

--- a/Source/Radiation/RadSrc_nd/Rad_nd.f90
+++ b/Source/Radiation/RadSrc_nd/Rad_nd.f90
@@ -16,9 +16,10 @@ subroutine ca_initradconstants(p, c, h, k, s, a, m, J_is_used) bind(C, name="ca_
   use rad_params_module, only: radtoE  !, radtoJ, Etorad, radfluxtoF
   use rad_params_module, only: etafactor
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
-  double precision p, c, h, k, s, a, m
+  real(rt)         p, c, h, k, s, a, m
   integer J_is_used
 
   c = c_fcm
@@ -26,7 +27,7 @@ subroutine ca_initradconstants(p, c, h, k, s, a, m, J_is_used) bind(C, name="ca_
   k = k_fcm
   s = s_fcm
   a = a_fcm
-  m = 1.d6 * ev2erg_fcm
+  m = 1.e6_rt * ev2erg_fcm
 
   pi       = p
   clight   = c
@@ -37,20 +38,20 @@ subroutine ca_initradconstants(p, c, h, k, s, a, m, J_is_used) bind(C, name="ca_
   avogadro = a
   mev2erg  = m
   Hz2MeV   = h / m
-  tiny     = 1.d-50
+  tiny     = 1.e-50_rt
 
   if (J_is_used > 0) then
-     radtoE = 4.d0*pi/clight
-     !           radtoJ = 1.0d0
-     !           Etorad = 1.d0/radtoE
-     !           radfluxtoF = 4.d0*pi
-     etafactor = 1.d0
+     radtoE = 4.e0_rt*pi/clight
+     !           radtoJ = 1.0e0_rt
+     !           Etorad = 1.e0_rt/radtoE
+     !           radfluxtoF = 4.e0_rt*pi
+     etafactor = 1.e0_rt
   else
-     radtoE = 1.0d0
-     !           radtoJ = clight/(4.d0*pi)
-     !           Etorad = 1.0d0
-     !           radfluxtoF = 1.d0
-     etafactor = 4.d0*pi/clight
+     radtoE = 1.0e0_rt
+     !           radtoJ = clight/(4.e0_rt*pi)
+     !           Etorad = 1.0e0_rt
+     !           radfluxtoF = 1.e0_rt
+     etafactor = 4.e0_rt*pi/clight
   end if
 
 end subroutine ca_initradconstants
@@ -59,6 +60,7 @@ end subroutine ca_initradconstants
 subroutine ca_initsinglegroup(ngr) bind(C, name="ca_initsinglegroup")
 
   use rad_params_module, only : ngroups, nugroup, dnugroup, ng0, ng1
+  use bl_fort_module, only : rt => c_real
   implicit none
   integer ngr
 
@@ -73,8 +75,8 @@ subroutine ca_initsinglegroup(ngr) bind(C, name="ca_initsinglegroup")
   allocate(dnugroup(0:ngroups-1))
 
   do i = 0, ngroups-1
-     nugroup(i)  = 1.d0  ! dummy
-     dnugroup(i) = 1.d0
+     nugroup(i)  = 1.e0_rt  ! dummy
+     dnugroup(i) = 1.e0_rt
   enddo
 end subroutine ca_initsinglegroup
 
@@ -89,9 +91,10 @@ subroutine ca_initgroups(nugr, dnugr, ngr, ngr0, ngr1)
 
   use rad_params_module, only: ngroups, ng0, ng1, nugroup, dnugroup
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
-  double precision nugr(0:ngr-1), dnugr(0:ngr-1)
+  real(rt)         nugr(0:ngr-1), dnugr(0:ngr-1)
   integer ngr, ngr0, ngr1
 
   ! Local variables
@@ -115,9 +118,10 @@ subroutine ca_initgroups2(nugr, dnugr, xnugr, ngr)
 
   use rad_params_module, only: ngroups, nugroup, dnugroup, xnu, dlognu, lognugroup
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
-  double precision, intent(in) :: nugr(0:ngr-1), dnugr(0:ngr-1), xnugr(0:ngr)
+  real(rt)        , intent(in) :: nugr(0:ngr-1), dnugr(0:ngr-1), xnugr(0:ngr)
   integer ngr
 
   ! Local variables
@@ -146,9 +150,10 @@ subroutine ca_initgroups3(nugr, dnugr, dlognugr, xnugr, ngr, ngr0, ngr1)
   use rad_params_module, only: ngroups, ng0, ng1, nnuspec, nradspec, nugroup, dnugroup, &
        xnu, dlognu, lognugroup, erg2rhoYe, avogadro, hplanck
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
-  double precision, intent(in) :: nugr(0:ngr-1), dnugr(0:ngr-1), dlognugr(0:ngr-1), xnugr(0:ngr+2)
+  real(rt)        , intent(in) :: nugr(0:ngr-1), dnugr(0:ngr-1), dlognugr(0:ngr-1), xnugr(0:ngr+2)
   integer ngr, ngr0, ngr1
 
   ! Local variables
@@ -185,11 +190,11 @@ subroutine ca_initgroups3(nugr, dnugr, dlognugr, xnugr, ngr, ngr0, ngr1)
   dlognu(:) = dlognugr(:)
   lognugroup(:) = log(nugroup)
 
-  erg2rhoYe = 0.d0
+  erg2rhoYe = 0.e0_rt
   if (ng0 > 0) then
-     erg2rhoYe(0:ng0-1) = 1.d0 / (avogadro*hplanck*nugroup(0:ng0-1))
+     erg2rhoYe(0:ng0-1) = 1.e0_rt / (avogadro*hplanck*nugroup(0:ng0-1))
      if (ng1 > 0) then
-        erg2rhoYe(ng0:ng0+ng1-1) = -1.d0 / (avogadro*hplanck*nugroup(ng0:ng0+ng1-1))
+        erg2rhoYe(ng0:ng0+ng1-1) = -1.e0_rt / (avogadro*hplanck*nugroup(ng0:ng0+ng1-1))
      end if
   end if
 
@@ -201,6 +206,7 @@ subroutine ca_setgroup(igroup)
 
   use rad_params_module, only: current_group
 
+  use bl_fort_module, only : rt => c_real
   implicit none
   integer igroup
 
@@ -220,18 +226,19 @@ subroutine ca_inelastic_sct (lo, hi, &
   use rad_params_module, only : ngroups, nugroup, dlognu
   use radhydro_nd_module, only: inelastic_scatter
 
+  use bl_fort_module, only : rt => c_real
   integer, intent(in) :: lo(3), hi(3)
   integer, intent(in) :: uu_l1,uu_l2,uu_l3,uu_h1,uu_h2,uu_h3
   integer, intent(in) :: Er_l1,Er_l2,Er_l3,Er_h1,Er_h2,Er_h3
   integer, intent(in) :: ks_l1,ks_l2,ks_l3,ks_h1,ks_h2,ks_h3
-  double precision, intent(inout) :: uu(uu_l1:uu_h1,uu_l2:uu_h2,uu_l3:uu_h3,NVAR)
-  double precision, intent(inout) :: Er(Er_l1:Er_h1,Er_l2:Er_h2,Er_l3:Er_h3,0:ngroups-1)
-  double precision, intent(in   ) :: ks(ks_l1:ks_h1,ks_l2:ks_h2,ks_l3:ks_h3)
-  double precision, intent(in) :: dt
+  real(rt)        , intent(inout) :: uu(uu_l1:uu_h1,uu_l2:uu_h2,uu_l3:uu_h3,NVAR)
+  real(rt)        , intent(inout) :: Er(Er_l1:Er_h1,Er_l2:Er_h2,Er_l3:Er_h3,0:ngroups-1)
+  real(rt)        , intent(in   ) :: ks(ks_l1:ks_h1,ks_l2:ks_h2,ks_l3:ks_h3)
+  real(rt)        , intent(in) :: dt
 
   integer :: i, j, k
-  double precision :: Ertotold, Ertmp(0:ngroups-1), dEr
-  double precision :: Erscale(0:ngroups-1)
+  real(rt)         :: Ertotold, Ertmp(0:ngroups-1), dEr
+  real(rt)         :: Erscale(0:ngroups-1)
 
   Erscale = nugroup*dlognu
 
@@ -266,16 +273,17 @@ subroutine ca_compute_scattering(lo, hi, &
   use network, only : naux
   use meth_params_module, only : NVAR, URHO, UTEMP, UFX
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: lo(3), hi(3)
   integer, intent(in) :: kps_l1,kps_l2,kps_l3,kps_h1,kps_h2,kps_h3
   integer, intent(in) :: sta_l1,sta_l2,sta_l3,sta_h1,sta_h2,sta_h3
-  double precision, intent(inout) :: kps(kps_l1:kps_h1,kps_l2:kps_h2,kps_l3:kps_h3)
-  double precision, intent(in   ) :: sta(sta_l1:sta_h1,sta_l2:sta_h2,sta_l3:sta_h3,NVAR)
+  real(rt)        , intent(inout) :: kps(kps_l1:kps_h1,kps_l2:kps_h2,kps_l3:kps_h3)
+  real(rt)        , intent(in   ) :: sta(sta_l1:sta_h1,sta_l2:sta_h2,sta_l3:sta_h3,NVAR)
 
   integer :: i, j, k
-  double precision :: kp, kr, nu, rho, temp, Ye
+  real(rt)         :: kp, kr, nu, rho, temp, Ye
   logical, parameter :: comp_kp = .true.
   logical, parameter :: comp_kr = .true.
 
@@ -292,12 +300,12 @@ subroutine ca_compute_scattering(lo, hi, &
            if (naux > 0) then
               Ye = sta(i,j,k,UFX)
            else
-              Ye = 0.d0
+              Ye = 0.e0_rt
            end if
 
            call get_opacities(kp, kr, rho, temp, Ye, nu, comp_kp, comp_kr)
 
-           kps(i,j,k) = max(kr - kp, 0.d0)
+           kps(i,j,k) = max(kr - kp, 0.e0_rt)
         end do
      end do
   end do
@@ -314,25 +322,26 @@ subroutine ca_compute_scattering_2(lo, hi, &
   use rad_params_module, only : ngroups, nugroup
   use meth_params_module, only : NVAR, URHO, UTEMP
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: lo(3), hi(3)
   integer, intent(in) :: kps_l1,kps_l2,kps_l3,kps_h1,kps_h2,kps_h3
   integer, intent(in) :: sta_l1,sta_l2,sta_l3,sta_h1,sta_h2,sta_h3
-  double precision, intent(inout) :: kps(kps_l1:kps_h1,kps_l2:kps_h2,kps_l3:kps_h3)
-  double precision, intent(in   ) :: sta(sta_l1:sta_h1,sta_l2:sta_h2,sta_l3:sta_h3,NVAR)
-  double precision, intent(in) :: k0_p, m_p, n_p
-  double precision, intent(in) :: k0_r, m_r, n_r
-  double precision, intent(in) :: Tfloor, kfloor
+  real(rt)        , intent(inout) :: kps(kps_l1:kps_h1,kps_l2:kps_h2,kps_l3:kps_h3)
+  real(rt)        , intent(in   ) :: sta(sta_l1:sta_h1,sta_l2:sta_h2,sta_l3:sta_h3,NVAR)
+  real(rt)        , intent(in) :: k0_p, m_p, n_p
+  real(rt)        , intent(in) :: k0_r, m_r, n_r
+  real(rt)        , intent(in) :: Tfloor, kfloor
 
   integer :: i, j, k
-  double precision, parameter :: tiny = 1.0d-50
-  double precision :: Teff, k_p, k_r
+  real(rt)        , parameter :: tiny = 1.0e-50_rt
+  real(rt)         :: Teff, k_p, k_r
 
   ! scattering is assumed to be independent of nu.
 
-  if ( m_p.eq.0.d0 .and. n_p.eq.0.d0 .and. &
-       m_r.eq.0.d0 .and. n_r.eq.0.d0 ) then
+  if ( m_p.eq.0.e0_rt .and. n_p.eq.0.e0_rt .and. &
+       m_r.eq.0.e0_rt .and. n_r.eq.0.e0_rt ) then
      do k = lo(3), hi(3)
         do j = lo(2), hi(2)
            do i = lo(1), hi(1)
@@ -363,6 +372,7 @@ subroutine init_godunov_indices_rad() bind(C)
        QU, QV, QW
   use rad_params_module, only: ngroups
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   ngdnv = 6 + 2*ngroups

--- a/Source/Radiation/RadSrc_nd/blackbody.f90
+++ b/Source/Radiation/RadSrc_nd/blackbody.f90
@@ -6,22 +6,23 @@ module blackbody_module
 
   use fundamental_constants_module, only : a_rad, k_B, hplanck
 
+  use bl_fort_module, only : rt => c_real
   implicit none
   
-  double precision, parameter :: pi = 3.1415926535897932384626d0
-  double precision :: bk_const = a_rad * 15.d0/pi**4
+  real(rt)        , parameter :: pi = 3.1415926535897932384626e0_rt
+  real(rt)         :: bk_const = a_rad * 15.e0_rt/pi**4
   !                            = 8 * pi * k**4 / (c**3 * h**3)
-  double precision :: magic_const = pi**4/15.d0
+  real(rt)         :: magic_const = pi**4/15.e0_rt
   integer, parameter :: Ncoefs = 8
-  double precision, dimension(0:Ncoefs) :: coefs =  &
-       (/ 1.d0/60.d0, -1.d0/5040.d0, 1.d0/272160.d0, -1.d0/13305600.d0, &
-       1.d0/622702080.d0, -691.d0/19615115520000.d0, 1.d0/1270312243200.d0,  &
-       -3617.d0/202741834014720000.d0, 43867.d0/107290978560589824000.d0 /)
-  double precision, parameter :: tol = 1.0d-10
+  real(rt)        , dimension(0:Ncoefs) :: coefs =  &
+       (/ 1.e0_rt/60.e0_rt, -1.e0_rt/5040.e0_rt, 1.e0_rt/272160.e0_rt, -1.e0_rt/13305600.e0_rt, &
+       1.e0_rt/622702080.e0_rt, -691.e0_rt/19615115520000.e0_rt, 1.e0_rt/1270312243200.e0_rt,  &
+       -3617.e0_rt/202741834014720000.e0_rt, 43867.e0_rt/107290978560589824000.e0_rt /)
+  real(rt)        , parameter :: tol = 1.0e-10_rt
 
-  double precision, parameter :: xmagic = 2.061981d0
-  double precision, parameter :: xsmall = 1.d-5
-  double precision, parameter :: xlarge = 100.d0
+  real(rt)        , parameter :: xmagic = 2.061981e0_rt
+  real(rt)        , parameter :: xsmall = 1.e-5_rt
+  real(rt)        , parameter :: xlarge = 100.e0_rt
   
   private
   public :: BdBdTIndefInteg, BIndefInteg, BGroup
@@ -29,41 +30,43 @@ module blackbody_module
   contains
 
     subroutine BdBdTIndefInteg(T, nu, B, dBdT)
-      double precision, intent(in) :: T, nu
-      double precision, intent(out) :: B, dBdT
-      double precision :: x, integ, part
+      use bl_fort_module, only : rt => c_real
+      real(rt)        , intent(in) :: T, nu
+      real(rt)        , intent(out) :: B, dBdT
+      real(rt)         :: x, integ, part
       
       x = hplanck*nu/(k_B*T)
 
       if (x .gt. xlarge) then
          B = a_rad * T**4
-         dBdT = 4.d0 * a_rad * T**3
+         dBdT = 4.e0_rt * a_rad * T**3
       else if ( x .lt. xsmall) then
-         B = 0.d0
-         dBdT = 0.d0
+         B = 0.e0_rt
+         dBdT = 0.e0_rt
       else
          if (x .gt. xmagic) then
             integ = integlarge(x)
          else
             integ = integsmall(x)
          end if
-         part = x**4/(exp(x) - 1.d0)
+         part = x**4/(exp(x) - 1.e0_rt)
          B = bk_const*T**4 * integ
          dBdT = bk_const*T**3 * (4.*integ - part)
       end if
     end subroutine BdBdTIndefInteg
 
     function BIndefInteg(T, nu)
-      double precision BIndefInteg
-      double precision, intent(in) :: T, nu
-      double precision :: x, integ
+      use bl_fort_module, only : rt => c_real
+      real(rt)         BIndefInteg
+      real(rt)        , intent(in) :: T, nu
+      real(rt)         :: x, integ
       
       x = hplanck*nu/(k_B*T)
 
       if (x .gt. xlarge) then
          BIndefInteg = a_rad * T**4
       else if ( x .lt. xsmall) then
-         BIndefInteg = 0.d0
+         BIndefInteg = 0.e0_rt
       else
          if (x .gt. xmagic) then
             integ = integlarge(x)
@@ -75,15 +78,17 @@ module blackbody_module
     end function BIndefInteg
 
     function BGroup(T, nu0, nu1)
-      double precision BGroup
-      double precision, intent(in) :: T, nu0, nu1
+      use bl_fort_module, only : rt => c_real
+      real(rt)         BGroup
+      real(rt)        , intent(in) :: T, nu0, nu1
       BGroup = BIndefInteg(T,nu1) - BIndefInteg(T,nu0)
     end function BGroup
     
     function Li(n, z)
+      use bl_fort_module, only : rt => c_real
       integer, intent(in) :: n
-      double precision, intent(in) :: z
-      double precision :: Li, t
+      real(rt)        , intent(in) :: z
+      real(rt)         :: Li, t
       integer :: k
       integer, parameter :: kmax = 18
       Li = z
@@ -97,22 +102,24 @@ module blackbody_module
     end function Li
 
     function integlarge(x)
-      double precision, intent(in) :: x
-      double precision :: integlarge, z
+      use bl_fort_module, only : rt => c_real
+      real(rt)        , intent(in) :: x
+      real(rt)         :: integlarge, z
       z = exp(-x)
       integlarge = magic_const & 
-           - (x**3 * Li(1,z) + 3.d0 * x**2 * Li(2,z) &
-           + 6.d0* x * Li(3,z) + 6.d0 * Li(4,z))
+           - (x**3 * Li(1,z) + 3.e0_rt * x**2 * Li(2,z) &
+           + 6.e0_rt* x * Li(3,z) + 6.e0_rt * Li(4,z))
     end function integlarge
 
     function integsmall(x)
-      double precision, intent(in) :: x
-      double precision :: integsmall, t
+      use bl_fort_module, only : rt => c_real
+      real(rt)        , intent(in) :: x
+      real(rt)         :: integsmall, t
       integer :: i
-      double precision :: x2, x3, xfoo
+      real(rt)         :: x2, x3, xfoo
       x2 = x**2
       x3 = x**3
-      integsmall = x3/3.d0 - x2**2/8.d0
+      integsmall = x3/3.e0_rt - x2**2/8.e0_rt
       xfoo = x3
       do i = 0, Ncoefs
          xfoo = xfoo * x2

--- a/Source/Radiation/RadSrc_nd/filter.f90
+++ b/Source/Radiation/RadSrc_nd/filter.f90
@@ -3,65 +3,66 @@
 module filter_module
 
   ! 3-point filter: T=1, R=S=0
-  double precision, dimension(0:1), parameter :: ff1 = &
-       (/ 0.5d0, 0.25d0 /)
+  use bl_fort_module, only : rt => c_real
+  real(rt)        , dimension(0:1), parameter :: ff1 = &
+       (/ 0.5e0_rt, 0.25e0_rt /)
   ! For boundary cell
-  double precision, dimension(0:1), parameter :: ff1b = &
-       (/ 0.75d0, 0.25d0 /)
+  real(rt)        , dimension(0:1), parameter :: ff1b = &
+       (/ 0.75e0_rt, 0.25e0_rt /)
   
 
   ! 5-point filter: T=2, R+S+1=T
   ! S = 0, 1
-  double precision, dimension(0:2,0:1), parameter :: ff2 = reshape( &
-       [ 0.625d0, 0.25d0, -0.0625d0, &
-       & 0.375d0, 0.25d0,  0.0625d0 ], &
+  real(rt)        , dimension(0:2,0:1), parameter :: ff2 = reshape( &
+       [ 0.625e0_rt, 0.25e0_rt, -0.0625e0_rt, &
+       & 0.375e0_rt, 0.25e0_rt,  0.0625e0_rt ], &
        [3,2] )
   ! For first bondary cell
-  double precision, dimension(0:2), parameter :: ff2b0 = & 
-       (/ 17.d0/16.d0, -2.d0/16.d0, 1.d0/16.d0 /)
+  real(rt)        , dimension(0:2), parameter :: ff2b0 = & 
+       (/ 17.e0_rt/16.e0_rt, -2.e0_rt/16.e0_rt, 1.e0_rt/16.e0_rt /)
   ! for second boundary cell
-  double precision, dimension(-1:2), parameter :: ff2b1 = & 
-       (/ -2.d0/16.d0, 21.d0/16.d0, -4.d0/16.d0, 1.d0/16.d0 /)
+  real(rt)        , dimension(-1:2), parameter :: ff2b1 = & 
+       (/ -2.e0_rt/16.e0_rt, 21.e0_rt/16.e0_rt, -4.e0_rt/16.e0_rt, 1.e0_rt/16.e0_rt /)
 
 
   ! 7-point filter: T=3, R+S+1=T
   ! S = 0, 1, 2
-  double precision, dimension(0:3,0:2), parameter :: ff3 = reshape( &
-       [ 44.d0/64.d0, 15.d0/64.d0, -6.d0/64.d0,  1.d0/64.d0, &
-       & 32.d0/64.d0, 18.d0/64.d0,  0.d0      , -2.d0/64.d0, &
-       & 20.d0/64.d0, 15.d0/64.d0,  6.d0/64.d0,  1.d0/64.d0 ], &
+  real(rt)        , dimension(0:3,0:2), parameter :: ff3 = reshape( &
+       [ 44.e0_rt/64.e0_rt, 15.e0_rt/64.e0_rt, -6.e0_rt/64.e0_rt,  1.e0_rt/64.e0_rt, &
+       & 32.e0_rt/64.e0_rt, 18.e0_rt/64.e0_rt,  0.e0_rt      , -2.e0_rt/64.e0_rt, &
+       & 20.e0_rt/64.e0_rt, 15.e0_rt/64.e0_rt,  6.e0_rt/64.e0_rt,  1.e0_rt/64.e0_rt ], &
        [4,3] ) 
   ! for boundary cells
-  double precision, dimension(0:3), parameter :: ff3b0 = & 
-       (/ 63.d0/64.d0, 3.d0/64.d0, -3.d0/64.d0, 1.d0/64.d0 /)
-  double precision, dimension(-1:3), parameter :: ff3b1 = & 
-       (/ 3.d0/64.d0, &
-       54.d0/64.d0, 12.d0/64.d0, -6.d0/64.d0, 1.d0/64.d0 /)
-  double precision, dimension(-2:3), parameter :: ff3b2 = & 
-       (/ -3.d0/64.d0, 12.d0/64.d0, &
-       45.d0/64.d0, 15.d0/64.d0, -6.d0/64.d0, 1.d0/64.d0 /)
+  real(rt)        , dimension(0:3), parameter :: ff3b0 = & 
+       (/ 63.e0_rt/64.e0_rt, 3.e0_rt/64.e0_rt, -3.e0_rt/64.e0_rt, 1.e0_rt/64.e0_rt /)
+  real(rt)        , dimension(-1:3), parameter :: ff3b1 = & 
+       (/ 3.e0_rt/64.e0_rt, &
+       54.e0_rt/64.e0_rt, 12.e0_rt/64.e0_rt, -6.e0_rt/64.e0_rt, 1.e0_rt/64.e0_rt /)
+  real(rt)        , dimension(-2:3), parameter :: ff3b2 = & 
+       (/ -3.e0_rt/64.e0_rt, 12.e0_rt/64.e0_rt, &
+       45.e0_rt/64.e0_rt, 15.e0_rt/64.e0_rt, -6.e0_rt/64.e0_rt, 1.e0_rt/64.e0_rt /)
   
 
   ! 9-point filter: T=4, R+S+1=T
   ! S = 0, 1, 2, 3
-  double precision, dimension(0:4,0:3), parameter :: ff4 = reshape( &
-       [ 186.d0/256.d0, 56.d0/256.d0, -28.d0/256.d0,  8.d0/256.d0, -1.d0/256.d0, &
-       & 146.d0/256.d0, 72.d0/256.d0, -12.d0/256.d0, -8.d0/256.d0,  3.d0/256.d0, &
-       & 110.d0/256.d0, 72.d0/256.d0,  12.d0/256.d0, -8.d0/256.d0, -3.d0/256.d0, &
-       &  70.d0/256.d0, 56.d0/256.d0,  28.d0/256.d0,  8.d0/256.d0,  1.d0/256.d0 ], &
+  real(rt)        , dimension(0:4,0:3), parameter :: ff4 = reshape( &
+       [ 186.e0_rt/256.e0_rt, 56.e0_rt/256.e0_rt, -28.e0_rt/256.e0_rt,  8.e0_rt/256.e0_rt, -1.e0_rt/256.e0_rt, &
+       & 146.e0_rt/256.e0_rt, 72.e0_rt/256.e0_rt, -12.e0_rt/256.e0_rt, -8.e0_rt/256.e0_rt,  3.e0_rt/256.e0_rt, &
+       & 110.e0_rt/256.e0_rt, 72.e0_rt/256.e0_rt,  12.e0_rt/256.e0_rt, -8.e0_rt/256.e0_rt, -3.e0_rt/256.e0_rt, &
+       &  70.e0_rt/256.e0_rt, 56.e0_rt/256.e0_rt,  28.e0_rt/256.e0_rt,  8.e0_rt/256.e0_rt,  1.e0_rt/256.e0_rt ], &
        [5,4] )
   ! for boundary cells
-  double precision, dimension(0:4), parameter :: ff4b0 = & 
-       (/ 257.d0/256.d0, -4.d0/256.d0, 6.d0/256.d0, -4.d0/256.d0, 1.d0/256.d0 /)
-  double precision, dimension(-1:4), parameter :: ff4b1 = & 
-       (/ -4.d0/256.d0,  &
-       273.d0/256.d0, -28.d0/256.d0, 22.d0/256.d0, -8.d0/256.d0, 1.d0/256.d0 /)
-  double precision, dimension(-2:4), parameter :: ff4b2 = & 
-       (/ 6.d0/256.d0, -28.d0/256.d0, &
-       309.d0/256.d0, -52.d0/256.d0, 28.d0/256.d0, -8.d0/256.d0, 1.d0/256.d0 /)
-  double precision, dimension(-3:4), parameter :: ff4b3 = & 
-       (/ -4.d0/256.d0, 22.d0/256.d0, -52.d0/256.d0, &
-       325.d0/256.d0, -56.d0/256.d0, 28.d0/256.d0, -8.d0/256.d0, 1.d0/256.d0 /)
+  real(rt)        , dimension(0:4), parameter :: ff4b0 = & 
+       (/ 257.e0_rt/256.e0_rt, -4.e0_rt/256.e0_rt, 6.e0_rt/256.e0_rt, -4.e0_rt/256.e0_rt, 1.e0_rt/256.e0_rt /)
+  real(rt)        , dimension(-1:4), parameter :: ff4b1 = & 
+       (/ -4.e0_rt/256.e0_rt,  &
+       273.e0_rt/256.e0_rt, -28.e0_rt/256.e0_rt, 22.e0_rt/256.e0_rt, -8.e0_rt/256.e0_rt, 1.e0_rt/256.e0_rt /)
+  real(rt)        , dimension(-2:4), parameter :: ff4b2 = & 
+       (/ 6.e0_rt/256.e0_rt, -28.e0_rt/256.e0_rt, &
+       309.e0_rt/256.e0_rt, -52.e0_rt/256.e0_rt, 28.e0_rt/256.e0_rt, -8.e0_rt/256.e0_rt, 1.e0_rt/256.e0_rt /)
+  real(rt)        , dimension(-3:4), parameter :: ff4b3 = & 
+       (/ -4.e0_rt/256.e0_rt, 22.e0_rt/256.e0_rt, -52.e0_rt/256.e0_rt, &
+       325.e0_rt/256.e0_rt, -56.e0_rt/256.e0_rt, 28.e0_rt/256.e0_rt, -8.e0_rt/256.e0_rt, 1.e0_rt/256.e0_rt /)
 
 
 end module filter_module

--- a/Source/Radiation/RadSrc_nd/fluxlimiter.f90
+++ b/Source/Radiation/RadSrc_nd/fluxlimiter.f90
@@ -1,16 +1,18 @@
 module fluxlimiter_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, save :: limiter = 0
   integer, save :: closure = 0
 
-  double precision, parameter :: OneThird = 1.d0/3.d0, TwoThirds=2.d0/3.d0, &
-       OneSixth=1.d0/6.d0, TwoNinths=2.d0/9.d0, FiveNinths=5.d0/9.d0
+  real(rt)        , parameter :: OneThird = 1.e0_rt/3.e0_rt, TwoThirds=2.e0_rt/3.e0_rt, &
+       OneSixth=1.e0_rt/6.e0_rt, TwoNinths=2.e0_rt/9.e0_rt, FiveNinths=5.e0_rt/9.e0_rt
 
   contains
 
     subroutine init_fluxlimiter_module(limiter_in, closure_in)
+      use bl_fort_module, only : rt => c_real
       implicit none
       integer, intent(in) :: limiter_in, closure_in
       limiter = limiter_in
@@ -18,9 +20,10 @@ module fluxlimiter_module
     end subroutine init_fluxlimiter_module
 
     function FLDlambda(r, limiter_in)
+      use bl_fort_module, only : rt => c_real
       integer, intent(in), optional :: limiter_in
-      double precision, intent(in) :: r
-      double precision :: FLDlambda
+      real(rt)        , intent(in) :: r
+      real(rt)         :: FLDlambda
       integer :: limiter_local
       if (present(limiter_in))then
          limiter_local = limiter_in
@@ -30,16 +33,16 @@ module fluxlimiter_module
       if (limiter_local .eq. 0) then ! no limiter
          FLDlambda = OneThird
       else if (limiter_local < 10) then  ! approximate LP, [123]
-         FLDlambda = (2.d0 + r) / (6.d0 + r * (3.d0 + r))
+         FLDlambda = (2.e0_rt + r) / (6.e0_rt + r * (3.e0_rt + r))
       else if (limiter_local < 20) then  ! Bruenn, 1[123]
-         FLDlambda = 1.d0 / (3.d0 + r)
+         FLDlambda = 1.e0_rt / (3.e0_rt + r)
       else if (limiter_local < 30) then  ! Larsen's square root, 2[123]
-         FLDlambda = 1.d0 / sqrt(9.d0 + r**2)
+         FLDlambda = 1.e0_rt / sqrt(9.e0_rt + r**2)
       else if (limiter_local < 40) then  ! Minerbo, 3[123]
-         if (r .lt. 1.5d0) then
-            FLDlambda = 2.d0/(3.d0 + sqrt(9.d0+12.d0*r**2))
+         if (r .lt. 1.5e0_rt) then
+            FLDlambda = 2.e0_rt/(3.e0_rt + sqrt(9.e0_rt+12.e0_rt*r**2))
          else 
-            FLDlambda = 1.d0/(1.d0+r+sqrt(1.d0+2.d0*r))
+            FLDlambda = 1.e0_rt/(1.e0_rt+r+sqrt(1.e0_rt+2.e0_rt*r))
          end if
       else
          print *, "Unknown limiter ", limiter_local
@@ -48,29 +51,30 @@ module fluxlimiter_module
     end function FLDlambda
 
     function Edd_factor(lambda) result(f)
-      double precision, intent(in) :: lambda
-      double precision :: f
+      use bl_fort_module, only : rt => c_real
+      real(rt)        , intent(in) :: lambda
+      real(rt)         :: f
       if (closure .eq. 0) then
          f = lambda
       else if (closure .eq. 1) then
          f = OneThird
       else if (closure .eq. 2) then
-         f = 1.d0 - 2.d0 * lambda
+         f = 1.e0_rt - 2.e0_rt * lambda
       else if (closure .eq. 3) then ! lambda + (lambda*R)**2
          if (limiter .eq. 0) then ! no limiter
             f = OneThird
          else if (limiter < 10) then  ! approximate LP, [123]
-            f = lambda + 0.25d0*((1.d0-3.d0*lambda) + &
-                 sqrt((1.d0-3.d0*lambda)*(1.d0+5.d0*lambda)))**2
+            f = lambda + 0.25e0_rt*((1.e0_rt-3.e0_rt*lambda) + &
+                 sqrt((1.e0_rt-3.e0_rt*lambda)*(1.e0_rt+5.e0_rt*lambda)))**2
          else if (limiter < 20) then  ! Bruenn, 1[123]
-            f = 1.0d0 - 5.d0*lambda + 9.d0*lambda**2
+            f = 1.0e0_rt - 5.e0_rt*lambda + 9.e0_rt*lambda**2
          else if (limiter < 30) then  ! Larsen's square root, 2[123]
-            f = 1.0d0 + lambda - 9.d0*lambda**2
+            f = 1.0e0_rt + lambda - 9.e0_rt*lambda**2
          else if (limiter < 40) then  ! Minerbo
             if (lambda .gt. TwoNinths) then
                f = OneThird
             else
-               f = 1.d0 + 3.d0*lambda - 2.d0*sqrt(2.d0*lambda)
+               f = 1.e0_rt + 3.e0_rt*lambda - 2.e0_rt*sqrt(2.e0_rt*lambda)
             end if
          else
             print *, "Unknown limiter ", limiter
@@ -80,17 +84,17 @@ module fluxlimiter_module
          if (limiter .eq. 0) then ! no limiter
             f = OneThird
          else if (limiter < 10) then  ! approximate LP, [123]
-            f = OneThird + OneSixth*((1.d0-3.d0*lambda) + &
-                 sqrt((1.d0-3.d0*lambda)*(1.d0+5.d0*lambda)))**2
+            f = OneThird + OneSixth*((1.e0_rt-3.e0_rt*lambda) + &
+                 sqrt((1.e0_rt-3.e0_rt*lambda)*(1.e0_rt+5.e0_rt*lambda)))**2
          else if (limiter < 20) then  ! Bruenn, 1[123]
-            f = OneThird + TwoThirds*(1.0d0 - 6.d0*lambda + 9.d0*lambda**2)
+            f = OneThird + TwoThirds*(1.0e0_rt - 6.e0_rt*lambda + 9.e0_rt*lambda**2)
          else if (limiter < 30) then  ! Larsen's square root, 2[123]
-            f = OneThird + TwoThirds*(1.0d0 - 9.d0*lambda**2)
+            f = OneThird + TwoThirds*(1.0e0_rt - 9.e0_rt*lambda**2)
          else if (limiter < 40) then  ! Minerbo
             if (lambda .gt. TwoNinths) then
                f = FiveNinths - TwoThirds*lambda
             else
-               f = OneThird + TwoThirds*(1.d0 + 2.d0*lambda - 2.d0*sqrt(2.d0*lambda))
+               f = OneThird + TwoThirds*(1.e0_rt + 2.e0_rt*lambda - 2.e0_rt*sqrt(2.e0_rt*lambda))
             end if
          else
             print *, "Unknown limiter ", limiter
@@ -100,35 +104,36 @@ module fluxlimiter_module
     end function Edd_factor
 
     function FLDalpha(lam) result(alpha)
-      double precision, intent(in) :: lam
-      double precision :: alpha, R, omtl, cr
-      omtl = max(0.d0, 1.d0-3.d0*lam)
+      use bl_fort_module, only : rt => c_real
+      real(rt)        , intent(in) :: lam
+      real(rt)         :: alpha, R, omtl, cr
+      omtl = max(0.e0_rt, 1.e0_rt-3.e0_rt*lam)
       if (limiter .eq. 0) then ! no limiter
-         R = 0.d0
+         R = 0.e0_rt
       else if (limiter < 10) then  ! approximate LP, [123]
-         R = (omtl + sqrt(omtl*(1.d0+5.d0*lam))) / (2.d0*lam+1.d-50)
+         R = (omtl + sqrt(omtl*(1.e0_rt+5.e0_rt*lam))) / (2.e0_rt*lam+1.e-50_rt)
       else if (limiter < 20) then  ! Bruenn, 1[123]
-         R =omtl/(lam+1.d-50)
+         R =omtl/(lam+1.e-50_rt)
       else if (limiter < 30) then  ! Larsen's square root, 2[123]
-         R = sqrt(omtl*(1.d0+3.d0*lam)) / (lam+1.d-50)
+         R = sqrt(omtl*(1.e0_rt+3.e0_rt*lam)) / (lam+1.e-50_rt)
       else if (limiter < 40) then  ! Minerbo
          if (lam .gt. TwoNinths) then
-            R = sqrt(omtl/3.d0) / (lam+1.d-50)
+            R = sqrt(omtl/3.e0_rt) / (lam+1.e-50_rt)
          else
-            R = 1.d0/(lam+1.d-50) - sqrt(2.d0/(lam+1.d-50))
+            R = 1.e0_rt/(lam+1.e-50_rt) - sqrt(2.e0_rt/(lam+1.e-50_rt))
          end if
       else
          print *, "Unknown limiter ", limiter
          stop
       endif
       
-      if (R .lt. 1.d-6) then
-         alpha = 0.25d0
-      else if ( R .gt. 300.d0) then
-         alpha = 0.5d0
+      if (R .lt. 1.e-6_rt) then
+         alpha = 0.25e0_rt
+      else if ( R .gt. 300.e0_rt) then
+         alpha = 0.5e0_rt
       else
          cr = cosh(R)
-         alpha = cr*log(cr) / (2.d0*R*sinh(R))
+         alpha = cr*log(cr) / (2.e0_rt*R*sinh(R))
       end if
     end function FLDalpha
 
@@ -136,6 +141,7 @@ end module fluxlimiter_module
 
 subroutine ca_initfluxlimiter(limiter, closure)  bind(C, name="ca_initfluxlimiter")
   use fluxlimiter_module, only : init_fluxlimiter_module
+  use bl_fort_module, only : rt => c_real
   implicit none
   integer, intent(in) :: limiter, closure
   call init_fluxlimiter_module(limiter, closure)

--- a/Source/Radiation/RadSrc_nd/kavg.F90
+++ b/Source/Radiation/RadSrc_nd/kavg.F90
@@ -1,29 +1,30 @@
 ! arithmetic average, geometrically correct(?) but underestimates surface flux
 
-#define tiny 1.d-50
+#define tiny 1.e-50_rt
 
-#define KAVG0(a,b) (0.5d0 * (a + b + tiny))
+#define KAVG0(a,b) (0.5e0_rt * (a + b + tiny))
 
 ! define KAVG(a,b,d) KAVG0(a,b)
 
 ! harmonic average, overestimates surface flux
 
-#define KAVG1(a,b) ((2.d0 * a * b) / (a + b + tiny) + tiny)
+#define KAVG1(a,b) ((2.e0_rt * a * b) / (a + b + tiny) + tiny)
 
 ! define KAVG(a,b,d) KAVG1(a,b)
 
 ! chooses arithmetic where optically thin, harmonic where optically thick,
 ! surface flux approximation at a thick/thin boundary
 
-#define KAVG2(a,b,d) min(KAVG0(a,b), max(KAVG1(a,b), 4.d0 / (3.d0 * d)))
+#define KAVG2(a,b,d) min(KAVG0(a,b), max(KAVG1(a,b), 4.e0_rt / (3.e0_rt * d)))
 
 ! define KAVG(a,b,d) KAVG2(a,b,d)
 
 #define KAVG(a,b,d) kavg(a,b,d,-1)
 
 real*8 function kavg(a, b, d, iopt)
+  use bl_fort_module, only : rt => c_real
   implicit none
-  real*8 :: a, b, d
+  real(rt)         :: a, b, d
   integer :: iopt
   integer, save :: opt=100
   if (iopt >= 0) then

--- a/Source/Radiation/RadSrc_nd/rad_params.f90
+++ b/Source/Radiation/RadSrc_nd/rad_params.f90
@@ -7,27 +7,29 @@
 module rad_params_module
 
   ! radiation energy group information
+  use bl_fort_module, only : rt => c_real
   integer         , save :: ngroups, current_group, ng0, ng1, nnuspec
   integer, save :: nradspec = 1
-  double precision, save, allocatable :: nugroup(:), dnugroup(:), xnu(:), dlognu(:), &
+  real(rt)        , save, allocatable :: nugroup(:), dnugroup(:), xnu(:), dlognu(:), &
        erg2rhoYe(:), lognugroup(:)
 
   ! physical constants used for radiation
-  double precision, save :: pi, clight, hplanck, kboltz, stefbol, arad, avogadro
-  double precision, save :: Hz2MeV, mev2erg, tiny
+  real(rt)        , save :: pi, clight, hplanck, kboltz, stefbol, arad, avogadro
+  real(rt)        , save :: Hz2MeV, mev2erg, tiny
 
   ! In our current solvers, E is stored in rad.  (In the past, J was stored.)
   ! So we use the following conversion factors to make sure the right variables are used
-  double precision, save :: radtoE  !, radtoJ, Etorad, radfluxtoF
-  double precision, save :: etafactor
+  real(rt)        , save :: radtoE  !, radtoJ, Etorad, radfluxtoF
+  real(rt)        , save :: etafactor
 
   ! (yes, I know pi isn't a physical constant)
   ! (stefbol is derived from the other constants)
-  ! (tiny a generic very small quantity without units, currently 1.d-50)
+  ! (tiny a generic very small quantity without units, currently 1.e-50_rt)
 
 contains
 
   function get_ispec(g) result(ispec)
+    use bl_fort_module, only : rt => c_real
     integer, intent(in) :: g
     integer ispec
 

--- a/Source/Radiation/RadSrc_nd/rad_util.f90
+++ b/Source/Radiation/RadSrc_nd/rad_util.f90
@@ -5,6 +5,7 @@ module rad_util_module
   use rad_params_module, only : ngroups
   use bl_constants_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
 contains
@@ -14,16 +15,17 @@ contains
     use meth_params_module, only : QPRES, QRHO, comoving, QRAD, QPTOT, QRADVAR
     use fluxlimiter_module, only : Edd_factor
 
-    real (kind=dp_t), intent(in) :: lam(0:ngroups-1)
-    real (kind=dp_t), intent(in) :: q(QRADVAR)
-    real (kind=dp_t), intent(in) :: cg
-    real (kind=dp_t), intent(out) :: ptot
-    real (kind=dp_t), intent(out) :: ctot
-    real (kind=dp_t), intent(out) :: gamc_tot
+    use bl_fort_module, only : rt => c_real
+    real(rt)        , intent(in) :: lam(0:ngroups-1)
+    real(rt)        , intent(in) :: q(QRADVAR)
+    real(rt)        , intent(in) :: cg
+    real(rt)        , intent(out) :: ptot
+    real(rt)        , intent(out) :: ctot
+    real(rt)        , intent(out) :: gamc_tot
 
     integer :: g
 
-    real (kind=dp_t) :: csrad2, Eddf, gamr, prad
+    real(rt)         :: csrad2, Eddf, gamr, prad
 
     csrad2 = ZERO
     prad = ZERO
@@ -51,33 +53,34 @@ contains
 
   function FLDlambda(r, limiter) result (lambda)
 
-    double precision :: r
+    use bl_fort_module, only : rt => c_real
+    real(rt)         :: r
     integer :: limiter
 
-    double precision :: lambda
+    real(rt)         :: lambda
 
     if (limiter .eq. 0) then
        ! no limiter
-       lambda = 1.d0/3.d0
+       lambda = 1.e0_rt/3.e0_rt
 
     else if (limiter < 10) then
        ! approximate LP
-       lambda = (2.d0 + r) / (6.d0 + r * (3.d0 + r))
+       lambda = (2.e0_rt + r) / (6.e0_rt + r * (3.e0_rt + r))
 
     else if (limiter < 20) then
        ! Bruenn
-       lambda = 1.d0 / (3.d0 + r)
+       lambda = 1.e0_rt / (3.e0_rt + r)
 
     else if (limiter < 30) then
        ! Larsen's square root
-       lambda = 1.d0 / sqrt(9.d0 + r**2)
+       lambda = 1.e0_rt / sqrt(9.e0_rt + r**2)
 
     else if (limiter < 40) then 
        ! Minerbo
-       if (r .lt. 1.5d0) then
-          lambda = 2.d0/(3.d0 + sqrt(9.d0+12.d0*r**2))
+       if (r .lt. 1.5e0_rt) then
+          lambda = 2.e0_rt/(3.e0_rt + sqrt(9.e0_rt+12.e0_rt*r**2))
        else 
-          lambda = 1.d0/(1.d0+r+sqrt(1.d0+2.d0*r))
+          lambda = 1.e0_rt/(1.e0_rt+r+sqrt(1.e0_rt+2.e0_rt*r))
        end if
 
     else

--- a/Source/Src_1d/Castro_1d.F90
+++ b/Source/Src_1d/Castro_1d.F90
@@ -43,6 +43,7 @@ subroutine ca_umdrv(is_finest_level, time, &
 #endif
   use advection_module  , only : umeth1d, consup
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: is_finest_level
@@ -66,39 +67,39 @@ subroutine ca_umdrv(is_finest_level, time, &
   integer, intent(in) :: dloga_l1, dloga_h1
   integer, intent(in) :: vol_l1, vol_h1
 
-  double precision, intent(in) ::      uin(  uin_l1:  uin_h1,NVAR)
-  double precision, intent(inout) ::  uout( uout_l1: uout_h1,NVAR)
-  double precision, intent(inout) ::     q(    q_l1:    q_h1,NQ)
-  double precision, intent(in) ::     qaux(   qa_l1:   qa_h1,NQAUX)
-  double precision, intent(in) ::     srcQ(  srQ_l1:  srQ_h1,QVAR)
-  double precision, intent(inout) :: update(updt_l1: updt_h1,NVAR)
-  double precision, intent(inout) ::  flux( flux_l1: flux_h1,NVAR)
+  real(rt)        , intent(in) ::      uin(  uin_l1:  uin_h1,NVAR)
+  real(rt)        , intent(inout) ::  uout( uout_l1: uout_h1,NVAR)
+  real(rt)        , intent(inout) ::     q(    q_l1:    q_h1,NQ)
+  real(rt)        , intent(in) ::     qaux(   qa_l1:   qa_h1,NQAUX)
+  real(rt)        , intent(in) ::     srcQ(  srQ_l1:  srQ_h1,QVAR)
+  real(rt)        , intent(inout) :: update(updt_l1: updt_h1,NVAR)
+  real(rt)        , intent(inout) ::  flux( flux_l1: flux_h1,NVAR)
 #ifdef RADIATION
-  double precision, intent(inout) :: Erout(Erout_l1:Erout_h1, 0:ngroups-1)
-  double precision, intent(inout) :: radflux(radflux_l1: radflux_h1, 0:ngroups-1)
-  double precision, intent(in) :: Erin( Erin_l1: Erin_h1, 0:ngroups-1)
+  real(rt)        , intent(inout) :: Erout(Erout_l1:Erout_h1, 0:ngroups-1)
+  real(rt)        , intent(inout) :: radflux(radflux_l1: radflux_h1, 0:ngroups-1)
+  real(rt)        , intent(in) :: Erin( Erin_l1: Erin_h1, 0:ngroups-1)
 #endif
-  double precision, intent(inout) :: pradial(  p_l1:   p_h1)
-  double precision, intent(in) :: area( area_l1: area_h1     )
-  double precision, intent(in) :: dloga(dloga_l1:dloga_h1     )
-  double precision, intent(in) ::   vol(  vol_l1: vol_h1      )
-  double precision, intent(in) :: delta(1), dt, time
-  double precision, intent(inout) :: courno
+  real(rt)        , intent(inout) :: pradial(  p_l1:   p_h1)
+  real(rt)        , intent(in) :: area( area_l1: area_h1     )
+  real(rt)        , intent(in) :: dloga(dloga_l1:dloga_h1     )
+  real(rt)        , intent(in) ::   vol(  vol_l1: vol_h1      )
+  real(rt)        , intent(in) :: delta(1), dt, time
+  real(rt)        , intent(inout) :: courno
 
-  double precision, intent(inout) :: E_added_flux, mass_added_flux
-  double precision, intent(inout) :: xmom_added_flux, ymom_added_flux, zmom_added_flux
-  double precision, intent(inout) :: mass_lost, xmom_lost, ymom_lost, zmom_lost
-  double precision, intent(inout) :: eden_lost, xang_lost, yang_lost, zang_lost
+  real(rt)        , intent(inout) :: E_added_flux, mass_added_flux
+  real(rt)        , intent(inout) :: xmom_added_flux, ymom_added_flux, zmom_added_flux
+  real(rt)        , intent(inout) :: mass_lost, xmom_lost, ymom_lost, zmom_lost
+  real(rt)        , intent(inout) :: eden_lost, xang_lost, yang_lost, zang_lost
 
   ! Automatic arrays for workspace
-  double precision, allocatable:: flatn(:)
-  double precision, allocatable:: div(:)
-  double precision, allocatable:: pdivu(:)
+  real(rt)        , allocatable:: flatn(:)
+  real(rt)        , allocatable:: div(:)
+  real(rt)        , allocatable:: pdivu(:)
 
   ! Edge-centered primitive variables (Riemann state)
-  double precision, allocatable :: q1(:,:)
+  real(rt)        , allocatable :: q1(:,:)
 
-  double precision :: dx
+  real(rt)         :: dx
 
   integer i,ngf, ngq
 
@@ -109,7 +110,7 @@ subroutine ca_umdrv(is_finest_level, time, &
   integer :: lo_3D(3), hi_3D(3)
   integer :: q_lo_3D(3), q_hi_3D(3)
   integer :: uin_lo_3D(3), uin_hi_3D(3)
-  double precision :: dx_3D(3)
+  real(rt)         :: dx_3D(3)
 
   uin_lo  = [uin_l1]
   uin_hi  = [uin_h1]

--- a/Source/Src_1d/Castro_advection_1d.F90
+++ b/Source/Src_1d/Castro_advection_1d.F90
@@ -2,6 +2,7 @@ module advection_module
 
   use bl_constants_module, only : ZERO, HALF, ONE, FOURTH
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   private
@@ -56,6 +57,7 @@ contains
     use meth_params_module, only : USHK
 #endif
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer, intent(in) :: lo(1),hi(1)
@@ -72,25 +74,25 @@ contains
     integer, intent(in) :: q1_l1, q1_h1
     integer, intent(in) :: ilo, ihi
 
-    double precision, intent(in) :: dx, dt
-    double precision, intent(in) :: q(   qd_l1:qd_h1,NQ)
-    double precision, intent(in) :: qaux(   qa_l1:qa_h1,NQAUX)
-    double precision, intent(in) :: flatn(   qd_l1:qd_h1)
-    double precision, intent(inout) :: uout(uout_l1:uout_h1,NVAR)
-    double precision, intent(inout) :: flux(fd_l1:fd_h1,NVAR)
+    real(rt)        , intent(in) :: dx, dt
+    real(rt)        , intent(in) :: q(   qd_l1:qd_h1,NQ)
+    real(rt)        , intent(in) :: qaux(   qa_l1:qa_h1,NQAUX)
+    real(rt)        , intent(in) :: flatn(   qd_l1:qd_h1)
+    real(rt)        , intent(inout) :: uout(uout_l1:uout_h1,NVAR)
+    real(rt)        , intent(inout) :: flux(fd_l1:fd_h1,NVAR)
 #ifdef RADIATION
-    double precision, intent(inout) :: rflux(rfd_l1:rfd_h1,0:ngroups-1)
+    real(rt)        , intent(inout) :: rflux(rfd_l1:rfd_h1,0:ngroups-1)
 #endif
-    double precision, intent(in) :: srcQ(src_l1  :src_h1,QVAR)
-    double precision, intent(inout) :: q1(q1_l1:q1_h1,NGDNV)
-    double precision, intent(in) :: dloga(dloga_l1:dloga_h1)
+    real(rt)        , intent(in) :: srcQ(src_l1  :src_h1,QVAR)
+    real(rt)        , intent(inout) :: q1(q1_l1:q1_h1,NGDNV)
+    real(rt)        , intent(in) :: dloga(dloga_l1:dloga_h1)
 
-    double precision, allocatable :: shk(:)
+    real(rt)        , allocatable :: shk(:)
 
     integer :: i
 
     ! Left and right state arrays (edge centered, cell centered)
-    double precision, allocatable:: dq(:,:), qm(:,:), qp(:,:)
+    real(rt)        , allocatable:: dq(:,:), qm(:,:), qp(:,:)
 
 
     allocate (shk(ilo-1:ihi+1))
@@ -218,6 +220,7 @@ contains
     use meth_params_module, only : USHK
 #endif
 
+    use bl_fort_module, only : rt => c_real
     integer, intent(in) :: lo(1), hi(1)
     integer, intent(in) :: uin_l1, uin_h1
     integer, intent(in) :: uout_l1, uout_h1
@@ -235,43 +238,43 @@ contains
     integer, intent(in) :: vol_l1,  vol_h1
     integer, intent(in) :: verbose
 
-    double precision, intent(in) :: uin(uin_l1:uin_h1,NVAR)
-    double precision, intent(in) :: uout(uout_l1:uout_h1,NVAR)
-    double precision, intent(inout) :: update(updt_l1:updt_h1,NVAR)
-    double precision, intent(in) :: q1(q1_l1:q1_h1,NGDNV)
-    double precision, intent(in) :: q(q_l1:q_h1,NQ)
-    double precision, intent(inout) :: flux(flux_l1:flux_h1,NVAR)
+    real(rt)        , intent(in) :: uin(uin_l1:uin_h1,NVAR)
+    real(rt)        , intent(in) :: uout(uout_l1:uout_h1,NVAR)
+    real(rt)        , intent(inout) :: update(updt_l1:updt_h1,NVAR)
+    real(rt)        , intent(in) :: q1(q1_l1:q1_h1,NGDNV)
+    real(rt)        , intent(in) :: q(q_l1:q_h1,NQ)
+    real(rt)        , intent(inout) :: flux(flux_l1:flux_h1,NVAR)
 #ifdef RADIATION
-    double precision, intent(in) :: Erin(Erin_l1:Erin_h1,0:ngroups-1)
-    double precision, intent(inout) :: Erout(Erout_l1:Erout_h1,0:ngroups-1)
-    double precision, intent(inout) :: rflux(rflux_l1:rflux_h1,0:ngroups-1)
+    real(rt)        , intent(in) :: Erin(Erin_l1:Erin_h1,0:ngroups-1)
+    real(rt)        , intent(inout) :: Erout(Erout_l1:Erout_h1,0:ngroups-1)
+    real(rt)        , intent(inout) :: rflux(rflux_l1:rflux_h1,0:ngroups-1)
 #endif
-    double precision, intent(in) :: area( area_l1: area_h1)
-    double precision, intent(in) :: vol(vol_l1:vol_h1)
-    double precision, intent(in) :: div(lo(1):hi(1)+1)
-    double precision, intent(in) :: pdivu(lo(1):hi(1)  )
-    double precision, intent(in) :: dx, dt
-    double precision, intent(inout) :: E_added_flux, mass_added_flux
-    double precision, intent(inout) :: xmom_added_flux, ymom_added_flux, zmom_added_flux
-    double precision, intent(inout) :: mass_lost, xmom_lost, ymom_lost, zmom_lost
-    double precision, intent(inout) :: eden_lost, xang_lost, yang_lost, zang_lost
+    real(rt)        , intent(in) :: area( area_l1: area_h1)
+    real(rt)        , intent(in) :: vol(vol_l1:vol_h1)
+    real(rt)        , intent(in) :: div(lo(1):hi(1)+1)
+    real(rt)        , intent(in) :: pdivu(lo(1):hi(1)  )
+    real(rt)        , intent(in) :: dx, dt
+    real(rt)        , intent(inout) :: E_added_flux, mass_added_flux
+    real(rt)        , intent(inout) :: xmom_added_flux, ymom_added_flux, zmom_added_flux
+    real(rt)        , intent(inout) :: mass_lost, xmom_lost, ymom_lost, zmom_lost
+    real(rt)        , intent(inout) :: eden_lost, xang_lost, yang_lost, zang_lost
 
     integer          :: i, j, k, n
-    double precision :: div1
+    real(rt)         :: div1
     integer          :: domlo(3), domhi(3)
-    double precision :: loc(3), ang_mom(3)
+    real(rt)         :: loc(3), ang_mom(3)
 #ifdef RADIATION
     integer :: g
-    double precision :: SrU, Up, SrE
+    real(rt)         :: SrU, Up, SrE
 
-    double precision, dimension(0:ngroups-1) :: Erscale
-    double precision, dimension(0:ngroups-1) :: ustar, af
-    double precision :: Eddf, Eddflft, Eddfrgt, f1, f2, f1lft, f1rgt
-    double precision :: ux, divu, dudx, Egdc, lamc
-    double precision :: dpdx, dprdx, ek1, ek2, dek
+    real(rt)        , dimension(0:ngroups-1) :: Erscale
+    real(rt)        , dimension(0:ngroups-1) :: ustar, af
+    real(rt)         :: Eddf, Eddflft, Eddfrgt, f1, f2, f1lft, f1rgt
+    real(rt)         :: ux, divu, dudx, Egdc, lamc
+    real(rt)         :: dpdx, dprdx, ek1, ek2, dek
 
-    double precision :: urho_new, umx_new1, umy_new1, umz_new1
-    double precision :: umx_new2, umy_new2, umz_new2
+    real(rt)         :: urho_new, umx_new1, umy_new1, umz_new1
+    real(rt)         :: umx_new2, umy_new2, umz_new2
 #endif
 
 #ifdef RADIATION
@@ -390,14 +393,14 @@ contains
        umx_new1 = uout(i,UMX) + dt * update(i,UMX)
        umy_new1 = uout(i,UMY) + dt * update(i,UMY)
        umz_new1 = uout(i,UMZ) + dt * update(i,UMZ)
-       ek1 = (umx_new1**2 + umy_new1**2 + umz_new1**2)/(2.d0*urho_new)
+       ek1 = (umx_new1**2 + umy_new1**2 + umz_new1**2)/(2.e0_rt*urho_new)
 
        ! now add the radiation pressure gradient
        update(i,UMX) = update(i,UMX) - dprdx
        umx_new2 = umx_new1 - dt * dprdx
        umy_new2 = umy_new1
        umz_new2 = umz_new1
-       ek2 = (umx_new2**2 + umy_new2**2 + umz_new2**2)/(2.d0*urho_new)
+       ek2 = (umx_new2**2 + umy_new2**2 + umz_new2**2)/(2.e0_rt*urho_new)
 
        dek = ek2 - ek1
 
@@ -424,7 +427,7 @@ contains
              lamc = HALF * (q1(i,GDLAMS+g) + q1(i+1,GDLAMS+g))
              Eddf = Edd_factor(lamc)
              f1 = (ONE - Eddf)*HALF
-             f2 = (3.d0*Eddf - ONE)*HALF
+             f2 = (3.e0_rt*Eddf - ONE)*HALF
              af(g) = -(f1*divu + f2*dudx)
 
              if (fspace_type .eq. 1) then

--- a/Source/Src_1d/GR_Gravity_1d.f90
+++ b/Source/Src_1d/GR_Gravity_1d.f90
@@ -13,23 +13,24 @@
       use network, only : nspec, naux
       use bl_constants_module, only: HALF, FOUR3RD, M_PI
 
+      use bl_fort_module, only : rt => c_real
       implicit none
 
       integer          :: lo(1),hi(1)
-      double precision :: dx(1),dr
-      double precision :: problo(1)
+      real(rt)         :: dx(1),dr
+      real(rt)         :: problo(1)
 
       integer          :: n1d,drdxfac,level
-      double precision :: radial_pres(0:n1d-1)
+      real(rt)         :: radial_pres(0:n1d-1)
 
       integer          :: r_l1,r_h1
-      double precision :: var(r_l1:r_h1,NVAR)
+      real(rt)         :: var(r_l1:r_h1,NVAR)
 
       integer          :: i,n,index
       integer          :: ii
-      double precision :: r
-      double precision :: fac,dx_frac,vol
-      double precision :: lo_i,rlo,rhi
+      real(rt)         :: r
+      real(rt)         :: fac,dx_frac,vol
+      real(rt)         :: lo_i,rlo,rhi
 
       type (eos_t) :: eos_state
 

--- a/Source/Src_1d/Gravity_1d.f90
+++ b/Source/Src_1d/Gravity_1d.f90
@@ -1,5 +1,6 @@
 module gravity_1D_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   public
@@ -13,18 +14,19 @@ contains
 
     use bl_constants_module
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer          :: lo(1),hi(1)
     integer          :: rhl1, rhh1
     integer          :: ecxl1, ecxh1
     integer          :: coord_type
-    double precision :: rhs(rhl1:rhh1)
-    double precision :: ecx(ecxl1:ecxh1)
-    double precision :: dx(1),problo(1)
+    real(rt)         :: rhs(rhl1:rhh1)
+    real(rt)         :: ecx(ecxl1:ecxh1)
+    real(rt)         :: dx(1),problo(1)
 
-    double precision :: lapphi
-    double precision :: rlo,rhi,rcen
+    real(rt)         :: lapphi
+    real(rt)         :: rlo,rhi,rcen
     integer          :: i
 
     ! Cartesian
@@ -75,24 +77,25 @@ contains
     use prob_params_module, only: center, Symmetry, physbc_lo, coord_type
     use meth_params_module, only: NVAR, URHO
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer          :: lo(1), hi(1)
-    double precision :: dx(1), dr
-    double precision :: problo(1)
+    real(rt)         :: dx(1), dr
+    real(rt)         :: problo(1)
 
     integer          :: n1d, drdxfac, level
-    double precision :: radial_mass(0:n1d-1)
-    double precision :: radial_vol (0:n1d-1)
+    real(rt)         :: radial_mass(0:n1d-1)
+    real(rt)         :: radial_vol (0:n1d-1)
 
     integer          :: r_l1, r_h1
-    double precision :: state(r_l1:r_h1,NVAR)
+    real(rt)         :: state(r_l1:r_h1,NVAR)
 
     integer          :: i, index
     integer          :: ii
-    double precision :: r
-    double precision :: dx_frac, fac, vol
-    double precision :: lo_i, rlo, rhi
+    real(rt)         :: r
+    real(rt)         :: dx_frac, fac, vol
+    real(rt)         :: lo_i, rlo, rhi
 
     if (physbc_lo(1) .ne. Symmetry) then
        call bl_error("Error: Gravity_1d.f90 :: 1D gravity assumes symmetric lower boundary.")
@@ -161,21 +164,22 @@ contains
     use prob_params_module, only: center
     use bl_constants_module, only: HALF, TWO
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer          :: lo(1), hi(1)
-    double precision :: dx(1), dr
-    double precision :: problo(1)
+    real(rt)         :: dx(1), dr
+    real(rt)         :: problo(1)
 
     integer          :: n1d, level
-    double precision :: radial_grav(0:n1d-1)
+    real(rt)         :: radial_grav(0:n1d-1)
 
     integer          :: g_l1, g_h1
-    double precision :: grav(g_l1:g_h1)
+    real(rt)         :: grav(g_l1:g_h1)
 
     integer          :: i, index
-    double precision :: r, mag_grav
-    double precision :: cen, xi, slope, glo, gmd, ghi, minvar, maxvar
+    real(rt)         :: r, mag_grav
+    real(rt)         :: cen, xi, slope, glo, gmd, ghi, minvar, maxvar
 
     ! Note that we are interpolating onto the entire range of grav,
     ! including the ghost cells. Taking the absolute value of r ensures
@@ -223,7 +227,7 @@ contains
           glo = radial_grav(index-1)
           mag_grav = ( ghi -  TWO*gmd + glo)*xi**2/(TWO*dr**2) + &
                      ( ghi       - glo     )*xi   /(TWO*dr   ) + &
-                     (-ghi + 26.d0*gmd - glo)/24.d0
+                     (-ghi + 26.e0_rt*gmd - glo)/24.e0_rt
 
           minvar = min(gmd, min(glo,ghi))
           maxvar = max(gmd, max(glo,ghi))
@@ -252,22 +256,23 @@ contains
     use prob_params_module, only: center
     use bl_constants_module, only: HALF, TWO
 
+    use bl_fort_module, only : rt => c_real
     implicit none
     integer          :: lo(1), hi(1)
     integer          :: domlo(1), domhi(1)
-    double precision :: dx(1), dr
-    double precision :: problo(1)
+    real(rt)         :: dx(1), dr
+    real(rt)         :: problo(1)
 
     integer          :: numpts_1d
-    double precision :: radial_phi(0:numpts_1d-1)
+    real(rt)         :: radial_phi(0:numpts_1d-1)
     integer          :: fill_interior
 
     integer          :: p_l1, p_h1
-    double precision :: phi(p_l1:p_h1)
+    real(rt)         :: phi(p_l1:p_h1)
 
     integer          :: i, index
-    double precision :: r
-    double precision :: cen, xi, slope, p_lo, p_md, p_hi, minvar, maxvar
+    real(rt)         :: r
+    real(rt)         :: cen, xi, slope, p_lo, p_md, p_hi, minvar, maxvar
 
     ! Note that when we interpolate into the ghost cells we use the
     ! location of the edge, not the cell center.
@@ -315,7 +320,7 @@ contains
              p_lo = radial_phi(index-1)
              phi(i) = ( p_hi -  TWO*p_md + p_lo)*xi**2/(TWO*dr**2) + &
                       ( p_hi       - p_lo      )*xi   /(TWO*dr   ) + &
-                      (-p_hi + 26.d0*p_md - p_lo)/24.d0
+                      (-p_hi + 26.e0_rt*p_md - p_lo)/24.e0_rt
              minvar = min(p_md, min(p_lo,p_hi))
              maxvar = max(p_md, max(p_lo,p_hi))
              phi(i) = max(phi(i),minvar)

--- a/Source/Src_1d/MGutils_1d.f90
+++ b/Source/Src_1d/MGutils_1d.f90
@@ -1,5 +1,6 @@
 module MGutils_1D_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   public
@@ -11,17 +12,18 @@ contains
        rhs, rl1, rh1,  &
        ecx, ecxl1, ecxh1, dx, coord_type) bind(C, name="ca_apply_metric")
 
+    use bl_fort_module, only : rt => c_real
     implicit none
     
     integer lo(1),hi(1),xlo(1),xhi(1)
     integer rl1, rh1
     integer ecxl1, ecxh1
     integer coord_type
-    double precision rhs(rl1:rh1)
-    double precision ecx(ecxl1:ecxh1)
-    double precision dx(1)
+    real(rt)         rhs(rl1:rh1)
+    real(rt)         ecx(ecxl1:ecxh1)
+    real(rt)         dx(1)
 
-    double precision r,rlo,rhi
+    real(rt)         r,rlo,rhi
     integer i
 
     ! r-z
@@ -29,7 +31,7 @@ contains
 
        ! At centers
        do i=lo(1),hi(1)
-          r = (dble(i)+0.5d0) * dx(1)
+          r = (dble(i)+0.5e0_rt) * dx(1)
           rhs(i) = rhs(i) * r
        enddo
 
@@ -44,11 +46,11 @@ contains
 
        ! At centers
        do i=lo(1),hi(1)
-          !           r = (dble(i)+0.5d0) * dx(1)
+          !           r = (dble(i)+0.5e0_rt) * dx(1)
           !           rhs(i) = rhs(i) * r**2
           rlo = dble(i) * dx(1)
           rhi = rlo + dx(1)
-          rhs(i) = rhs(i) * (rhi**3 - rlo**3) / (3.d0 * dx(1))
+          rhs(i) = rhs(i) * (rhi**3 - rlo**3) / (3.e0_rt * dx(1))
        enddo
 
        ! Note that (rhi**3 - rlo**3) / (3 dr) = ( (r + dr/2)**3 - (r - dr/2)**3 ) / (3 dr)
@@ -73,22 +75,23 @@ contains
        cc, cl1, ch1,  &
        dx, coord_type) bind(C, name="ca_weight_cc")
 
+    use bl_fort_module, only : rt => c_real
     implicit none
     
     integer lo(1),hi(1)
     integer cl1, ch1
     integer coord_type
-    double precision cc(cl1:ch1)
-    double precision dx(1)
+    real(rt)         cc(cl1:ch1)
+    real(rt)         dx(1)
 
-    double precision r
+    real(rt)         r
     integer i
 
     ! r-z
     if (coord_type .eq. 1) then
 
        do i=lo(1),hi(1)
-          r = (dble(i)+0.5d0) * dx(1)
+          r = (dble(i)+0.5e0_rt) * dx(1)
           cc(i) = cc(i) * r
        enddo
 
@@ -96,7 +99,7 @@ contains
     else if (coord_type .eq. 2) then
 
        do i=lo(1),hi(1)
-          r = (dble(i)+0.5d0) * dx(1)
+          r = (dble(i)+0.5e0_rt) * dx(1)
           cc(i) = cc(i) * r**2
        enddo
 
@@ -113,22 +116,23 @@ contains
        cc, cl1, ch1,  &
        dx, coord_type) bind(C, name="ca_unweight_cc")
 
+    use bl_fort_module, only : rt => c_real
     implicit none
     
     integer lo(1),hi(1)
     integer cl1, ch1
     integer coord_type
-    double precision cc(cl1:ch1)
-    double precision dx(1)
+    real(rt)         cc(cl1:ch1)
+    real(rt)         dx(1)
 
-    double precision r
+    real(rt)         r
     integer i
 
     ! r-z
     if (coord_type .eq. 1) then
 
        do i=lo(1),hi(1)
-          r = (dble(i)+0.5d0) * dx(1)
+          r = (dble(i)+0.5e0_rt) * dx(1)
           cc(i) = cc(i) / r
        enddo
 
@@ -136,7 +140,7 @@ contains
     else if (coord_type .eq. 2) then
 
        do i=lo(1),hi(1)
-          r = (dble(i)+0.5d0) * dx(1)
+          r = (dble(i)+0.5e0_rt) * dx(1)
           cc(i) = cc(i) / r**2
        enddo
 
@@ -153,15 +157,16 @@ contains
        ecx, ecxl1, ecxh1, dx, coord_type, idir) &
        bind(C, name="ca_unweight_edges")
 
+    use bl_fort_module, only : rt => c_real
     implicit none
     
     integer lo(1),hi(1)
     integer ecxl1, ecxh1
     integer coord_type, idir
-    double precision ecx(ecxl1:ecxh1)
-    double precision dx(1)
+    real(rt)         ecx(ecxl1:ecxh1)
+    real(rt)         dx(1)
 
-    double precision r
+    real(rt)         r
     integer i
 
     ! r-z

--- a/Source/Src_1d/Prob_1d.f90
+++ b/Source/Src_1d/Prob_1d.f90
@@ -1,10 +1,11 @@
 subroutine PROBINIT (init,name,namlen,problo,probhi)
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer          :: init, namlen
   integer          :: name(namlen)
-  double precision :: problo(1), probhi(1)
+  real(rt)         :: problo(1), probhi(1)
 
 end subroutine PROBINIT
 
@@ -36,13 +37,14 @@ subroutine ca_initdata(level,time,lo,hi,nvar, &
 
   use bl_error_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer :: level, nvar
   integer :: lo(1), hi(1)
   integer :: state_l1,state_h1
-  double precision :: xlo(1), xhi(1), time, dx(1)
-  double precision :: state(state_l1:state_h1,nvar)
+  real(rt)         :: xlo(1), xhi(1), time, dx(1)
+  real(rt)         :: state(state_l1:state_h1,nvar)
 
   ! Remove this call if you're defining your own problem; it is here to 
   ! ensure that you cannot run Castro if you haven't got your own copy of this function.

--- a/Source/Src_1d/advection_util_1d.f90
+++ b/Source/Src_1d/advection_util_1d.f90
@@ -1,5 +1,6 @@
 module advection_util_1d_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   private
@@ -14,15 +15,16 @@ contains
     use meth_params_module, only : NVAR, URHO, UFS
     use bl_constants_module
 
+    use bl_fort_module, only : rt => c_real
     implicit none
     
     integer          :: lo(1),hi(1)
     integer          :: flux_l1,flux_h1
-    double precision :: flux(flux_l1:flux_h1,NVAR)
+    real(rt)         :: flux(flux_l1:flux_h1,NVAR)
     
     ! Local variables
     integer          :: i,n
-    double precision :: sum,fac
+    real(rt)         :: sum,fac
     
     do i = lo(1),hi(1)+1
        sum = ZERO
@@ -51,15 +53,16 @@ contains
     use meth_params_module, only : NVAR, URHO, UFS
     use bl_constants_module    
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer          :: lo(1), hi(1)
     integer          :: u_l1,u_h1
-    double precision :: u(u_l1:u_h1,NVAR)
+    real(rt)         :: u(u_l1:u_h1,NVAR)
     
     ! Local variables
     integer          :: i,n
-    double precision :: fac,sum
+    real(rt)         :: fac,sum
     
     do i = lo(1),hi(1)
        sum = ZERO

--- a/Source/Src_1d/bc_fill_1d.F90
+++ b/Source/Src_1d/bc_fill_1d.F90
@@ -1,5 +1,6 @@
 module bc_fill_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   public
@@ -12,6 +13,7 @@ contains
 
     use meth_params_module, only: NVAR  
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     include 'bc_types.fi'
@@ -19,8 +21,8 @@ contains
     integer          :: adv_l1,adv_h1
     integer          :: bc(1,2,*)
     integer          :: domlo(1), domhi(1)
-    double precision :: delta(1), xlo(1), time
-    double precision :: adv(adv_l1:adv_h1,NVAR)
+    real(rt)         :: delta(1), xlo(1), time
+    real(rt)         :: adv(adv_l1:adv_h1,NVAR)
 
     integer          :: n
 
@@ -36,6 +38,7 @@ contains
   subroutine ca_denfill(adv,adv_l1,adv_h1,domlo,domhi,delta,xlo,time,bc) &
        bind(C, name="ca_denfill")
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     include 'bc_types.fi'
@@ -43,8 +46,8 @@ contains
     integer          :: adv_l1,adv_h1
     integer          :: bc(1,2,*)
     integer          :: domlo(1), domhi(1)
-    double precision :: delta(1), xlo(1), time
-    double precision :: adv(adv_l1:adv_h1)
+    real(rt)         :: delta(1), xlo(1), time
+    real(rt)         :: adv(adv_l1:adv_h1)
 
     call filcc(adv,adv_l1,adv_h1,domlo,domhi,delta,xlo,bc)
 
@@ -57,6 +60,7 @@ contains
                             domlo,domhi,delta,xlo,time,bc) &
                             bind(C, name="ca_phigravfill")
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     include 'bc_types.fi'
@@ -64,8 +68,8 @@ contains
     integer          :: phi_l1,phi_h1
     integer          :: bc(1,2,*)
     integer          :: domlo(1), domhi(1)
-    double precision :: delta(1), xlo(1), time
-    double precision :: phi(phi_l1:phi_h1)
+    real(rt)         :: delta(1), xlo(1), time
+    real(rt)         :: phi(phi_l1:phi_h1)
 
     call filcc(phi,phi_l1,phi_h1, &
                domlo,domhi,delta,xlo,bc)
@@ -78,6 +82,7 @@ contains
                           domlo,domhi,delta,xlo,time,bc) &
                           bind(C, name="ca_gravxfill")
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     include 'bc_types.fi'
@@ -85,8 +90,8 @@ contains
     integer          :: grav_l1,grav_h1
     integer          :: bc(1,2,*)
     integer          :: domlo(1), domhi(1)
-    double precision :: delta(1), xlo(1), time
-    double precision :: grav(grav_l1:grav_h1)
+    real(rt)         :: delta(1), xlo(1), time
+    real(rt)         :: grav(grav_l1:grav_h1)
 
     call filcc(grav,grav_l1,grav_h1,domlo,domhi,delta,xlo,bc)
 
@@ -98,6 +103,7 @@ contains
                           domlo,domhi,delta,xlo,time,bc) &
                           bind(C, name="ca_gravyfill")
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     include 'bc_types.fi'
@@ -105,8 +111,8 @@ contains
     integer          :: grav_l1,grav_h1
     integer          :: bc(1,2,*)
     integer          :: domlo(1), domhi(1)
-    double precision :: delta(1), xlo(1), time
-    double precision :: grav(grav_l1:grav_h1)
+    real(rt)         :: delta(1), xlo(1), time
+    real(rt)         :: grav(grav_l1:grav_h1)
 
     call filcc(grav,grav_l1,grav_h1,domlo,domhi,delta,xlo,bc)
 
@@ -118,6 +124,7 @@ contains
                           domlo,domhi,delta,xlo,time,bc) &
                           bind(C, name="ca_gravzfill")
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     include 'bc_types.fi'
@@ -125,8 +132,8 @@ contains
     integer          :: grav_l1,grav_h1
     integer          :: bc(1,2,*)
     integer          :: domlo(1), domhi(1)
-    double precision :: delta(1), xlo(1), time
-    double precision :: grav(grav_l1:grav_h1)
+    real(rt)         :: delta(1), xlo(1), time
+    real(rt)         :: grav(grav_l1:grav_h1)
 
     call filcc(grav,grav_l1,grav_h1,domlo,domhi,delta,xlo,bc)
 
@@ -140,6 +147,7 @@ contains
                            domlo,domhi,delta,xlo,time,bc) &
                            bind(C, name="ca_phirotfill")
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     include 'bc_types.fi'
@@ -147,8 +155,8 @@ contains
     integer          :: phi_l1,phi_h1
     integer          :: bc(1,2,*)
     integer          :: domlo(1), domhi(1)
-    double precision :: delta(1), xlo(1), time
-    double precision :: phi(phi_l1:phi_h1)
+    real(rt)         :: delta(1), xlo(1), time
+    real(rt)         :: phi(phi_l1:phi_h1)
 
     call filcc(phi,phi_l1,phi_h1, &
                domlo,domhi,delta,xlo,bc)
@@ -161,6 +169,7 @@ contains
                          domlo,domhi,delta,xlo,time,bc) &
                          bind(C, name="ca_rotxfill")
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     include 'bc_types.fi'
@@ -168,8 +177,8 @@ contains
     integer          :: rot_l1,rot_h1
     integer          :: bc(1,2,*)
     integer          :: domlo(1), domhi(1)
-    double precision :: delta(1), xlo(1), time
-    double precision :: rot(rot_l1:rot_h1)
+    real(rt)         :: delta(1), xlo(1), time
+    real(rt)         :: rot(rot_l1:rot_h1)
 
     call filcc(rot,rot_l1,rot_h1,domlo,domhi,delta,xlo,bc)
 
@@ -181,6 +190,7 @@ contains
                          domlo,domhi,delta,xlo,time,bc) &
                          bind(C, name="ca_rotyfill")
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     include 'bc_types.fi'
@@ -188,8 +198,8 @@ contains
     integer          :: rot_l1,rot_h1
     integer          :: bc(1,2,*)
     integer          :: domlo(1), domhi(1)
-    double precision :: delta(1), xlo(1), time
-    double precision :: rot(rot_l1:rot_h1)
+    real(rt)         :: delta(1), xlo(1), time
+    real(rt)         :: rot(rot_l1:rot_h1)
 
     call filcc(rot,rot_l1,rot_h1,domlo,domhi,delta,xlo,bc)
 
@@ -201,6 +211,7 @@ contains
                          domlo,domhi,delta,xlo,time,bc) &
                          bind(C, name="ca_rotzfill")
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     include 'bc_types.fi'
@@ -208,8 +219,8 @@ contains
     integer          :: rot_l1,rot_h1
     integer          :: bc(1,2,*)
     integer          :: domlo(1), domhi(1)
-    double precision :: delta(1), xlo(1), time
-    double precision :: rot(rot_l1:rot_h1)
+    real(rt)         :: delta(1), xlo(1), time
+    real(rt)         :: rot(rot_l1:rot_h1)
 
     call filcc(rot,rot_l1,rot_h1,domlo,domhi,delta,xlo,bc)
 
@@ -223,6 +234,7 @@ contains
                           domlo,domhi,delta,xlo,time,bc) &
                           bind(C, name="ca_reactfill")
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     include 'bc_types.fi'
@@ -230,8 +242,8 @@ contains
     integer          :: react_l1,react_h1
     integer          :: bc(1,2,*)
     integer          :: domlo(1), domhi(1)
-    double precision :: delta(1), xlo(1), time
-    double precision :: react(react_l1:react_h1)
+    real(rt)         :: delta(1), xlo(1), time
+    real(rt)         :: react(react_l1:react_h1)
 
     call filcc(react,react_l1,react_h1, &
                domlo,domhi,delta,xlo,bc)
@@ -246,6 +258,7 @@ contains
                         domlo,domhi,delta,xlo,time,bc) &
                         bind(C, name="ca_radfill")
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     include 'bc_types.fi'
@@ -253,8 +266,8 @@ contains
     integer rad_l1,rad_h1
     integer bc(1,2,*)
     integer domlo(1), domhi(1)
-    double precision delta(1), xlo(1), time
-    double precision rad(rad_l1:rad_h1)
+    real(rt)         delta(1), xlo(1), time
+    real(rt)         rad(rad_l1:rad_h1)
 
     call filcc(rad,rad_l1,rad_h1,domlo,domhi,delta,xlo,bc)
 

--- a/Source/Src_1d/ext_src_1d.f90
+++ b/Source/Src_1d/ext_src_1d.f90
@@ -26,16 +26,17 @@
     use meth_params_module, only : NVAR
     use bl_constants_module
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer         ,intent(in   ) :: lo(1),hi(1)
     integer         ,intent(in   ) :: old_state_l1,old_state_h1
     integer         ,intent(in   ) :: new_state_l1,new_state_h1
     integer         ,intent(in   ) :: src_l1,src_h1
-    double precision,intent(in   ) :: old_state(old_state_l1:old_state_h1,NVAR)
-    double precision,intent(in   ) :: new_state(new_state_l1:new_state_h1,NVAR)
-    double precision,intent(  out) :: src(src_l1:src_h1,NVAR)
-    double precision,intent(in   ) :: problo(1),dx(1),time,dt
+    real(rt)        ,intent(in   ) :: old_state(old_state_l1:old_state_h1,NVAR)
+    real(rt)        ,intent(in   ) :: new_state(new_state_l1:new_state_h1,NVAR)
+    real(rt)        ,intent(  out) :: src(src_l1:src_h1,NVAR)
+    real(rt)        ,intent(in   ) :: problo(1),dx(1),time,dt
 
     ! lo and hi specify work region
     src(lo(1):hi(1),:) = ZERO ! Fill work region only

--- a/Source/Src_1d/pointmass_1d.f90
+++ b/Source/Src_1d/pointmass_1d.f90
@@ -7,16 +7,17 @@
        use fundamental_constants_module, only : Gconst
        use bl_constants_module
 
+       use bl_fort_module, only : rt => c_real
        implicit none
 
        integer         , intent(in   ) :: lo(1), hi(1)
        integer         , intent(in   ) :: grav_l1,grav_h1
-       double precision, intent(in   ) :: point_mass
-       double precision, intent(inout) :: grav(grav_l1  :grav_h1)
-       double precision, intent(in   ) :: problo(1),dx(1)
+       real(rt)        , intent(in   ) :: point_mass
+       real(rt)        , intent(inout) :: grav(grav_l1  :grav_h1)
+       real(rt)        , intent(in   ) :: problo(1),dx(1)
 
        integer          :: i
-       double precision :: x
+       real(rt)         :: x
 
        ! We must be in spherical coordinates with center(1) = 0.
        !    or this doesn't make sense
@@ -44,6 +45,7 @@
       use meth_params_module, only : NVAR, URHO, UMX
       use bl_constants_module
 
+      use bl_fort_module, only : rt => c_real
       implicit none
 
       integer :: lo(1),hi(1)
@@ -51,11 +53,11 @@
       integer ::  uout_l1, uout_h1
       integer ::   vol_l1,  vol_h1
 
-      double precision   :: delta_mass
-      double precision   ::   uin( uin_l1: uin_h1, NVAR)
-      double precision   ::  uout(uout_l1:uout_h1, NVAR)
-      double precision   ::   vol( vol_l1: vol_h1)
-      double precision   :: problo(1),dx(1),time,dt
+      real(rt)           :: delta_mass
+      real(rt)           ::   uin( uin_l1: uin_h1, NVAR)
+      real(rt)           ::  uout(uout_l1:uout_h1, NVAR)
+      real(rt)           ::   vol( vol_l1: vol_h1)
+      real(rt)           :: problo(1),dx(1),time,dt
 
       integer, parameter :: box_size = 2
       integer            :: ii
@@ -80,15 +82,16 @@
 
       use meth_params_module, only : NVAR, UMX
 
+      use bl_fort_module, only : rt => c_real
       implicit none
 
       integer :: lo(1),hi(1)
       integer ::   uin_l1,  uin_h1
       integer ::  uout_l1, uout_h1
 
-      double precision   ::   uin(  uin_l1:uin_h1,  NVAR)
-      double precision   ::  uout( uout_l1:uout_h1, NVAR)
-      double precision   :: problo(1),dx(1),time,dt
+      real(rt)           ::   uin(  uin_l1:uin_h1,  NVAR)
+      real(rt)           ::  uout( uout_l1:uout_h1, NVAR)
+      real(rt)           :: problo(1),dx(1),time,dt
 
       integer, parameter :: box_size = 2
       integer            :: ii
@@ -103,7 +106,7 @@
       end do
 
       ! Linear interpolation between the point (box_size) and the origin.
-      uout(0,UMX) = 0.2d0 * uout(box_size,UMX)
-      uout(1,UMX) = 0.6d0 * uout(box_size,UMX)
+      uout(0,UMX) = 0.2e0_rt * uout(box_size,UMX)
+      uout(1,UMX) = 0.6e0_rt * uout(box_size,UMX)
 
       end subroutine pm_fix_solution

--- a/Source/Src_1d/ppm_1d.f90
+++ b/Source/Src_1d/ppm_1d.f90
@@ -1,5 +1,6 @@
 module ppm_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
 contains
@@ -13,42 +14,43 @@ contains
     use meth_params_module, only : ppm_type
     use bl_constants_module
 
+    use bl_fort_module, only : rt => c_real
     implicit none
        
     integer          qd_l1,qd_h1
     integer          ilo,ihi
-    double precision s(qd_l1:qd_h1)
-    double precision u(qd_l1:qd_h1)
-    double precision cspd(qd_l1:qd_h1)
-    double precision flatn(qd_l1:qd_h1)
-    double precision Ip(ilo-1:ihi+1,1:3)
-    double precision Im(ilo-1:ihi+1,1:3)
-    double precision dx,dt
+    real(rt)         s(qd_l1:qd_h1)
+    real(rt)         u(qd_l1:qd_h1)
+    real(rt)         cspd(qd_l1:qd_h1)
+    real(rt)         flatn(qd_l1:qd_h1)
+    real(rt)         Ip(ilo-1:ihi+1,1:3)
+    real(rt)         Im(ilo-1:ihi+1,1:3)
+    real(rt)         dx,dt
 
     ! local
     integer i
     logical extremum, bigp, bigm
 
-    double precision dsl, dsr, dsc, D2, D2C, D2L, D2R, D2LIM, C, alphap, alpham
-    double precision sgn, sigma, s6, amax, delam, delap
-    double precision dafacem, dafacep, dabarm, dabarp, dafacemin, dabarmin, dachkm, dachkp
+    real(rt)         dsl, dsr, dsc, D2, D2C, D2L, D2R, D2LIM, C, alphap, alpham
+    real(rt)         sgn, sigma, s6, amax, delam, delap
+    real(rt)         dafacem, dafacep, dabarm, dabarp, dafacemin, dabarmin, dachkm, dachkp
 
     ! s_{\ib,+}, s_{\ib,-}
-    double precision, allocatable :: sp(:)
-    double precision, allocatable :: sm(:)
+    real(rt)        , allocatable :: sp(:)
+    real(rt)        , allocatable :: sm(:)
     
     ! \delta s_{\ib}^{vL}
-    double precision, allocatable :: dsvl(:)
+    real(rt)        , allocatable :: dsvl(:)
     
     ! s_{i+\half}^{H.O.}
-    double precision, allocatable :: sedge(:)
+    real(rt)        , allocatable :: sedge(:)
 
     ! cell-centered indexing
     allocate(sp(ilo-1:ihi+1))
     allocate(sm(ilo-1:ihi+1))
     
     ! constant used in Colella 2008
-    C = 1.25d0
+    C = 1.25e0_rt
     
     ! cell-centered indexing w/extra x-ghost cell
     allocate(dsvl(ilo-2:ihi+2))
@@ -172,15 +174,15 @@ contains
              D2C = s(i-1)-TWO*s(i)+s(i+1)
              sgn = sign(ONE,D2)
              D2LIM = max(min(sgn*D2,C*sgn*D2L,C*sgn*D2R,C*sgn*D2C),ZERO)
-             alpham = alpham*D2LIM/max(abs(D2),1.d-10)
-             alphap = alphap*D2LIM/max(abs(D2),1.d-10)
+             alpham = alpham*D2LIM/max(abs(D2),1.e-10_rt)
+             alphap = alphap*D2LIM/max(abs(D2),1.e-10_rt)
           else
              if (bigp) then
                 sgn = sign(ONE,alpham)
                 amax = -alphap**2 / (4*(alpham + alphap))
                 delam = s(i-1) - s(i)
                 if (sgn*amax .ge. sgn*delam) then
-                   if (sgn*(delam - alpham).ge.1.d-10) then
+                   if (sgn*(delam - alpham).ge.1.e-10_rt) then
                       alphap = (-TWO*delam - TWO*sgn*sqrt(delam**2 - delam*alpham))
                    else 
                       alphap = -TWO*alpham
@@ -192,7 +194,7 @@ contains
                 amax = -alpham**2 / (4*(alpham + alphap))
                 delap = s(i+1) - s(i)
                if (sgn*amax .ge. sgn*delap) then
-                  if (sgn*(delap - alphap).ge.1.d-10) then
+                  if (sgn*(delap - alphap).ge.1.e-10_rt) then
                      alpham = (-TWO*delap - TWO*sgn*sqrt(delap**2 - delap*alphap))
                   else
                      alpham = -TWO*alphap

--- a/Source/Src_1d/problem_tagging_1d.f90
+++ b/Source/Src_1d/problem_tagging_1d.f90
@@ -1,5 +1,6 @@
 module problem_tagging_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   public
@@ -18,14 +19,15 @@ contains
 
     use meth_params_module, only: NVAR
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer         ,intent(in   ) :: lo(1),hi(1)
     integer         ,intent(in   ) :: state_l1,state_h1
     integer         ,intent(in   ) :: tagl1,tagh1
-    double precision,intent(in   ) :: state(state_l1:state_h1,NVAR)
+    real(rt)        ,intent(in   ) :: state(state_l1:state_h1,NVAR)
     integer         ,intent(inout) :: tag(tagl1:tagh1)
-    double precision,intent(in   ) :: problo(1),dx(1),time
+    real(rt)        ,intent(in   ) :: problo(1),dx(1),time
     integer         ,intent(in   ) :: level,set,clear
 
   end subroutine set_problem_tags

--- a/Source/Src_1d/riemann_1d.F90
+++ b/Source/Src_1d/riemann_1d.F90
@@ -17,13 +17,14 @@ module riemann_module
                                    riemann_solver, ppm_temp_fix, hybrid_riemann, &
                                    allow_negative_energy
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   private
 
   public cmpflx, shock
 
-  real (kind=dp_t), parameter :: smallu = 1.e-12_dp_t
+  real(rt)        , parameter :: smallu = 1.e-12_rt
 
 contains
 
@@ -44,6 +45,7 @@ contains
     use rad_params_module, only : ngroups
 #endif
 
+    use bl_fort_module, only : rt => c_real
     integer lo(1),hi(1)
     integer domlo(1),domhi(1)
     integer ilo,ihi
@@ -52,23 +54,23 @@ contains
     integer  qg_l1,  qg_h1
     integer  qa_l1,  qa_h1
 
-    double precision    qm(qpd_l1:qpd_h1, NQ)
-    double precision    qp(qpd_l1:qpd_h1, NQ)
+    real(rt)            qm(qpd_l1:qpd_h1, NQ)
+    real(rt)            qp(qpd_l1:qpd_h1, NQ)
 
-    double precision   flx(flx_l1:flx_h1, NVAR)
-    double precision  qint( qg_l1: qg_h1, NGDNV)
-    double precision  qaux( qa_l1: qa_h1, NQAUX)
+    real(rt)           flx(flx_l1:flx_h1, NVAR)
+    real(rt)          qint( qg_l1: qg_h1, NGDNV)
+    real(rt)          qaux( qa_l1: qa_h1, NQAUX)
 
 #ifdef RADIATION
     integer rflx_l1, rflx_h1
-    double precision rflx(rflx_l1:rflx_h1, 0:ngroups-1)
+    real(rt)         rflx(rflx_l1:rflx_h1, 0:ngroups-1)
 #endif
 
     ! Local variables
     integer i
-    double precision, allocatable :: smallc(:), cavg(:), gamcp(:), gamcm(:)
+    real(rt)        , allocatable :: smallc(:), cavg(:), gamcp(:), gamcm(:)
 #ifdef RADIATION
-    double precision, allocatable :: gamcgp(:), gamcgm(:), lam(:,:)
+    real(rt)        , allocatable :: gamcgp(:), gamcgm(:), lam(:,:)
 #endif
 
     allocate ( smallc(ilo:ihi+1) )
@@ -136,24 +138,25 @@ contains
 
     use prob_params_module, only : coord_type
 
+    use bl_fort_module, only : rt => c_real
     integer, intent(in) :: qd_l1, qd_h1
     integer, intent(in) :: s_l1, s_h1
     integer, intent(in) :: ilo1, ihi1
-    double precision, intent(in) :: dx
-    double precision, intent(in) :: q(qd_l1:qd_h1,NQ)
-    double precision, intent(inout) :: shk(s_l1:s_h1)
+    real(rt)        , intent(in) :: dx
+    real(rt)        , intent(in) :: q(qd_l1:qd_h1,NQ)
+    real(rt)        , intent(inout) :: shk(s_l1:s_h1)
 
     integer :: i
 
-    double precision :: divU
-    double precision :: px_pre, px_post
-    double precision :: e_x, d
-    double precision :: p_pre, p_post, pjump
+    real(rt)         :: divU
+    real(rt)         :: px_pre, px_post
+    real(rt)         :: e_x, d
+    real(rt)         :: p_pre, p_post, pjump
 
-    double precision :: rc, rm, rp
+    real(rt)         :: rc, rm, rp
 
-    double precision, parameter :: small = 1.d-10
-    double precision, parameter :: eps = 0.33d0
+    real(rt)        , parameter :: small = 1.e-10_rt
+    real(rt)        , parameter :: eps = 0.33e0_rt
 
     ! This is a basic multi-dimensional shock detection algorithm.
     ! This implementation follows Flash, which in turn follows
@@ -236,54 +239,55 @@ contains
     use eos_module
     use riemann_util_module
 
-    double precision, parameter :: small = 1.d-8
+    use bl_fort_module, only : rt => c_real
+    real(rt)        , parameter :: small = 1.e-8_rt
 
     integer :: qpd_l1, qpd_h1
     integer :: uflx_l1, uflx_h1
     integer :: qg_l1, qg_h1
 
-    double precision :: ql(qpd_l1:qpd_h1, NQ)
-    double precision :: qr(qpd_l1:qpd_h1, NQ)
-    double precision ::  gamcl(ilo:ihi+1)
-    double precision ::  gamcr(ilo:ihi+1)
-    double precision ::    cav(ilo:ihi+1)
-    double precision :: smallc(ilo:ihi+1)
-    double precision :: uflx(uflx_l1:uflx_h1, NVAR)
-    double precision ::  qint(qg_l1:qg_h1, NGDNV)
+    real(rt)         :: ql(qpd_l1:qpd_h1, NQ)
+    real(rt)         :: qr(qpd_l1:qpd_h1, NQ)
+    real(rt)         ::  gamcl(ilo:ihi+1)
+    real(rt)         ::  gamcr(ilo:ihi+1)
+    real(rt)         ::    cav(ilo:ihi+1)
+    real(rt)         :: smallc(ilo:ihi+1)
+    real(rt)         :: uflx(uflx_l1:uflx_h1, NVAR)
+    real(rt)         ::  qint(qg_l1:qg_h1, NGDNV)
 
     integer :: ilo,ihi
     integer :: n, nqp, ipassive
 
-    double precision :: rgdnv,ustar,gamgdnv,v1gdnv,v2gdnv
-    double precision :: rl, ul, v1l, v2l, pl, rel
-    double precision :: rr, ur, v1r, v2r, pr, rer
-    double precision :: wl, wr, rhoetot
-    double precision :: rstar, cstar, pstar
-    double precision :: ro, uo, po, co, gamco
-    double precision :: sgnm, spin, spout, ushock, frac
-    double precision :: wsmall, csmall,qavg
+    real(rt)         :: rgdnv,ustar,gamgdnv,v1gdnv,v2gdnv
+    real(rt)         :: rl, ul, v1l, v2l, pl, rel
+    real(rt)         :: rr, ur, v1r, v2r, pr, rer
+    real(rt)         :: wl, wr, rhoetot
+    real(rt)         :: rstar, cstar, pstar
+    real(rt)         :: ro, uo, po, co, gamco
+    real(rt)         :: sgnm, spin, spout, ushock, frac
+    real(rt)         :: wsmall, csmall,qavg
 
-    double precision :: gcl, gcr
-    double precision :: clsq, clsql, clsqr, wlsq, wosq, wrsq, wo
-    double precision :: zm, zp
-    double precision :: denom, dpditer, dpjmp
-    double precision :: gamc_bar, game_bar
-    double precision :: gamel, gamer, gameo, gamstar, gmin, gmax, gdot
+    real(rt)         :: gcl, gcr
+    real(rt)         :: clsq, clsql, clsqr, wlsq, wosq, wrsq, wo
+    real(rt)         :: zm, zp
+    real(rt)         :: denom, dpditer, dpjmp
+    real(rt)         :: gamc_bar, game_bar
+    real(rt)         :: gamel, gamer, gameo, gamstar, gmin, gmax, gdot
 
     integer :: iter, iter_max
-    double precision :: tol
-    double precision :: err
+    real(rt)         :: tol
+    real(rt)         :: err
 
     logical :: converged
 
-    double precision :: pstnm1
-    double precision :: taul, taur, tauo
-    double precision :: ustarm, ustarp, ustnm1, ustnp1
-    double precision :: pstarl, pstarc, pstaru, pfuncc, pfuncu
+    real(rt)         :: pstnm1
+    real(rt)         :: taul, taur, tauo
+    real(rt)         :: ustarm, ustarp, ustnm1, ustnp1
+    real(rt)         :: pstarl, pstarc, pstaru, pfuncc, pfuncu
 
-    double precision, parameter :: weakwv = 1.d-3
+    real(rt)        , parameter :: weakwv = 1.e-3_rt
 
-    double precision, allocatable :: pstar_hist(:), pstar_hist_extra(:)
+    real(rt)        , allocatable :: pstar_hist(:), pstar_hist_extra(:)
 
     type (eos_t) :: eos_state
 
@@ -375,8 +379,8 @@ contains
 
        ! these should consider a wider average of the cell-centered
        ! gammas
-       gmin = min(gamel, gamer, ONE, 4.d0/3.d0)
-       gmax = max(gamel, gamer, TWO, 5.d0/3.d0)
+       gmin = min(gamel, gamer, ONE, 4.e0_rt/3.e0_rt)
+       gmax = max(gamel, gamer, TWO, 5.e0_rt/3.e0_rt)
 
        game_bar = HALF*(gamel + gamer)
        gamc_bar = HALF*(gcl + gcr)
@@ -762,7 +766,8 @@ contains
     use fluxlimiter_module, only : Edd_factor
 #endif
 
-    double precision, parameter:: small = 1.d-8
+    use bl_fort_module, only : rt => c_real
+    real(rt)        , parameter:: small = 1.e-8_rt
 
     integer ilo,ihi
     integer domlo(1),domhi(1)
@@ -774,38 +779,38 @@ contains
     integer rflx_l1, rflx_h1
 #endif
 
-    double precision ql(qpd_l1:qpd_h1, NQ)
-    double precision qr(qpd_l1:qpd_h1, NQ)
+    real(rt)         ql(qpd_l1:qpd_h1, NQ)
+    real(rt)         qr(qpd_l1:qpd_h1, NQ)
 
-    double precision   cav(ilo:ihi+1), smallc(ilo:ihi+1)
-    double precision gamcl(ilo:ihi+1), gamcr(ilo:ihi+1)
-    double precision  uflx(uflx_l1:uflx_h1, NVAR)
-    double precision  qint( qg_l1: qg_h1, NGDNV)
+    real(rt)           cav(ilo:ihi+1), smallc(ilo:ihi+1)
+    real(rt)         gamcl(ilo:ihi+1), gamcr(ilo:ihi+1)
+    real(rt)          uflx(uflx_l1:uflx_h1, NVAR)
+    real(rt)          qint( qg_l1: qg_h1, NGDNV)
 
 #ifdef RADIATION
-    double precision lam(ilo-1:ihi+2, 0:ngroups-1)
-    double precision gamcgl(ilo:ihi+1),gamcgr(ilo:ihi+1)
-    double precision  rflx(rflx_l1:rflx_h1, 0:ngroups-1)
+    real(rt)         lam(ilo-1:ihi+2, 0:ngroups-1)
+    real(rt)         gamcgl(ilo:ihi+1),gamcgr(ilo:ihi+1)
+    real(rt)          rflx(rflx_l1:rflx_h1, 0:ngroups-1)
 
-    double precision, dimension(0:ngroups-1) :: erl, err
-    double precision :: regdnv_g, pgdnv_g, pgdnv_t
-    double precision :: estar_g, pstar_g
-    double precision, dimension(0:ngroups-1) :: lambda, reo_r, po_r, estar_r, regdnv_r
-    double precision :: eddf, f1
-    double precision :: co_g, gamco_g, pl_g, po_g, pr_g, rel_g, reo_g, rer_g
+    real(rt)        , dimension(0:ngroups-1) :: erl, err
+    real(rt)         :: regdnv_g, pgdnv_g, pgdnv_t
+    real(rt)         :: estar_g, pstar_g
+    real(rt)        , dimension(0:ngroups-1) :: lambda, reo_r, po_r, estar_r, regdnv_r
+    real(rt)         :: eddf, f1
+    real(rt)         :: co_g, gamco_g, pl_g, po_g, pr_g, rel_g, reo_g, rer_g
 
     integer :: g
 #endif
 
-    double precision rgdnv, regdnv, ustar, v1gdnv, v2gdnv
-    double precision rl, ul, v1l, v2l, pl, rel
-    double precision rr, ur, v1r, v2r, pr, rer
-    double precision wl, wr, rhoetot, scr
-    double precision rstar, cstar, estar, pstar, drho
-    double precision ro, uo, po, reo, co, gamco, entho
-    double precision sgnm, spin, spout, ushock, frac
+    real(rt)         rgdnv, regdnv, ustar, v1gdnv, v2gdnv
+    real(rt)         rl, ul, v1l, v2l, pl, rel
+    real(rt)         rr, ur, v1r, v2r, pr, rer
+    real(rt)         wl, wr, rhoetot, scr
+    real(rt)         rstar, cstar, estar, pstar, drho
+    real(rt)         ro, uo, po, reo, co, gamco, entho
+    real(rt)         sgnm, spin, spout, ushock, frac
 
-    double precision wsmall, csmall
+    real(rt)         wsmall, csmall
     integer ipassive, n, nqp
     integer k
     logical :: fix_mass_flux_lo, fix_mass_flux_hi
@@ -911,12 +916,12 @@ contains
 
 #ifdef RADIATION
           do g=0, ngroups-1
-             lambda(g) = 0.5d0*(lam(k-1,g)+lam(k,g))
+             lambda(g) = 0.5e0_rt*(lam(k-1,g)+lam(k,g))
           end do
-          reo_r(:) = 0.5d0*(erl(:)+err(:))
-          reo_g = 0.5d0*(rel_g+rer_g)
+          reo_r(:) = 0.5e0_rt*(erl(:)+err(:))
+          reo_g = 0.5e0_rt*(rel_g+rer_g)
           po_r(:) = lambda(:) * reo_r(:)
-          gamco_g = 0.5d0*(gamcgl(k)+gamcgr(k))
+          gamco_g = 0.5e0_rt*(gamcgl(k)+gamcgr(k))
           po_g = 0.5*(pr_g+pl_g)
 #endif
        endif
@@ -982,10 +987,10 @@ contains
        rgdnv = frac*rstar + (ONE - frac)*ro
        qint(k,GDU) = frac*ustar + (ONE - frac)*uo
 #ifdef RADIATION
-       pgdnv_t = frac*pstar + (1.d0 - frac)*po
-       pgdnv_g = frac*pstar_g + (1.d0 - frac)*po_g
-       regdnv_g = frac*estar_g + (1.d0 - frac)*reo_g
-       regdnv_r(:) = frac*estar_r(:) + (1.d0 - frac)*reo_r(:)
+       pgdnv_t = frac*pstar + (1.e0_rt - frac)*po
+       pgdnv_g = frac*pstar_g + (1.e0_rt - frac)*po_g
+       regdnv_g = frac*estar_g + (1.e0_rt - frac)*reo_g
+       regdnv_r(:) = frac*estar_r(:) + (1.e0_rt - frac)*reo_r(:)
 #else
        qint(k,GDPRES) = frac*pstar + (ONE - frac)*po
        regdnv = frac*estar + (ONE - frac)*reo
@@ -1068,8 +1073,8 @@ contains
        if (fspace_type.eq.1) then
           do g = 0, ngroups-1
              eddf = Edd_factor(lambda(g))
-             f1 = 0.5d0*(1.d0-eddf)
-             rflx(k,g) = (1.d0+f1) * qint(k,GDERADS+g) * qint(k,GDU)
+             f1 = 0.5e0_rt*(1.e0_rt-eddf)
+             rflx(k,g) = (1.e0_rt+f1) * qint(k,GDERADS+g) * qint(k,GDU)
           end do
        else ! type 2
           do g = 0, ngroups-1

--- a/Source/Src_1d/slope_1d.f90
+++ b/Source/Src_1d/slope_1d.f90
@@ -1,5 +1,6 @@
 module slope_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
 contains
@@ -12,19 +13,20 @@ contains
 !      use meth_params_module, only : QPRES
       use bl_constants_module
 
+      use bl_fort_module, only : rt => c_real
       implicit none
 
       integer ilo, ihi, nv
       integer qd_l1,qd_h1,qpd_l1,qpd_h1
-      double precision q(qd_l1:qd_h1, nv)
-      double precision dq(qpd_l1:qpd_h1,nv)
-      double precision flatn(qd_l1:qd_h1)
+      real(rt)         q(qd_l1:qd_h1, nv)
+      real(rt)         dq(qpd_l1:qpd_h1,nv)
+      real(rt)         flatn(qd_l1:qd_h1)
 
 !     Local arrays 
-      double precision, allocatable::dsgn(:),dlim(:),df(:),dcen(:)
+      real(rt)        , allocatable::dsgn(:),dlim(:),df(:),dcen(:)
 
       integer i, n
-      double precision dlft, drgt, slop, dq1
+      real(rt)         dlft, drgt, slop, dq1
 
       allocate (dsgn(ilo-2:ihi+2))
       allocate (dlim(ilo-2:ihi+2))
@@ -72,24 +74,25 @@ contains
       use bl_constants_module
       use meth_params_module, only: QU, QVAR
       
+      use bl_fort_module, only : rt => c_real
       implicit none
 
       integer ilo, ihi
       integer  qd_l1, qd_h1
       integer qpd_l1,qpd_h1
       integer src_l1,src_h1
-      double precision, intent(in   ) ::      p( qd_l1: qd_h1)
-      double precision, intent(in   ) ::    rho( qd_l1: qd_h1)
-      double precision, intent(in   ) ::  flatn( qd_l1: qd_h1)
-      double precision, intent(  out) ::     dp(qpd_l1:qpd_h1)
-      double precision, intent(in   ) ::    src(src_l1:src_h1,QVAR)
-      double precision, intent(in   ) ::  dx
+      real(rt)        , intent(in   ) ::      p( qd_l1: qd_h1)
+      real(rt)        , intent(in   ) ::    rho( qd_l1: qd_h1)
+      real(rt)        , intent(in   ) ::  flatn( qd_l1: qd_h1)
+      real(rt)        , intent(  out) ::     dp(qpd_l1:qpd_h1)
+      real(rt)        , intent(in   ) ::    src(src_l1:src_h1,QVAR)
+      real(rt)        , intent(in   ) ::  dx
 
 !     Local arrays
-      double precision, allocatable :: dsgn(:), dlim(:), df(:), dcen(:)
+      real(rt)        , allocatable :: dsgn(:), dlim(:), df(:), dcen(:)
 
       integer          :: i
-      double precision :: dlft, drgt, dp1
+      real(rt)         :: dlft, drgt, dp1
 
       allocate (dsgn(ilo-2:ihi+2))
       allocate (dlim(ilo-2:ihi+2))

--- a/Source/Src_1d/trace_1d.f90
+++ b/Source/Src_1d/trace_1d.f90
@@ -1,5 +1,6 @@
 module trace_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   private
@@ -23,6 +24,7 @@ contains
     use slope_module, only : uslope, pslope
     use bl_constants_module
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer domlo(1),domhi(1)
@@ -31,31 +33,31 @@ contains
     integer dloga_l1,dloga_h1
     integer   qpd_l1,  qpd_h1
     integer   src_l1,  src_h1
-    double precision dx, dt
-    double precision     q( qd_l1: qd_h1,QVAR)
-    double precision  srcQ(src_l1:src_h1,QVAR)
-    double precision flatn(qd_l1:qd_h1)
-    double precision     c(qd_l1:qd_h1)
-    double precision dloga(dloga_l1:dloga_h1)
+    real(rt)         dx, dt
+    real(rt)             q( qd_l1: qd_h1,QVAR)
+    real(rt)          srcQ(src_l1:src_h1,QVAR)
+    real(rt)         flatn(qd_l1:qd_h1)
+    real(rt)             c(qd_l1:qd_h1)
+    real(rt)         dloga(dloga_l1:dloga_h1)
 
-    double precision   dq( qpd_l1: qpd_h1,QVAR)
-    double precision  qxm( qpd_l1: qpd_h1,QVAR)
-    double precision  qxp( qpd_l1: qpd_h1,QVAR)
+    real(rt)           dq( qpd_l1: qpd_h1,QVAR)
+    real(rt)          qxm( qpd_l1: qpd_h1,QVAR)
+    real(rt)          qxp( qpd_l1: qpd_h1,QVAR)
 
     !     Local variables
     integer          :: i
     integer          :: n, ipassive
 
-    double precision :: hdt,dtdx
-    double precision :: cc, csq, rho, u, p, rhoe
-    double precision :: drho, du, dp, drhoe
+    real(rt)         :: hdt,dtdx
+    real(rt)         :: cc, csq, rho, u, p, rhoe
+    real(rt)         :: drho, du, dp, drhoe
 
-    double precision :: enth, alpham, alphap, alpha0r, alpha0e
-    double precision :: spminus, spplus, spzero
-    double precision :: apright, amright, azrright, azeright
-    double precision :: apleft, amleft, azrleft, azeleft
-    double precision :: acmprght, acmpleft
-    double precision :: sourcr,sourcp,source,courn,eta,dlogatmp
+    real(rt)         :: enth, alpham, alphap, alpha0r, alpha0e
+    real(rt)         :: spminus, spplus, spzero
+    real(rt)         :: apright, amright, azrright, azeright
+    real(rt)         :: apleft, amleft, azrleft, azeleft
+    real(rt)         :: acmprght, acmpleft
+    real(rt)         :: sourcr,sourcp,source,courn,eta,dlogatmp
 
     logical :: fix_mass_flux_lo, fix_mass_flux_hi
 

--- a/Source/Src_1d/trace_ppm_1d.f90
+++ b/Source/Src_1d/trace_ppm_1d.f90
@@ -3,6 +3,7 @@
 
 module trace_ppm_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   private
@@ -27,6 +28,7 @@ contains
     use prob_params_module, only : physbc_lo, physbc_hi, Outflow
     use ppm_module, only : ppm
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer ilo,ihi
@@ -35,23 +37,23 @@ contains
     integer dloga_l1,dloga_h1
     integer   qpd_l1,  qpd_h1
     integer   src_l1,  src_h1
-    double precision dx, dt
+    real(rt)         dx, dt
 
-    double precision     q( qd_l1: qd_h1,QVAR)
-    double precision  srcQ(src_l1:src_h1,QVAR)
-    double precision  gamc(qd_l1:qd_h1)
-    double precision flatn(qd_l1:qd_h1)
-    double precision     c(qd_l1:qd_h1)
-    double precision dloga(dloga_l1:dloga_h1)
+    real(rt)             q( qd_l1: qd_h1,QVAR)
+    real(rt)          srcQ(src_l1:src_h1,QVAR)
+    real(rt)          gamc(qd_l1:qd_h1)
+    real(rt)         flatn(qd_l1:qd_h1)
+    real(rt)             c(qd_l1:qd_h1)
+    real(rt)         dloga(dloga_l1:dloga_h1)
 
-    double precision  qxm( qpd_l1: qpd_h1,QVAR)
-    double precision  qxp( qpd_l1: qpd_h1,QVAR)
+    real(rt)          qxm( qpd_l1: qpd_h1,QVAR)
+    real(rt)          qxp( qpd_l1: qpd_h1,QVAR)
 
     ! Local variables
     integer :: i
     integer :: n, ipassive
 
-    double precision :: hdt,dtdx
+    real(rt)         :: hdt,dtdx
 
     ! To allow for easy integration of radiation, we adopt the
     ! following conventions:
@@ -71,36 +73,36 @@ contains
     ! for pure hydro, we will only consider:
     !   rho, u, v, w, ptot, rhoe_g, cc, h_g
 
-    double precision :: cc, csq, Clag
-    double precision :: rho, u, p, rhoe_g, h_g
-    double precision :: gam_g, game
+    real(rt)         :: cc, csq, Clag
+    real(rt)         :: rho, u, p, rhoe_g, h_g
+    real(rt)         :: gam_g, game
 
-    double precision :: drho, dptot, drhoe_g
-    double precision :: dge, dtau
-    double precision :: dup, dptotp
-    double precision :: dum, dptotm
+    real(rt)         :: drho, dptot, drhoe_g
+    real(rt)         :: dge, dtau
+    real(rt)         :: dup, dptotp
+    real(rt)         :: dum, dptotm
 
-    double precision :: rho_ref, u_ref, p_ref, rhoe_g_ref, h_g_ref
-    double precision :: tau_ref
+    real(rt)         :: rho_ref, u_ref, p_ref, rhoe_g_ref, h_g_ref
+    real(rt)         :: tau_ref
 
-    double precision :: cc_ref, csq_ref, Clag_ref, gam_g_ref, game_ref, gfactor
-    double precision :: cc_ev, csq_ev, Clag_ev, rho_ev, p_ev, h_g_ev, tau_ev
+    real(rt)         :: cc_ref, csq_ref, Clag_ref, gam_g_ref, game_ref, gfactor
+    real(rt)         :: cc_ev, csq_ev, Clag_ev, rho_ev, p_ev, h_g_ev, tau_ev
 
-    double precision :: alpham, alphap, alpha0r, alpha0e_g
-    double precision :: sourcr, sourcp, source, courn, eta, dlogatmp
+    real(rt)         :: alpham, alphap, alpha0r, alpha0e_g
+    real(rt)         :: sourcr, sourcp, source, courn, eta, dlogatmp
 
-    double precision :: tau_s
+    real(rt)         :: tau_s
 
     logical :: fix_mass_flux_lo, fix_mass_flux_hi
 
-    double precision, allocatable :: Ip(:,:,:)
-    double precision, allocatable :: Im(:,:,:)
+    real(rt)        , allocatable :: Ip(:,:,:)
+    real(rt)        , allocatable :: Im(:,:,:)
 
-    double precision, allocatable :: Ip_src(:,:,:)
-    double precision, allocatable :: Im_src(:,:,:)
+    real(rt)        , allocatable :: Ip_src(:,:,:)
+    real(rt)        , allocatable :: Im_src(:,:,:)
 
-    double precision, allocatable :: Ip_gc(:,:,:)
-    double precision, allocatable :: Im_gc(:,:,:)
+    real(rt)        , allocatable :: Ip_gc(:,:,:)
+    real(rt)        , allocatable :: Im_gc(:,:,:)
 
     fix_mass_flux_lo = (fix_mass_flux == 1) .and. (physbc_lo(1) == Outflow) &
          .and. (ilo == domlo(1))

--- a/Source/Src_2d/Castro_2d.F90
+++ b/Source/Src_2d/Castro_2d.F90
@@ -47,6 +47,7 @@ subroutine ca_umdrv(is_finest_level, time, &
 #endif
   use advection_module, only : umeth2d, consup
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
 #ifdef RADIATION
@@ -77,46 +78,46 @@ subroutine ca_umdrv(is_finest_level, time, &
   integer, intent(in) :: dloga_l1,dloga_l2,dloga_h1,dloga_h2
   integer, intent(in) :: vol_l1,vol_l2,vol_h1,vol_h2
 
-  double precision, intent(in) :: uin(uin_l1:uin_h1,uin_l2:uin_h2,NVAR)
-  double precision, intent(inout) :: uout(uout_l1:uout_h1,uout_l2:uout_h2,NVAR)
+  real(rt)        , intent(in) :: uin(uin_l1:uin_h1,uin_l2:uin_h2,NVAR)
+  real(rt)        , intent(inout) :: uout(uout_l1:uout_h1,uout_l2:uout_h2,NVAR)
 #ifdef RADIATION
-  double precision, intent(in) :: Erin(Erin_l1:Erin_h1,Erin_l2:Erin_h2,0:ngroups-1)
-  double precision, intent(inout) :: Erout(Erout_l1:Erout_h1,Erout_l2:Erout_h2,0:ngroups-1)
+  real(rt)        , intent(in) :: Erin(Erin_l1:Erin_h1,Erin_l2:Erin_h2,0:ngroups-1)
+  real(rt)        , intent(inout) :: Erout(Erout_l1:Erout_h1,Erout_l2:Erout_h2,0:ngroups-1)
 #endif
-  double precision, intent(inout) :: q(q_l1:q_h1,q_l2:q_h2,NQ)
-  double precision, intent(inout) :: qaux(qa_l1:qa_h1,qa_l2:qa_h2,NQAUX)
-  double precision, intent(in) :: srcQ(srQ_l1:srQ_h1,srQ_l2:srQ_h2,QVAR)
-  double precision, intent(inout) :: update(updt_l1:updt_h1,updt_l2:updt_h2,NVAR)
-  double precision, intent(inout) :: flux1(flux1_l1:flux1_h1,flux1_l2:flux1_h2,NVAR)
-  double precision, intent(inout) :: flux2(flux2_l1:flux2_h1,flux2_l2:flux2_h2,NVAR)
+  real(rt)        , intent(inout) :: q(q_l1:q_h1,q_l2:q_h2,NQ)
+  real(rt)        , intent(inout) :: qaux(qa_l1:qa_h1,qa_l2:qa_h2,NQAUX)
+  real(rt)        , intent(in) :: srcQ(srQ_l1:srQ_h1,srQ_l2:srQ_h2,QVAR)
+  real(rt)        , intent(inout) :: update(updt_l1:updt_h1,updt_l2:updt_h2,NVAR)
+  real(rt)        , intent(inout) :: flux1(flux1_l1:flux1_h1,flux1_l2:flux1_h2,NVAR)
+  real(rt)        , intent(inout) :: flux2(flux2_l1:flux2_h1,flux2_l2:flux2_h2,NVAR)
 #ifdef RADIATION
-  double precision, intent(inout) :: radflux1(radflux1_l1:radflux1_h1,radflux1_l2:radflux1_h2,0:ngroups-1)
-  double precision, intent(inout) :: radflux2(radflux2_l1:radflux2_h1,radflux2_l2:radflux2_h2,0:ngroups-1)
+  real(rt)        , intent(inout) :: radflux1(radflux1_l1:radflux1_h1,radflux1_l2:radflux1_h2,0:ngroups-1)
+  real(rt)        , intent(inout) :: radflux2(radflux2_l1:radflux2_h1,radflux2_l2:radflux2_h2,0:ngroups-1)
 #endif
-  double precision, intent(inout) :: pradial(p_l1:p_h1,p_l2:p_h2)
-  double precision, intent(in) :: area1(area1_l1:area1_h1,area1_l2:area1_h2)
-  double precision, intent(in) :: area2(area2_l1:area2_h1,area2_l2:area2_h2)
-  double precision, intent(in) :: dloga(dloga_l1:dloga_h1,dloga_l2:dloga_h2)
-  double precision, intent(in) :: vol(vol_l1:vol_h1,vol_l2:vol_h2)
-  double precision, intent(in) :: delta(2), dt, time
-  double precision, intent(inout) :: courno
+  real(rt)        , intent(inout) :: pradial(p_l1:p_h1,p_l2:p_h2)
+  real(rt)        , intent(in) :: area1(area1_l1:area1_h1,area1_l2:area1_h2)
+  real(rt)        , intent(in) :: area2(area2_l1:area2_h1,area2_l2:area2_h2)
+  real(rt)        , intent(in) :: dloga(dloga_l1:dloga_h1,dloga_l2:dloga_h2)
+  real(rt)        , intent(in) :: vol(vol_l1:vol_h1,vol_l2:vol_h2)
+  real(rt)        , intent(in) :: delta(2), dt, time
+  real(rt)        , intent(inout) :: courno
 
-  double precision, intent(inout) :: E_added_flux, mass_added_flux
-  double precision, intent(inout) :: xmom_added_flux, ymom_added_flux, zmom_added_flux
-  double precision, intent(inout) :: mass_lost, xmom_lost, ymom_lost, zmom_lost
-  double precision, intent(inout) :: eden_lost, xang_lost, yang_lost, zang_lost
+  real(rt)        , intent(inout) :: E_added_flux, mass_added_flux
+  real(rt)        , intent(inout) :: xmom_added_flux, ymom_added_flux, zmom_added_flux
+  real(rt)        , intent(inout) :: mass_lost, xmom_lost, ymom_lost, zmom_lost
+  real(rt)        , intent(inout) :: eden_lost, xang_lost, yang_lost, zang_lost
 
   ! Automatic arrays for workspace
-  double precision, allocatable :: flatn(:,:)
-  double precision, allocatable :: div(:,:)
-  double precision, allocatable :: pdivu(:,:)
+  real(rt)        , allocatable :: flatn(:,:)
+  real(rt)        , allocatable :: div(:,:)
+  real(rt)        , allocatable :: pdivu(:,:)
 
   ! Edge-centered primitive variables (Riemann state)
-  double precision, allocatable :: q1(:,:,:)
-  double precision, allocatable :: q2(:,:,:)
+  real(rt)        , allocatable :: q1(:,:,:)
+  real(rt)        , allocatable :: q2(:,:,:)
 
   integer ngq, ngf
-  double precision dx,dy
+  real(rt)         dx,dy
 
   integer ::  uin_lo(2),  uin_hi(2)
   integer :: uout_lo(2), uout_hi(2)
@@ -125,7 +126,7 @@ subroutine ca_umdrv(is_finest_level, time, &
   integer :: lo_3D(3), hi_3D(3)
   integer :: q_lo_3D(3), q_hi_3D(3)
   integer :: uin_lo_3D(3), uin_hi_3D(3)
-  double precision :: dx_3D(3)
+  real(rt)         :: dx_3D(3)
 
   uin_lo  = [uin_l1, uin_l2]
   uin_hi  = [uin_h1, uin_h2]

--- a/Source/Src_2d/Castro_advection_2d.F90
+++ b/Source/Src_2d/Castro_advection_2d.F90
@@ -2,6 +2,7 @@ module advection_module
 
   use bl_constants_module, only : ZERO, HALF, ONE, FOURTH, TWO
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   private
@@ -70,6 +71,7 @@ contains
     use meth_params_module, only : USHK
 #endif
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer, intent(in) :: qd_l1, qd_l2, qd_h1, qd_h2
@@ -91,43 +93,43 @@ contains
     integer, intent(in) :: ilo1, ilo2, ihi1, ihi2
     integer, intent(in) :: domlo(2), domhi(2)
 
-    double precision, intent(in) :: dx, dy, dt
-    double precision, intent(in) :: q(qd_l1:qd_h1,qd_l2:qd_h2,NQ)
-    double precision, intent(inout) :: qaux(qa_l1:qa_h1,qa_l2:qa_h2,NQAUX)
-    double precision, intent(in) :: flatn(qd_l1:qd_h1,qd_l2:qd_h2)
-    double precision, intent(in) :: srcQ(src_l1:src_h1,src_l2:src_h2,QVAR)
-    double precision, intent(in) :: dloga(dloga_l1:dloga_h1,dloga_l2:dloga_h2)
-    double precision, intent(inout) :: q1(q1_l1:q1_h1,q1_l2:q1_h2,NGDNV)
-    double precision, intent(inout) :: q2(q2_l1:q2_h1,q2_l2:q2_h2,NGDNV)
-    double precision, intent(inout) :: uout(uout_l1:uout_h1,uout_l2:uout_h2,NVAR)
-    double precision, intent(inout) :: flux1(fd1_l1:fd1_h1,fd1_l2:fd1_h2,NVAR)
-    double precision, intent(inout) :: flux2(fd2_l1:fd2_h1,fd2_l2:fd2_h2,NVAR)
+    real(rt)        , intent(in) :: dx, dy, dt
+    real(rt)        , intent(in) :: q(qd_l1:qd_h1,qd_l2:qd_h2,NQ)
+    real(rt)        , intent(inout) :: qaux(qa_l1:qa_h1,qa_l2:qa_h2,NQAUX)
+    real(rt)        , intent(in) :: flatn(qd_l1:qd_h1,qd_l2:qd_h2)
+    real(rt)        , intent(in) :: srcQ(src_l1:src_h1,src_l2:src_h2,QVAR)
+    real(rt)        , intent(in) :: dloga(dloga_l1:dloga_h1,dloga_l2:dloga_h2)
+    real(rt)        , intent(inout) :: q1(q1_l1:q1_h1,q1_l2:q1_h2,NGDNV)
+    real(rt)        , intent(inout) :: q2(q2_l1:q2_h1,q2_l2:q2_h2,NGDNV)
+    real(rt)        , intent(inout) :: uout(uout_l1:uout_h1,uout_l2:uout_h2,NVAR)
+    real(rt)        , intent(inout) :: flux1(fd1_l1:fd1_h1,fd1_l2:fd1_h2,NVAR)
+    real(rt)        , intent(inout) :: flux2(fd2_l1:fd2_h1,fd2_l2:fd2_h2,NVAR)
 #ifdef RADIATION
-    double precision, intent(inout) :: rflux1(rfd1_l1:rfd1_h1,rfd1_l2:rfd1_h2,0:ngroups-1)
-    double precision, intent(inout) :: rflux2(rfd2_l1:rfd2_h1,rfd2_l2:rfd2_h2,0:ngroups-1)
+    real(rt)        , intent(inout) :: rflux1(rfd1_l1:rfd1_h1,rfd1_l2:rfd1_h2,0:ngroups-1)
+    real(rt)        , intent(inout) :: rflux2(rfd2_l1:rfd2_h1,rfd2_l2:rfd2_h2,0:ngroups-1)
 #endif
-    double precision, intent(in) :: area1(area1_l1:area1_h1,area1_l2:area1_h2)
-    double precision, intent(in) :: area2(area2_l1:area2_h1,area2_l2:area2_h2)
-    double precision, intent(inout) :: pdivu(ilo1:ihi1,ilo2:ihi2)
-    double precision, intent(in) :: vol(vol_l1:vol_h1,vol_l2:vol_h2)
+    real(rt)        , intent(in) :: area1(area1_l1:area1_h1,area1_l2:area1_h2)
+    real(rt)        , intent(in) :: area2(area2_l1:area2_h1,area2_l2:area2_h2)
+    real(rt)        , intent(inout) :: pdivu(ilo1:ihi1,ilo2:ihi2)
+    real(rt)        , intent(in) :: vol(vol_l1:vol_h1,vol_l2:vol_h2)
 
     ! Left and right state arrays (edge centered, cell centered)
-    double precision, allocatable::  qm(:,:,:),  qp(:,:,:)
-    double precision, allocatable:: qxm(:,:,:), qym(:,:,:)
-    double precision, allocatable:: qxp(:,:,:), qyp(:,:,:)
+    real(rt)        , allocatable::  qm(:,:,:),  qp(:,:,:)
+    real(rt)        , allocatable:: qxm(:,:,:), qym(:,:,:)
+    real(rt)        , allocatable:: qxp(:,:,:), qyp(:,:,:)
 
     ! Work arrays to hold riemann state and conservative fluxes
 
-    double precision, allocatable ::  fx(:,:,:),  fy(:,:,:)
+    real(rt)        , allocatable ::  fx(:,:,:),  fy(:,:,:)
 #ifdef RADIATION
-    double precision, allocatable ::  rfx(:,:,:),  rfy(:,:,:)
+    real(rt)        , allocatable ::  rfx(:,:,:),  rfy(:,:,:)
 #endif
-    double precision, allocatable ::  qgdxtmp(:,:,:)
-    double precision, allocatable :: shk(:,:)
+    real(rt)        , allocatable ::  qgdxtmp(:,:,:)
+    real(rt)        , allocatable :: shk(:,:)
 
     ! Local scalar variables
-    double precision :: dtdx
-    double precision :: hdtdx, hdt, hdtdy
+    real(rt)         :: dtdx
+    real(rt)         :: hdtdx, hdt, hdtdy
     integer          :: i,j
 
     allocate ( qgdxtmp(q1_l1:q1_h1,q1_l2:q1_h2,NGDNV))
@@ -377,6 +379,7 @@ contains
     use meth_params_module, only : USHK
 #endif
 
+    use bl_fort_module, only : rt => c_real
     integer, intent(in) :: lo(2), hi(2)
     integer, intent(in) :: uin_l1,uin_l2,uin_h1,uin_h2
     integer, intent(in) :: q_l1,q_l2,q_h1,q_h2
@@ -398,53 +401,53 @@ contains
 
     integer, intent(in) :: verbose
 
-    double precision, intent(in) :: uin(uin_l1:uin_h1,uin_l2:uin_h2,NVAR)
-    double precision, intent(in) :: q(q_l1:q_h1,q_l2:q_h2,NQ)
-    double precision, intent(in) :: uout(uout_l1:uout_h1,uout_l2:uout_h2,NVAR)
-    double precision, intent(inout) :: update(updt_l1:updt_h1,updt_l2:updt_h2,NVAR)
-    double precision, intent(in) :: q1(q1_l1:q1_h1,q1_l2:q1_h2,NGDNV)
-    double precision, intent(in) :: q2(q2_l1:q2_h1,q2_l2:q2_h2,NGDNV)
-    double precision, intent(inout) :: flux1(flux1_l1:flux1_h1,flux1_l2:flux1_h2,NVAR)
-    double precision, intent(inout) :: flux2(flux2_l1:flux2_h1,flux2_l2:flux2_h2,NVAR)
+    real(rt)        , intent(in) :: uin(uin_l1:uin_h1,uin_l2:uin_h2,NVAR)
+    real(rt)        , intent(in) :: q(q_l1:q_h1,q_l2:q_h2,NQ)
+    real(rt)        , intent(in) :: uout(uout_l1:uout_h1,uout_l2:uout_h2,NVAR)
+    real(rt)        , intent(inout) :: update(updt_l1:updt_h1,updt_l2:updt_h2,NVAR)
+    real(rt)        , intent(in) :: q1(q1_l1:q1_h1,q1_l2:q1_h2,NGDNV)
+    real(rt)        , intent(in) :: q2(q2_l1:q2_h1,q2_l2:q2_h2,NGDNV)
+    real(rt)        , intent(inout) :: flux1(flux1_l1:flux1_h1,flux1_l2:flux1_h2,NVAR)
+    real(rt)        , intent(inout) :: flux2(flux2_l1:flux2_h1,flux2_l2:flux2_h2,NVAR)
 #ifdef RADIATION
-    double precision, intent(in) :: Erin( Erin_l1: Erin_h1, Erin_l2: Erin_h2,0:ngroups-1)
-    double precision, intent(inout) :: Erout(Erout_l1:Erout_h1,Erout_l2:Erout_h2,0:ngroups-1)
-    double precision, intent(inout) :: rflux1(rflux1_l1:rflux1_h1,rflux1_l2:rflux1_h2,0:ngroups-1)
-    double precision, intent(inout) :: rflux2(rflux2_l1:rflux2_h1,rflux2_l2:rflux2_h2,0:ngroups-1)
+    real(rt)        , intent(in) :: Erin( Erin_l1: Erin_h1, Erin_l2: Erin_h2,0:ngroups-1)
+    real(rt)        , intent(inout) :: Erout(Erout_l1:Erout_h1,Erout_l2:Erout_h2,0:ngroups-1)
+    real(rt)        , intent(inout) :: rflux1(rflux1_l1:rflux1_h1,rflux1_l2:rflux1_h2,0:ngroups-1)
+    real(rt)        , intent(inout) :: rflux2(rflux2_l1:rflux2_h1,rflux2_l2:rflux2_h2,0:ngroups-1)
     integer, intent(inout) :: nstep_fsp
 #endif
-    double precision, intent(in) :: area1(area1_l1:area1_h1,area1_l2:area1_h2)
-    double precision, intent(in) :: area2(area2_l1:area2_h1,area2_l2:area2_h2)
-    double precision, intent(in) :: vol(vol_l1:vol_h1,vol_l2:vol_h2)
-    double precision, intent(in) :: div(lo(1):hi(1)+1,lo(2):hi(2)+1)
-    double precision, intent(in) :: pdivu(lo(1):hi(1),lo(2):hi(2))
-    double precision, intent(in) :: dx, dy, dt
-    double precision, intent(inout) :: E_added_flux, mass_added_flux
-    double precision, intent(inout) :: xmom_added_flux, ymom_added_flux, zmom_added_flux
-    double precision, intent(inout) :: mass_lost, xmom_lost, ymom_lost, zmom_lost
-    double precision, intent(inout) :: eden_lost, xang_lost, yang_lost, zang_lost
+    real(rt)        , intent(in) :: area1(area1_l1:area1_h1,area1_l2:area1_h2)
+    real(rt)        , intent(in) :: area2(area2_l1:area2_h1,area2_l2:area2_h2)
+    real(rt)        , intent(in) :: vol(vol_l1:vol_h1,vol_l2:vol_h2)
+    real(rt)        , intent(in) :: div(lo(1):hi(1)+1,lo(2):hi(2)+1)
+    real(rt)        , intent(in) :: pdivu(lo(1):hi(1),lo(2):hi(2))
+    real(rt)        , intent(in) :: dx, dy, dt
+    real(rt)        , intent(inout) :: E_added_flux, mass_added_flux
+    real(rt)        , intent(inout) :: xmom_added_flux, ymom_added_flux, zmom_added_flux
+    real(rt)        , intent(inout) :: mass_lost, xmom_lost, ymom_lost, zmom_lost
+    real(rt)        , intent(inout) :: eden_lost, xang_lost, yang_lost, zang_lost
 
     integer i, j, k, n
 
-    double precision div1
-    !double precision rho, Up, Vp, SrE
+    real(rt)         div1
+    !real(rt)         rho, Up, Vp, SrE
     integer domlo(3), domhi(3)
-    double precision loc(3), ang_mom(3)
+    real(rt)         loc(3), ang_mom(3)
 
 #ifdef RADIATION
     integer :: g
-    double precision :: SrU, Up, SrE
+    real(rt)         :: SrU, Up, SrE
 
-    double precision, dimension(0:ngroups-1) :: Erscale
-    double precision, dimension(0:ngroups-1) :: ustar, af
-    double precision :: Eddf, Eddfxm, Eddfxp, Eddfym, Eddfyp, f1, f2, f1xm, f1xp, f1ym, f1yp
-    double precision :: Gf1E(2)
-    double precision :: ux, uy, divu, lamc, Egdc
-    double precision :: dudx(2), dudy(2), nhat(2), GnDotu(2), nnColonDotGu
-    double precision :: dpdx, dprdx, dpdy, dprdy, ek1, ek2, dek
-    double precision :: urho_new
-    double precision :: umx_new1, umy_new1, umz_new1
-    double precision :: umx_new2, umy_new2, umz_new2
+    real(rt)        , dimension(0:ngroups-1) :: Erscale
+    real(rt)        , dimension(0:ngroups-1) :: ustar, af
+    real(rt)         :: Eddf, Eddfxm, Eddfxp, Eddfym, Eddfyp, f1, f2, f1xm, f1xp, f1ym, f1yp
+    real(rt)         :: Gf1E(2)
+    real(rt)         :: ux, uy, divu, lamc, Egdc
+    real(rt)         :: dudx(2), dudy(2), nhat(2), GnDotu(2), nnColonDotGu
+    real(rt)         :: dpdx, dprdx, dpdy, dprdy, ek1, ek2, dek
+    real(rt)         :: urho_new
+    real(rt)         :: umx_new1, umy_new1, umz_new1
+    real(rt)         :: umx_new2, umy_new2, umz_new2
 #endif
 
 #ifdef RADIATION
@@ -682,13 +685,13 @@ contains
                 GnDotu(1) = dot_product(nhat, dudx)
                 GnDotu(2) = dot_product(nhat, dudy)
 
-                nnColonDotGu = dot_product(nhat, GnDotu) / (dot_product(nhat,nhat)+1.d-50)
+                nnColonDotGu = dot_product(nhat, GnDotu) / (dot_product(nhat,nhat)+1.e-50_rt)
 
-                lamc = 0.25d0*(q1(i,j,GDLAMS+g) + q1(i+1,j,GDLAMS+g) + &
+                lamc = 0.25e0_rt*(q1(i,j,GDLAMS+g) + q1(i+1,j,GDLAMS+g) + &
                                q2(i,j,GDLAMS+g) + q2(i,j+1,GDLAMS+g))
                 Eddf = Edd_factor(lamc)
                 f1 = (ONE - Eddf)*HALF
-                f2 = (3.d0*Eddf - ONE)*HALF
+                f2 = (3.e0_rt*Eddf - ONE)*HALF
                 af(g) = -(f1*divu + f2*nnColonDotGu)
 
                 if (fspace_type .eq. 1) then
@@ -705,7 +708,7 @@ contains
                    Gf1E(1) = (f1xp*q1(i+1,j,GDERADS+g) - f1xm*q1(i,j,GDERADS+g)) / dx
                    Gf1E(2) = (f1yp*q2(i,j+1,GDERADS+g) - f1ym*q2(i,j,GDERADS+g)) / dy
 
-                   Egdc = 0.25d0*(q1(i,j,GDERADS+g) + q1(i+1,j,GDERADS+g) + &
+                   Egdc = 0.25e0_rt*(q1(i,j,GDERADS+g) + q1(i+1,j,GDERADS+g) + &
                                   q2(i,j,GDERADS+g) + q2(i,j+1,GDERADS+g))
 
                    Erout(i,j,g) = Erout(i,j,g) + dt*(ux*Gf1E(1)+uy*Gf1E(2)) &

--- a/Source/Src_2d/GR_Gravity_2d.f90
+++ b/Source/Src_2d/GR_Gravity_2d.f90
@@ -12,23 +12,24 @@
       use network, only : nspec, naux
       use bl_constants_module
 
+      use bl_fort_module, only : rt => c_real
       implicit none
 
       integer          :: lo(2),hi(2)
-      double precision :: dx(2),dr
-      double precision :: problo(2)
+      real(rt)         :: dx(2),dr
+      real(rt)         :: problo(2)
 
       integer          :: n1d,drdxfac,level
-      double precision :: radial_pres(0:n1d-1)
+      real(rt)         :: radial_pres(0:n1d-1)
 
       integer          :: r_l1,r_l2,r_h1,r_h2
-      double precision :: var(r_l1:r_h1,r_l2:r_h2,NVAR)
+      real(rt)         :: var(r_l1:r_h1,r_l2:r_h2,NVAR)
 
       integer          :: i,j,n,index
       integer          :: ii,jj
-      double precision :: xc,yc,r
-      double precision :: fac,xx,yy,dx_frac,dy_frac,vol_frac
-      double precision :: lo_i,lo_j,rlo,rhi
+      real(rt)         :: xc,yc,r
+      real(rt)         :: fac,xx,yy,dx_frac,dy_frac,vol_frac
+      real(rt)         :: lo_i,lo_j,rlo,rhi
 
       type (eos_t) :: eos_state
 

--- a/Source/Src_2d/Gravity_2d.f90
+++ b/Source/Src_2d/Gravity_2d.f90
@@ -1,5 +1,6 @@
 module gravity_2D_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   public
@@ -14,6 +15,7 @@ contains
 
     use bl_constants_module
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer          :: lo(2),hi(2)
@@ -21,14 +23,14 @@ contains
     integer          :: rhl1, rhl2, rhh1, rhh2
     integer          :: ecxl1, ecxl2, ecxh1, ecxh2
     integer          :: ecyl1, ecyl2, ecyh1, ecyh2
-    double precision :: rhs(rhl1:rhh1,rhl2:rhh2)
-    double precision :: ecx(ecxl1:ecxh1,ecxl2:ecxh2)
-    double precision :: ecy(ecyl1:ecyh1,ecyl2:ecyh2)
-    double precision :: dx(2), problo(2)
+    real(rt)         :: rhs(rhl1:rhh1,rhl2:rhh2)
+    real(rt)         :: ecx(ecxl1:ecxh1,ecxl2:ecxh2)
+    real(rt)         :: ecy(ecyl1:ecyh1,ecyl2:ecyh2)
+    real(rt)         :: dx(2), problo(2)
 
     ! Local variables
-    double precision :: lapphi
-    double precision :: ri,ro,rc
+    real(rt)         :: lapphi
+    real(rt)         :: ri,ro,rc
     integer          :: i,j
 
     ! Cartesian
@@ -80,24 +82,25 @@ contains
     use prob_params_module, only: center
     use meth_params_module, only: NVAR, URHO
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer          :: lo(2),hi(2)
-    double precision :: dx(2),dr
-    double precision :: problo(2)
+    real(rt)         :: dx(2),dr
+    real(rt)         :: problo(2)
 
     integer          :: n1d,drdxfac,level
-    double precision :: radial_mass(0:n1d-1)
-    double precision :: radial_vol (0:n1d-1)
+    real(rt)         :: radial_mass(0:n1d-1)
+    real(rt)         :: radial_vol (0:n1d-1)
 
     integer          :: r_l1,r_l2,r_h1,r_h2
-    double precision :: state(r_l1:r_h1,r_l2:r_h2,NVAR)
+    real(rt)         :: state(r_l1:r_h1,r_l2:r_h2,NVAR)
 
     integer          :: i,j,index
     integer          :: ii,jj
-    double precision :: xc,yc,r,octant_factor
-    double precision :: fac,xx,yy,dx_frac,dy_frac,vol_frac,vol_frac_fac
-    double precision :: lo_i,lo_j,rlo,rhi
+    real(rt)         :: xc,yc,r,octant_factor
+    real(rt)         :: fac,xx,yy,dx_frac,dy_frac,vol_frac,vol_frac_fac
+    real(rt)         :: lo_i,lo_j,rlo,rhi
 
     if (abs(center(2) - problo(2)) .lt. 1.e-2 * dx(2)) then
        octant_factor = TWO
@@ -168,21 +171,22 @@ contains
     use prob_params_module, only: center
     use bl_constants_module
 
+    use bl_fort_module, only : rt => c_real
     implicit none
     
     integer          :: lo(2),hi(2)
-    double precision :: dx(2),dr
-    double precision :: problo(2)
+    real(rt)         :: dx(2),dr
+    real(rt)         :: problo(2)
 
     integer          :: n1d,level
-    double precision :: radial_grav(0:n1d-1)
+    real(rt)         :: radial_grav(0:n1d-1)
 
     integer          :: g_l1,g_l2,g_h1,g_h2
-    double precision :: grav(g_l1:g_h1,g_l2:g_h2,2)
+    real(rt)         :: grav(g_l1:g_h1,g_l2:g_h2,2)
 
     integer          :: i,j,index
-    double precision :: x,y,r,mag_grav
-    double precision :: cen,xi,slope,glo,gmd,ghi,minvar,maxvar
+    real(rt)         :: x,y,r,mag_grav
+    real(rt)         :: cen,xi,slope,glo,gmd,ghi,minvar,maxvar
 
     ! Note that we are interpolating onto the entire range of grav,
     ! including the ghost cells
@@ -221,7 +225,7 @@ contains
              mag_grav = &
                   ( ghi -  TWO*gmd + glo)*xi**2/(TWO*dr**2) + &
                   ( ghi       - glo     )*xi   /(TWO*dr   ) + &
-                  (-ghi + 26.d0*gmd - glo)/24.d0
+                  (-ghi + 26.e0_rt*gmd - glo)/24.e0_rt
 
              minvar = min(gmd, min(glo,ghi))
              maxvar = max(gmd, max(glo,ghi))
@@ -248,22 +252,23 @@ contains
     use prob_params_module, only: center
     use bl_constants_module
 
+    use bl_fort_module, only : rt => c_real
     implicit none
     integer          :: lo(2),hi(2)
     integer          :: domlo(2),domhi(2)
-    double precision :: dx(2),dr
-    double precision :: problo(2)
+    real(rt)         :: dx(2),dr
+    real(rt)         :: problo(2)
 
     integer          :: numpts_1d
-    double precision :: radial_phi(0:numpts_1d-1)
+    real(rt)         :: radial_phi(0:numpts_1d-1)
     integer          :: fill_interior
 
     integer          :: p_l1,p_l2,p_h1,p_h2
-    double precision :: phi(p_l1:p_h1,p_l2:p_h2)
+    real(rt)         :: phi(p_l1:p_h1,p_l2:p_h2)
 
     integer          :: i,j,index
-    double precision :: x,y,r
-    double precision :: cen,xi,slope,p_lo,p_md,p_hi,minvar,maxvar
+    real(rt)         :: x,y,r
+    real(rt)         :: cen,xi,slope,p_lo,p_md,p_hi,minvar,maxvar
 
     ! Note that when we interpolate into the ghost cells we use the
     ! location of the edge, not the cell center
@@ -315,7 +320,7 @@ contains
                 phi(i,j) = &
                      ( p_hi -  TWO*p_md + p_lo)*xi**2/(TWO*dr**2) + &
                      ( p_hi       - p_lo      )*xi   /(TWO*dr   ) + &
-                     (-p_hi + 26.d0*p_md - p_lo)/24.d0
+                     (-p_hi + 26.e0_rt*p_md - p_lo)/24.e0_rt
                 minvar = min(p_md, min(p_lo,p_hi))
                 maxvar = max(p_md, max(p_lo,p_hi))
                 phi(i,j) = max(phi(i,j),minvar)

--- a/Source/Src_2d/MGutils_2d.f90
+++ b/Source/Src_2d/MGutils_2d.f90
@@ -1,5 +1,6 @@
 module MGutils_2D_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   public
@@ -14,6 +15,7 @@ contains
        ecy, ecyl1, ecyl2, ecyh1, ecyh2, dx, coord_type) &
        bind(C, name="ca_apply_metric")
 
+    use bl_fort_module, only : rt => c_real
     implicit none
     
     integer lo(2),hi(2),xlo(2),ylo(2),xhi(2),yhi(2)
@@ -21,12 +23,12 @@ contains
     integer ecxl1, ecxl2, ecxh1, ecxh2
     integer ecyl1, ecyl2, ecyh1, ecyh2
     integer coord_type
-    double precision rhs(rl1:rh1,rl2:rh2)
-    double precision ecx(ecxl1:ecxh1,ecxl2:ecxh2)
-    double precision ecy(ecyl1:ecyh1,ecyl2:ecyh2)
-    double precision dx(2)
+    real(rt)         rhs(rl1:rh1,rl2:rh2)
+    real(rt)         ecx(ecxl1:ecxh1,ecxl2:ecxh2)
+    real(rt)         ecy(ecyl1:ecyh1,ecyl2:ecyh2)
+    real(rt)         dx(2)
 
-    double precision r
+    real(rt)         r
     integer i,j
 
     ! r-z
@@ -34,7 +36,7 @@ contains
 
        ! At centers
        do i=lo(1),hi(1)
-          r = (dble(i)+0.5d0) * dx(1)
+          r = (dble(i)+0.5e0_rt) * dx(1)
           do j=lo(2),hi(2)
              rhs(i,j) = rhs(i,j) * r
           enddo
@@ -50,7 +52,7 @@ contains
 
        ! On y-edges
        do i=ylo(1),yhi(1)
-          r = (dble(i)+0.5d0) * dx(1)
+          r = (dble(i)+0.5e0_rt) * dx(1)
           do j=ylo(2),yhi(2)
              ecy(i,j) = ecy(i,j) * r
           enddo
@@ -69,15 +71,16 @@ contains
        cc, cl1, cl2, ch1, ch2,  &
        dx, coord_type) bind(C, name="ca_weight_cc")
 
+    use bl_fort_module, only : rt => c_real
     implicit none
     
     integer lo(2),hi(2)
     integer cl1, cl2, ch1, ch2
     integer coord_type
-    double precision cc(cl1:ch1,cl2:ch2)
-    double precision dx(2)
+    real(rt)         cc(cl1:ch1,cl2:ch2)
+    real(rt)         dx(2)
 
-    double precision r
+    real(rt)         r
     integer i,j
 
     ! r-z
@@ -85,7 +88,7 @@ contains
 
        ! At centers
        do i=lo(1),hi(1)
-          r = (dble(i)+0.5d0) * dx(1)
+          r = (dble(i)+0.5e0_rt) * dx(1)
           do j=lo(2),hi(2)
              cc(i,j) = cc(i,j) * r
           enddo
@@ -104,15 +107,16 @@ contains
        cc, cl1, cl2, ch1, ch2,  &
        dx, coord_type) bind(C, name="ca_unweight_cc")
 
+    use bl_fort_module, only : rt => c_real
     implicit none
     
     integer lo(2),hi(2)
     integer cl1, cl2, ch1, ch2
     integer coord_type
-    double precision cc(cl1:ch1,cl2:ch2)
-    double precision dx(2)
+    real(rt)         cc(cl1:ch1,cl2:ch2)
+    real(rt)         dx(2)
 
-    double precision r
+    real(rt)         r
     integer i,j
 
     ! r-z
@@ -120,7 +124,7 @@ contains
 
        ! At centers
        do i=lo(1),hi(1)
-          r = (dble(i)+0.5d0) * dx(1)
+          r = (dble(i)+0.5e0_rt) * dx(1)
           do j=lo(2),hi(2)
              cc(i,j) = cc(i,j) / r
           enddo
@@ -139,15 +143,16 @@ contains
        ec, ecl1, ecl2, ech1, ech2, dx, coord_type, idir) &
        bind(C, name="ca_unweight_edges")
 
+    use bl_fort_module, only : rt => c_real
     implicit none
     
     integer lo(2),hi(2)
     integer ecl1, ecl2, ech1, ech2
     integer coord_type, idir
-    double precision ec(ecl1:ech1,ecl2:ech2)
-    double precision dx(2)
+    real(rt)         ec(ecl1:ech1,ecl2:ech2)
+    real(rt)         dx(2)
 
-    double precision :: r
+    real(rt)         :: r
     integer          :: i,j
 
     ! r-z
@@ -166,7 +171,7 @@ contains
        else
           ! On y-edges
           do i = lo(1), hi(1)
-             r = (dble(i)+0.5d0) * dx(1)
+             r = (dble(i)+0.5e0_rt) * dx(1)
              do j = lo(2),hi(2)
                 ec(i,j) = ec(i,j) / r
              enddo

--- a/Source/Src_2d/Prob_2d.f90
+++ b/Source/Src_2d/Prob_2d.f90
@@ -1,10 +1,11 @@
 subroutine PROBINIT (init,name,namlen,problo,probhi)
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer          :: init, namlen
   integer          :: name(namlen)
-  double precision :: problo(2), probhi(2)
+  real(rt)         :: problo(2), probhi(2)
 
 end subroutine PROBINIT
 
@@ -36,13 +37,14 @@ subroutine ca_initdata(level,time,lo,hi,nvar, &
 
   use bl_error_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer :: level, nvar
   integer :: lo(2), hi(2)
   integer :: state_l1,state_l2,state_h1,state_h2
-  double precision :: xlo(2), xhi(2), time, dx(2)
-  double precision :: state(state_l1:state_h1,state_l2:state_h2,nvar)
+  real(rt)         :: xlo(2), xhi(2), time, dx(2)
+  real(rt)         :: state(state_l1:state_h1,state_l2:state_h2,nvar)
 
   ! Remove this call if you're defining your own problem; it is here to 
   ! ensure that you cannot run Castro if you haven't got your own copy of this function.

--- a/Source/Src_2d/advection_util_2d.f90
+++ b/Source/Src_2d/advection_util_2d.f90
@@ -1,5 +1,6 @@
 module advection_util_2d_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   private
@@ -17,17 +18,18 @@ contains
     use meth_params_module, only : NVAR, URHO, UFS
     use bl_constants_module
     
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer          :: lo(2),hi(2)
     integer          :: flux1_l1,flux1_l2,flux1_h1,flux1_h2
     integer          :: flux2_l1,flux2_l2,flux2_h1,flux2_h2
-    double precision :: flux1(flux1_l1:flux1_h1,flux1_l2:flux1_h2,NVAR)
-    double precision :: flux2(flux2_l1:flux2_h1,flux2_l2:flux2_h2,NVAR)
+    real(rt)         :: flux1(flux1_l1:flux1_h1,flux1_l2:flux1_h2,NVAR)
+    real(rt)         :: flux2(flux2_l1:flux2_h1,flux2_l2:flux2_h2,NVAR)
     
     ! Local variables
     integer          :: i,j,n
-    double precision :: sum,fac
+    real(rt)         :: sum,fac
     
     do j = lo(2),hi(2)
        do i = lo(1),hi(1)+1
@@ -74,15 +76,16 @@ contains
     use meth_params_module, only : NVAR, URHO, UFS
     use bl_constants_module
     
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer          :: lo(2), hi(2)
     integer          :: u_l1,u_l2,u_h1,u_h2
-    double precision :: u(u_l1:u_h1,u_l2:u_h2,NVAR)
+    real(rt)         :: u(u_l1:u_h1,u_l2:u_h2,NVAR)
     
     ! Local variables
     integer          :: i,j,n
-    double precision :: fac,sum
+    real(rt)         :: fac,sum
     
     do j = lo(2),hi(2)
        do i = lo(1),hi(1)
@@ -114,19 +117,20 @@ contains
     use meth_params_module, only : QU, QV
     use bl_constants_module
     
+    use bl_fort_module, only : rt => c_real
     implicit none
     
     integer          :: lo(2),hi(2)
     integer          :: q_l1,q_l2,q_h1,q_h2
     integer          :: div_l1,div_l2,div_h1,div_h2
-    double precision :: q(q_l1:q_h1,q_l2:q_h2,*)
-    double precision :: div(div_l1:div_h1,div_l2:div_h2)
-    double precision :: dx(2)
+    real(rt)         :: q(q_l1:q_h1,q_l2:q_h2,*)
+    real(rt)         :: div(div_l1:div_h1,div_l2:div_h2)
+    real(rt)         :: dx(2)
     
     integer          :: i, j
-    double precision :: rl, rr, rc, ul, ur
-    double precision :: vb, vt
-    double precision :: ux,vy
+    real(rt)         :: rl, rr, rc, ul, ur
+    real(rt)         :: vb, vt
+    real(rt)         :: ux,vy
     
     if (coord_type .eq. 0) then
        do j=lo(2),hi(2)+1

--- a/Source/Src_2d/bc_ext_fill_2d.F90
+++ b/Source/Src_2d/bc_ext_fill_2d.F90
@@ -7,6 +7,7 @@ module bc_ext_fill_module
                                  xl_ext, xr_ext, yl_ext, yr_ext, EXT_HSE, EXT_INTERP
   use interpolate_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   include 'bc_types.fi'
@@ -32,20 +33,21 @@ contains
     use network, only: nspec
     use model_parser_module
 
+    use bl_fort_module, only : rt => c_real
     integer adv_l1, adv_l2, adv_h1, adv_h2
     integer bc(2,2,*)
     integer domlo(2), domhi(2)
-    double precision delta(2), xlo(2), time
-    double precision adv(adv_l1:adv_h1,adv_l2:adv_h2,NVAR)
+    real(rt)         delta(2), xlo(2), time
+    real(rt)         adv(adv_l1:adv_h1,adv_l2:adv_h2,NVAR)
 
     integer i, j, q, n, iter, m
-    double precision y
-    double precision :: dens_above, dens_base, temp_above
-    double precision :: pres_above, p_want, pres_zone, A
-    double precision :: drho, dpdr, temp_zone, eint, X_zone(nspec), dens_zone
+    real(rt)         y
+    real(rt)         :: dens_above, dens_base, temp_above
+    real(rt)         :: pres_above, p_want, pres_zone, A
+    real(rt)         :: drho, dpdr, temp_zone, eint, X_zone(nspec), dens_zone
 
     integer, parameter :: MAX_ITER = 100
-    double precision, parameter :: TOL = 1.d-8
+    real(rt)        , parameter :: TOL = 1.e-8_rt
     logical :: converged_hse
 
     type (eos_t) :: eos_state
@@ -153,8 +155,8 @@ contains
                          A = p_want - pres_zone
                          drho = A/(dpdr + HALF*delta(2)*const_grav)
 
-                         dens_zone = max(0.9_dp_t*dens_zone, &
-                              min(dens_zone + drho, 1.1_dp_t*dens_zone))
+                         dens_zone = max(0.9_rt*dens_zone, &
+                              min(dens_zone + drho, 1.1_rt*dens_zone))
 
                          ! convergence?
                          if (abs(drho) < TOL*dens_zone) then
@@ -353,14 +355,15 @@ contains
     use model_parser_module
     use bl_error_module
 
+    use bl_fort_module, only : rt => c_real
     integer adv_l1,adv_l2,adv_h1,adv_h2
     integer bc(2,2,*)
     integer domlo(2), domhi(2)
-    double precision delta(2), xlo(2), time
-    double precision adv(adv_l1:adv_h1,adv_l2:adv_h2)
+    real(rt)         delta(2), xlo(2), time
+    real(rt)         adv(adv_l1:adv_h1,adv_l2:adv_h2)
 
     integer i,j
-    double precision y
+    real(rt)         y
 
     ! Note: this function should not be needed, technically, but is
     ! provided to filpatch because there are many times in the algorithm

--- a/Source/Src_2d/bc_fill_2d.F90
+++ b/Source/Src_2d/bc_fill_2d.F90
@@ -2,6 +2,7 @@ module bc_fill_module
 
   use bc_ext_fill_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   include 'bc_types.fi'
@@ -16,11 +17,12 @@ contains
 
     use meth_params_module, only: NVAR
 
+    use bl_fort_module, only : rt => c_real
     integer          :: adv_l1,adv_l2,adv_h1,adv_h2
     integer          :: bc(2,2,*)
     integer          :: domlo(2), domhi(2)
-    double precision :: delta(2), xlo(2), time
-    double precision :: adv(adv_l1:adv_h1,adv_l2:adv_h2,NVAR)
+    real(rt)         :: delta(2), xlo(2), time
+    real(rt)         :: adv(adv_l1:adv_h1,adv_l2:adv_h2,NVAR)
 
     integer          :: n
 
@@ -41,11 +43,12 @@ contains
                         domlo,domhi,delta,xlo,time,bc) &
                         bind(C, name="ca_denfill")
 
+    use bl_fort_module, only : rt => c_real
     integer          :: adv_l1,adv_l2,adv_h1,adv_h2
     integer          :: bc(2,2,*)
     integer          :: domlo(2), domhi(2)
-    double precision :: delta(2), xlo(2), time
-    double precision :: adv(adv_l1:adv_h1,adv_l2:adv_h2)
+    real(rt)         :: delta(2), xlo(2), time
+    real(rt)         :: adv(adv_l1:adv_h1,adv_l2:adv_h2)
 
     call filcc(adv,adv_l1,adv_l2,adv_h1,adv_h2,domlo,domhi,delta,xlo,bc)
 
@@ -62,11 +65,12 @@ contains
                             phi_h1,phi_h2,domlo,domhi,delta,xlo,time,bc) &
                             bind(C, name="ca_phigravfill")
 
+    use bl_fort_module, only : rt => c_real
     integer          :: phi_l1,phi_l2,phi_h1,phi_h2
     integer          :: bc(2,2,*)
     integer          :: domlo(2), domhi(2)
-    double precision :: delta(2), xlo(2), time
-    double precision :: phi(phi_l1:phi_h1,phi_l2:phi_h2)
+    real(rt)         :: delta(2), xlo(2), time
+    real(rt)         :: phi(phi_l1:phi_h1,phi_l2:phi_h2)
 
     call filcc(phi,phi_l1,phi_l2,phi_h1,phi_h2, &
                domlo,domhi,delta,xlo,bc)
@@ -79,11 +83,12 @@ contains
                           domlo,domhi,delta,xlo,time,bc) &
                           bind(C, name="ca_gravxfill")
 
+    use bl_fort_module, only : rt => c_real
     integer          :: grav_l1,grav_l2,grav_h1,grav_h2
     integer          :: bc(2,2,*)
     integer          :: domlo(2), domhi(2)
-    double precision :: delta(2), xlo(2), time
-    double precision :: grav(grav_l1:grav_h1,grav_l2:grav_h2)
+    real(rt)         :: delta(2), xlo(2), time
+    real(rt)         :: grav(grav_l1:grav_h1,grav_l2:grav_h2)
 
     integer :: bc_temp(2,2)
     
@@ -104,11 +109,12 @@ contains
                           domlo,domhi,delta,xlo,time,bc) &
                           bind(C, name="ca_gravyfill")
 
+    use bl_fort_module, only : rt => c_real
     integer          :: grav_l1,grav_l2,grav_h1,grav_h2
     integer          :: bc(2,2,*)
     integer          :: domlo(2), domhi(2)
-    double precision :: delta(2), xlo(2), time
-    double precision :: grav(grav_l1:grav_h1,grav_l2:grav_h2)
+    real(rt)         :: delta(2), xlo(2), time
+    real(rt)         :: grav(grav_l1:grav_h1,grav_l2:grav_h2)
 
     integer :: bc_temp(2,2)
 
@@ -129,11 +135,12 @@ contains
                           domlo,domhi,delta,xlo,time,bc) &
                           bind(C, name="ca_gravzfill")
 
+    use bl_fort_module, only : rt => c_real
     integer          :: grav_l1,grav_l2,grav_h1,grav_h2
     integer          :: bc(2,2,*)
     integer          :: domlo(2), domhi(2)
-    double precision :: delta(2), xlo(2), time
-    double precision :: grav(grav_l1:grav_h1,grav_l2:grav_h2)
+    real(rt)         :: delta(2), xlo(2), time
+    real(rt)         :: grav(grav_l1:grav_h1,grav_l2:grav_h2)
 
     integer :: bc_temp(2,2)
 
@@ -156,11 +163,12 @@ contains
                            phi_h1,phi_h2,domlo,domhi,delta,xlo,time,bc) &
                            bind(C, name="ca_phirotfill")
 
+    use bl_fort_module, only : rt => c_real
     integer          :: phi_l1,phi_l2,phi_h1,phi_h2
     integer          :: bc(2,2,*)
     integer          :: domlo(2), domhi(2)
-    double precision :: delta(2), xlo(2), time
-    double precision :: phi(phi_l1:phi_h1,phi_l2:phi_h2)
+    real(rt)         :: delta(2), xlo(2), time
+    real(rt)         :: phi(phi_l1:phi_h1,phi_l2:phi_h2)
 
     integer :: bc_temp(2,2)
 
@@ -182,11 +190,12 @@ contains
                          domlo,domhi,delta,xlo,time,bc) &
                          bind(C, name="ca_rotxfill")
 
+    use bl_fort_module, only : rt => c_real
     integer          :: rot_l1,rot_l2,rot_h1,rot_h2
     integer          :: bc(2,2,*)
     integer          :: domlo(2), domhi(2)
-    double precision :: delta(2), xlo(2), time
-    double precision :: rot(rot_l1:rot_h1,rot_l2:rot_h2)
+    real(rt)         :: delta(2), xlo(2), time
+    real(rt)         :: rot(rot_l1:rot_h1,rot_l2:rot_h2)
 
     integer :: bc_temp(2,2)
 
@@ -207,11 +216,12 @@ contains
                          domlo,domhi,delta,xlo,time,bc) &
                          bind(C, name="ca_rotyfill")
 
+    use bl_fort_module, only : rt => c_real
     integer          :: rot_l1,rot_l2,rot_h1,rot_h2
     integer          :: bc(2,2,*)
     integer          :: domlo(2), domhi(2)
-    double precision :: delta(2), xlo(2), time
-    double precision :: rot(rot_l1:rot_h1,rot_l2:rot_h2)
+    real(rt)         :: delta(2), xlo(2), time
+    real(rt)         :: rot(rot_l1:rot_h1,rot_l2:rot_h2)
 
     integer :: bc_temp(2,2)
 
@@ -232,11 +242,12 @@ contains
                          domlo,domhi,delta,xlo,time,bc) &
                          bind(C, name="ca_rotzfill")
 
+    use bl_fort_module, only : rt => c_real
     integer          :: rot_l1,rot_l2,rot_h1,rot_h2
     integer          :: bc(2,2,*)
     integer          :: domlo(2), domhi(2)
-    double precision :: delta(2), xlo(2), time
-    double precision :: rot(rot_l1:rot_h1,rot_l2:rot_h2)
+    real(rt)         :: delta(2), xlo(2), time
+    real(rt)         :: rot(rot_l1:rot_h1,rot_l2:rot_h2)
 
     integer :: bc_temp(2,2)
 
@@ -259,11 +270,12 @@ contains
                           react_h1,react_h2,domlo,domhi,delta,xlo,time,bc) &
                           bind(C, name="ca_reactfill")
 
+    use bl_fort_module, only : rt => c_real
     integer          :: react_l1,react_l2,react_h1,react_h2
     integer          :: bc(2,2,*)
     integer          :: domlo(2), domhi(2)
-    double precision :: delta(2), xlo(2), time
-    double precision :: react(react_l1:react_h1,react_l2:react_h2)
+    real(rt)         :: delta(2), xlo(2), time
+    real(rt)         :: react(react_l1:react_h1,react_l2:react_h2)
 
     integer :: bc_temp(2,2)
 
@@ -286,11 +298,12 @@ contains
   subroutine ca_radfill(rad,rad_l1,rad_l2, &
        rad_h1,rad_h2,domlo,domhi,delta,xlo,time,bc) bind(C, name="ca_radfill")
 
+    use bl_fort_module, only : rt => c_real
     integer :: rad_l1,rad_l2,rad_h1,rad_h2
     integer :: bc(2,2,*)
     integer :: domlo(2), domhi(2)
-    double precision delta(2), xlo(2), time
-    double precision rad(rad_l1:rad_h1,rad_l2:rad_h2)
+    real(rt)         delta(2), xlo(2), time
+    real(rt)         rad(rad_l1:rad_h1,rad_l2:rad_h2)
 
     integer :: bc_temp(2,2)
 

--- a/Source/Src_2d/ext_src_2d.f90
+++ b/Source/Src_2d/ext_src_2d.f90
@@ -26,15 +26,16 @@
     use meth_params_module, only : NVAR
     use bl_constants_module
 
+    use bl_fort_module, only : rt => c_real
     implicit none
     integer         , intent(in   ) :: lo(2),hi(2)
     integer         , intent(in   ) :: old_state_l1,old_state_l2,old_state_h1,old_state_h2
     integer         , intent(in   ) :: new_state_l1,new_state_l2,new_state_h1,new_state_h2
     integer         , intent(in   ) :: src_l1,src_l2,src_h1,src_h2
-    double precision, intent(in   ) :: old_state(old_state_l1:old_state_h1,old_state_l2:old_state_h2,NVAR)
-    double precision, intent(in   ) :: new_state(new_state_l1:new_state_h1,new_state_l2:new_state_h2,NVAR)
-    double precision, intent(  out) :: src(    src_l1:  src_h1,  src_l2:src_h2  ,NVAR)
-    double precision, intent(in   ) :: problo(2),dx(2),time,dt
+    real(rt)        , intent(in   ) :: old_state(old_state_l1:old_state_h1,old_state_l2:old_state_h2,NVAR)
+    real(rt)        , intent(in   ) :: new_state(new_state_l1:new_state_h1,new_state_l2:new_state_h2,NVAR)
+    real(rt)        , intent(  out) :: src(    src_l1:  src_h1,  src_l2:src_h2  ,NVAR)
+    real(rt)        , intent(in   ) :: problo(2),dx(2),time,dt
 
     integer          :: i,j
 

--- a/Source/Src_2d/pointmass_2d.f90
+++ b/Source/Src_2d/pointmass_2d.f90
@@ -10,16 +10,17 @@
        use prob_params_module          , only : center
        use bl_constants_module
 
+       use bl_fort_module, only : rt => c_real
        implicit none
 
        integer         , intent(in   ) :: lo(2), hi(2)
        integer         , intent(in   ) :: grav_l1,grav_l2,grav_h1,grav_h2
-       double precision, intent(in   ) :: point_mass
-       double precision, intent(inout) :: grav(grav_l1:grav_h1,grav_l2:grav_h2,2)
-       double precision, intent(in   ) :: problo(2),dx(2)
+       real(rt)        , intent(in   ) :: point_mass
+       real(rt)        , intent(inout) :: grav(grav_l1:grav_h1,grav_l2:grav_h2,2)
+       real(rt)        , intent(in   ) :: problo(2),dx(2)
 
        integer          :: i,j
-       double precision :: x,y,r,rsq,radial_force
+       real(rt)         :: x,y,r,rsq,radial_force
 
        ! We must be in r-z coordinates with problo(1) = 0. and center(1) = 0.
        !    or this doesn't make sense
@@ -57,6 +58,7 @@
       use prob_params_module, only : center
       use bl_constants_module
 
+      use bl_fort_module, only : rt => c_real
       implicit none
 
       integer :: lo(2),hi(2)
@@ -64,13 +66,13 @@
       integer :: uout_l1,uout_l2,uout_h1,uout_h2
       integer ::   vol_l1,  vol_l2,  vol_h1,  vol_h2
 
-      double precision   ::   delta_mass
-      double precision   ::   uin(  uin_l1:uin_h1,    uin_l2:uin_h2,  NVAR)
-      double precision   ::  uout( uout_l1:uout_h1,  uout_l2:uout_h2, NVAR)
-      double precision   ::   vol(  vol_l1:  vol_h1,  vol_l2:  vol_h2)
-      double precision   :: problo(2),dx(2),time,dt
+      real(rt)           ::   delta_mass
+      real(rt)           ::   uin(  uin_l1:uin_h1,    uin_l2:uin_h2,  NVAR)
+      real(rt)           ::  uout( uout_l1:uout_h1,  uout_l2:uout_h2, NVAR)
+      real(rt)           ::   vol(  vol_l1:  vol_h1,  vol_l2:  vol_h2)
+      real(rt)           :: problo(2),dx(2),time,dt
 
-      double precision   :: eps
+      real(rt)           :: eps
       integer            :: icen,istart,iend
       integer            :: jcen,jstart,jend
       integer            :: ii,jj,n
@@ -81,7 +83,7 @@
 
       ! This is just a small number to keep precision issues from making
       !   icen,jcen,kcen one cell too low.
-      eps = 1.d-8
+      eps = 1.e-8_rt
  
       ! This should be the cell whose lower left corner is at "center"
       icen = floor( (center(1)-problo(1))/dx(1) + eps)
@@ -115,24 +117,25 @@
       use meth_params_module, only : NVAR
       use prob_params_module, only : center
 
+      use bl_fort_module, only : rt => c_real
       implicit none
 
       integer :: lo(2),hi(2)
       integer :: uin_l1,uin_l2,uin_h1,uin_h2
       integer :: uout_l1,uout_l2,uout_h1,uout_h2
 
-      double precision   ::   uin(  uin_l1:uin_h1,    uin_l2:uin_h2,  NVAR)
-      double precision   ::  uout( uout_l1:uout_h1,  uout_l2:uout_h2, NVAR)
-      double precision   :: problo(2),dx(2),time,dt
+      real(rt)           ::   uin(  uin_l1:uin_h1,    uin_l2:uin_h2,  NVAR)
+      real(rt)           ::  uout( uout_l1:uout_h1,  uout_l2:uout_h2, NVAR)
+      real(rt)           :: problo(2),dx(2),time,dt
 
-      double precision   :: eps
+      real(rt)           :: eps
       integer            :: ii,icen,istart,iend
       integer            :: jj,jcen,jstart,jend
       integer, parameter :: box_size = 2
 
       ! This is just a small number to keep precision issues from making
       !   icen,jcen,kcen one cell too low.
-      eps = 1.d-8
+      eps = 1.e-8_rt
  
       ! This should be the cell whose lower left corner is at "center"
       icen = floor( (center(1)-problo(1))/dx(1) + eps)

--- a/Source/Src_2d/ppm_2d.f90
+++ b/Source/Src_2d/ppm_2d.f90
@@ -1,5 +1,6 @@
 module ppm_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   private 
@@ -18,45 +19,46 @@ contains
         use meth_params_module, only : ppm_type
         use bl_constants_module
 
+        use bl_fort_module, only : rt => c_real
         implicit none
 
         integer          s_l1,s_l2,s_h1,s_h2
         integer          qd_l1,qd_l2,qd_h1,qd_h2
         integer          ilo1,ilo2,ihi1,ihi2
-        double precision s(s_l1:s_h1,s_l2:s_h2)
-        double precision     u(qd_l1:qd_h1,qd_l2:qd_h2,1:2)
-        double precision  cspd(qd_l1:qd_h1,qd_l2:qd_h2)
-        double precision flatn(s_l1:s_h1,s_l2:s_h2)
-        double precision Ip(ilo1-1:ihi1+1,ilo2-1:ihi2+1,1:2,1:3)
-        double precision Im(ilo1-1:ihi1+1,ilo2-1:ihi2+1,1:2,1:3)
-        double precision dx,dy,dt
+        real(rt)         s(s_l1:s_h1,s_l2:s_h2)
+        real(rt)             u(qd_l1:qd_h1,qd_l2:qd_h2,1:2)
+        real(rt)          cspd(qd_l1:qd_h1,qd_l2:qd_h2)
+        real(rt)         flatn(s_l1:s_h1,s_l2:s_h2)
+        real(rt)         Ip(ilo1-1:ihi1+1,ilo2-1:ihi2+1,1:2,1:3)
+        real(rt)         Im(ilo1-1:ihi1+1,ilo2-1:ihi2+1,1:2,1:3)
+        real(rt)         dx,dy,dt
 
         ! local
         integer i,j
 
         logical extremum, bigp, bigm
 
-        double precision dsl, dsr, dsc, D2, D2C, D2L, D2R, D2LIM, C, alphap, alpham
-        double precision sgn, sigma, s6, amax, delam, delap
-        double precision dafacem, dafacep, dabarm, dabarp, dafacemin, dabarmin
-        double precision dachkm, dachkp
+        real(rt)         dsl, dsr, dsc, D2, D2C, D2L, D2R, D2LIM, C, alphap, alpham
+        real(rt)         sgn, sigma, s6, amax, delam, delap
+        real(rt)         dafacem, dafacep, dabarm, dabarp, dafacemin, dabarmin
+        real(rt)         dachkm, dachkp
 
         ! s_{\ib,+}, s_{\ib,-}
-        double precision, allocatable :: sp(:,:)
-        double precision, allocatable :: sm(:,:)
+        real(rt)        , allocatable :: sp(:,:)
+        real(rt)        , allocatable :: sm(:,:)
 
         ! \delta s_{\ib}^{vL}
-        double precision, allocatable :: dsvl(:,:)
+        real(rt)        , allocatable :: dsvl(:,:)
 
         ! s_{i+\half}^{H.O.}
-        double precision, allocatable :: sedge(:,:)
+        real(rt)        , allocatable :: sedge(:,:)
 
         ! cell-centered indexing
         allocate(sp(ilo1-1:ihi1+1,ilo2-1:ihi2+1))
         allocate(sm(ilo1-1:ihi1+1,ilo2-1:ihi2+1))
 
         ! constant used in Colella 2008
-        C = 1.25d0
+        C = 1.25e0_rt
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
         ! x-direction
@@ -197,15 +199,15 @@ contains
                     D2C = s(i-1,j)-TWO*s(i,j)+s(i+1,j)
                     sgn = sign(ONE,D2)
                     D2LIM = max(min(sgn*D2,C*sgn*D2L,C*sgn*D2R,C*sgn*D2C),ZERO)
-                    alpham = alpham*D2LIM/max(abs(D2),1.d-10)
-                    alphap = alphap*D2LIM/max(abs(D2),1.d-10)
+                    alpham = alpham*D2LIM/max(abs(D2),1.e-10_rt)
+                    alphap = alphap*D2LIM/max(abs(D2),1.e-10_rt)
                  else
                     if (bigp) then
                        sgn = sign(ONE,alpham)
                        amax = -alphap**2 / (4*(alpham + alphap))
                        delam = s(i-1,j) - s(i,j)
                        if (sgn*amax .ge. sgn*delam) then
-                          if (sgn*(delam - alpham).ge.1.d-10) then
+                          if (sgn*(delam - alpham).ge.1.e-10_rt) then
                              alphap = (-TWO*delam - TWO*sgn*sqrt(delam**2 - delam*alpham))
                           else 
                              alphap = -TWO*alpham
@@ -217,7 +219,7 @@ contains
                        amax = -alpham**2 / (4*(alpham + alphap))
                        delap = s(i+1,j) - s(i,j)
                        if (sgn*amax .ge. sgn*delap) then
-                          if (sgn*(delap - alphap).ge.1.d-10) then
+                          if (sgn*(delap - alphap).ge.1.e-10_rt) then
                              alpham = (-TWO*delap - TWO*sgn*sqrt(delap**2 - delap*alphap))
                           else
                              alpham = -TWO*alphap
@@ -439,15 +441,15 @@ contains
                     D2C = s(i,j-1)-TWO*s(i,j)+s(i,j+1)
                     sgn = sign(ONE,D2)
                     D2LIM = max(min(sgn*D2,C*sgn*D2L,C*sgn*D2R,C*sgn*D2C),ZERO)
-                    alpham = alpham*D2LIM/max(abs(D2),1.d-10)
-                    alphap = alphap*D2LIM/max(abs(D2),1.d-10)
+                    alpham = alpham*D2LIM/max(abs(D2),1.e-10_rt)
+                    alphap = alphap*D2LIM/max(abs(D2),1.e-10_rt)
                  else
                     if (bigp) then
                        sgn = sign(ONE,alpham)
                        amax = -alphap**2 / (4*(alpham + alphap))
                        delam = s(i,j-1) - s(i,j)
                        if (sgn*amax .ge. sgn*delam) then
-                          if (sgn*(delam - alpham).ge.1.d-10) then
+                          if (sgn*(delam - alpham).ge.1.e-10_rt) then
                              alphap = (-TWO*delam - TWO*sgn*sqrt(delam**2 - delam*alpham))
                           else 
                              alphap = -TWO*alpham
@@ -459,7 +461,7 @@ contains
                        amax = -alpham**2 / (4*(alpham + alphap))
                        delap = s(i,j+1) - s(i,j)
                        if (sgn*amax .ge. sgn*delap) then
-                          if (sgn*(delap - alphap).ge.1.d-10) then
+                          if (sgn*(delap - alphap).ge.1.e-10_rt) then
                              alpham = (-TWO*delap - TWO*sgn*sqrt(delap**2 - delap*alphap))
                           else
                              alpham = -TWO*alphap

--- a/Source/Src_2d/problem_tagging_2d.f90
+++ b/Source/Src_2d/problem_tagging_2d.f90
@@ -1,5 +1,6 @@
 module problem_tagging_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   public
@@ -18,16 +19,17 @@ contains
 
     use meth_params_module, only: NVAR
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer         ,intent(in   ) :: lo(2),hi(2)
     integer         ,intent(in   ) :: state_l1,state_l2, &
                                       state_h1,state_h2
     integer         ,intent(in   ) :: tagl1,tagl2,tagh1,tagh2
-    double precision,intent(in   ) :: state(state_l1:state_h1, &
+    real(rt)        ,intent(in   ) :: state(state_l1:state_h1, &
                                       state_l2:state_h2, NVAR)
     integer         ,intent(inout) :: tag(tagl1:tagh1,tagl2:tagh2)
-    double precision,intent(in   ) :: problo(2),dx(2),time
+    real(rt)        ,intent(in   ) :: problo(2),dx(2),time
     integer         ,intent(in   ) :: level,set,clear
 
   end subroutine set_problem_tags

--- a/Source/Src_2d/riemann_2d.F90
+++ b/Source/Src_2d/riemann_2d.F90
@@ -23,13 +23,14 @@ module riemann_module
     use fluxlimiter_module, only : Edd_factor
 #endif
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   private
 
   public cmpflx, shock, riemanncg
 
-  real (kind=dp_t), parameter :: smallu = 1.e-12_dp_t
+  real(rt)        , parameter :: smallu = 1.e-12_rt
 
 contains
 
@@ -51,6 +52,7 @@ contains
     use eos_module
     use network, only: nspec, naux
 
+    use bl_fort_module, only : rt => c_real
     integer, intent(in) :: qpd_l1,qpd_l2,qpd_h1,qpd_h2
     integer, intent(in) :: flx_l1,flx_l2,flx_h1,flx_h2
     integer, intent(in) :: qg_l1,qg_l2,qg_h1,qg_h2
@@ -62,30 +64,30 @@ contains
 
 #ifdef RADIATION
     integer, intent(in) :: rflx_l1,rflx_l2,rflx_h1,rflx_h2
-    double precision, intent(inout) :: rflx(rflx_l1:rflx_h1,rflx_l2:rflx_h2,0:ngroups-1)
+    real(rt)        , intent(inout) :: rflx(rflx_l1:rflx_h1,rflx_l2:rflx_h2,0:ngroups-1)
 #endif
 
-    double precision, intent(inout) :: qint(qg_l1:qg_h1,qg_l2:qg_h2,NGDNV)
+    real(rt)        , intent(inout) :: qint(qg_l1:qg_h1,qg_l2:qg_h2,NGDNV)
 
-    double precision, intent(inout) ::  qm(qpd_l1:qpd_h1,qpd_l2:qpd_h2,NQ)
-    double precision, intent(inout) ::  qp(qpd_l1:qpd_h1,qpd_l2:qpd_h2,NQ)
-    double precision, intent(inout) :: flx(flx_l1:flx_h1,flx_l2:flx_h2,NVAR)
+    real(rt)        , intent(inout) ::  qm(qpd_l1:qpd_h1,qpd_l2:qpd_h2,NQ)
+    real(rt)        , intent(inout) ::  qp(qpd_l1:qpd_h1,qpd_l2:qpd_h2,NQ)
+    real(rt)        , intent(inout) :: flx(flx_l1:flx_h1,flx_l2:flx_h2,NVAR)
 
-    double precision, intent(in) :: qaux(qa_l1:qa_h1,qa_l2:qa_h2,NQAUX)
-    double precision, intent(in) ::  shk( s_l1: s_h1, s_l2: s_h2)
+    real(rt)        , intent(in) :: qaux(qa_l1:qa_h1,qa_l2:qa_h2,NQAUX)
+    real(rt)        , intent(in) ::  shk( s_l1: s_h1, s_l2: s_h2)
 
     ! Local variables
     integer i, j
 
-    double precision, allocatable :: smallc(:,:), cavg(:,:)
-    double precision, allocatable :: gamcm(:,:), gamcp(:,:)
+    real(rt)        , allocatable :: smallc(:,:), cavg(:,:)
+    real(rt)        , allocatable :: gamcm(:,:), gamcp(:,:)
 #ifdef RADIATION    
-    double precision, allocatable :: gamcgm(:,:), gamcgp(:,:), lam(:,:,:)
+    real(rt)        , allocatable :: gamcgm(:,:), gamcgp(:,:), lam(:,:,:)
 #endif
     
     integer :: imin, imax, jmin, jmax
     integer :: is_shock
-    double precision :: cl, cr
+    real(rt)         :: cl, cr
     type (eos_t) :: eos_state
 
     allocate ( smallc(ilo-1:ihi+1,jlo-1:jhi+1) )
@@ -170,7 +172,7 @@ contains
 
              ! this is an initial guess for iterations, since we
              ! can't be certain that temp is on interfaces
-             eos_state%T = 10000.0d0
+             eos_state%T = 10000.0e0_rt
 
              ! minus state
              eos_state % rho = qm(i,j,QRHO)
@@ -308,24 +310,25 @@ contains
 
     use prob_params_module, only : coord_type
 
+    use bl_fort_module, only : rt => c_real
     integer, intent(in) :: qd_l1, qd_l2, qd_h1, qd_h2
     integer, intent(in) :: s_l1, s_l2, s_h1, s_h2
     integer, intent(in) :: ilo1, ilo2, ihi1, ihi2
-    double precision, intent(in) :: dx, dy
-    double precision, intent(in) :: q(qd_l1:qd_h1,qd_l2:qd_h2,NQ)
-    double precision, intent(inout) :: shk(s_l1:s_h1,s_l2:s_h2)
+    real(rt)        , intent(in) :: dx, dy
+    real(rt)        , intent(in) :: q(qd_l1:qd_h1,qd_l2:qd_h2,NQ)
+    real(rt)        , intent(inout) :: shk(s_l1:s_h1,s_l2:s_h2)
 
     integer :: i, j
 
-    double precision :: divU
-    double precision :: px_pre, px_post, py_pre, py_post
-    double precision :: e_x, e_y, d
-    double precision :: p_pre, p_post, pjump
+    real(rt)         :: divU
+    real(rt)         :: px_pre, px_post, py_pre, py_post
+    real(rt)         :: e_x, e_y, d
+    real(rt)         :: p_pre, p_post, pjump
 
-    double precision :: rc, rm, rp
+    real(rt)         :: rc, rm, rp
 
-    double precision, parameter :: small = 1.d-10
-    double precision, parameter :: eps = 0.33d0
+    real(rt)        , parameter :: small = 1.e-10_rt
+    real(rt)        , parameter :: eps = 0.33e0_rt
 
     ! This is a basic multi-dimensional shock detection algorithm.
     ! This implementation follows Flash, which in turn follows
@@ -420,8 +423,9 @@ contains
     use eos_module
     use prob_params_module, only : coord_type
 
-    double precision, parameter:: small = 1.d-8
-    double precision, parameter :: small_u = 1.d-10
+    use bl_fort_module, only : rt => c_real
+    real(rt)        , parameter:: small = 1.e-8_rt
+    real(rt)        , parameter :: small_u = 1.e-10_rt
 
     integer :: qpd_l1,qpd_l2,qpd_h1,qpd_h2
     integer :: gd_l1,gd_l2,gd_h1,gd_h2
@@ -430,48 +434,48 @@ contains
     integer :: idir,ilo1,ihi1,ilo2,ihi2
     integer :: domlo(2),domhi(2)
 
-    double precision :: ql(qpd_l1:qpd_h1,qpd_l2:qpd_h2,NQ)
-    double precision :: qr(qpd_l1:qpd_h1,qpd_l2:qpd_h2,NQ)
-    double precision ::  gamcl(gd_l1:gd_h1,gd_l2:gd_h2)
-    double precision ::  gamcr(gd_l1:gd_h1,gd_l2:gd_h2)
-    double precision ::    cav(gd_l1:gd_h1,gd_l2:gd_h2)
-    double precision :: smallc(gd_l1:gd_h1,gd_l2:gd_h2)
-    double precision :: uflx(uflx_l1:uflx_h1,uflx_l2:uflx_h2,NVAR)
-    double precision :: qint(qg_l1:qg_h1,qg_l2:qg_h2,NGDNV)
+    real(rt)         :: ql(qpd_l1:qpd_h1,qpd_l2:qpd_h2,NQ)
+    real(rt)         :: qr(qpd_l1:qpd_h1,qpd_l2:qpd_h2,NQ)
+    real(rt)         ::  gamcl(gd_l1:gd_h1,gd_l2:gd_h2)
+    real(rt)         ::  gamcr(gd_l1:gd_h1,gd_l2:gd_h2)
+    real(rt)         ::    cav(gd_l1:gd_h1,gd_l2:gd_h2)
+    real(rt)         :: smallc(gd_l1:gd_h1,gd_l2:gd_h2)
+    real(rt)         :: uflx(uflx_l1:uflx_h1,uflx_l2:uflx_h2,NVAR)
+    real(rt)         :: qint(qg_l1:qg_h1,qg_l2:qg_h2,NGDNV)
 
     integer :: i,j,ilo,jlo,ihi,jhi, ipassive
     integer :: n, nqp
 
-    double precision :: rgdnv,vgdnv,wgdnv,ustar,gamgdnv
-    double precision :: rl, ul, vl, v2l, pl, rel
-    double precision :: rr, ur, vr, v2r, pr, rer
-    double precision :: wl, wr, rhoetot
-    double precision :: rstar, cstar, pstar
-    double precision :: ro, uo, po, co, gamco
-    double precision :: sgnm, spin, spout, ushock, frac
-    double precision :: wsmall, csmall,qavg
+    real(rt)         :: rgdnv,vgdnv,wgdnv,ustar,gamgdnv
+    real(rt)         :: rl, ul, vl, v2l, pl, rel
+    real(rt)         :: rr, ur, vr, v2r, pr, rer
+    real(rt)         :: wl, wr, rhoetot
+    real(rt)         :: rstar, cstar, pstar
+    real(rt)         :: ro, uo, po, co, gamco
+    real(rt)         :: sgnm, spin, spout, ushock, frac
+    real(rt)         :: wsmall, csmall,qavg
 
-    double precision :: gcl, gcr
-    double precision :: clsq, clsql, clsqr, wlsq, wosq, wrsq, wo
-    double precision :: zl, zr
-    double precision :: denom, dpditer, dpjmp
-    double precision :: gamc_bar, game_bar
-    double precision :: gamel, gamer, gameo, gamstar, gmin, gmax, gdot
+    real(rt)         :: gcl, gcr
+    real(rt)         :: clsq, clsql, clsqr, wlsq, wosq, wrsq, wo
+    real(rt)         :: zl, zr
+    real(rt)         :: denom, dpditer, dpjmp
+    real(rt)         :: gamc_bar, game_bar
+    real(rt)         :: gamel, gamer, gameo, gamstar, gmin, gmax, gdot
 
     integer :: iter, iter_max
-    double precision :: tol
-    double precision :: err
+    real(rt)         :: tol
+    real(rt)         :: err
 
     logical :: converged
 
-    double precision :: pstar_old
-    double precision :: taul, taur, tauo
-    double precision :: ustar_r, ustar_l, ustar_r_old, ustar_l_old
-    double precision :: pstar_lo, pstar_hi
+    real(rt)         :: pstar_old
+    real(rt)         :: taul, taur, tauo
+    real(rt)         :: ustar_r, ustar_l, ustar_r_old, ustar_l_old
+    real(rt)         :: pstar_lo, pstar_hi
 
-    double precision, parameter :: weakwv = 1.d-3
+    real(rt)        , parameter :: weakwv = 1.e-3_rt
 
-    double precision, allocatable :: pstar_hist(:), pstar_hist_extra(:)
+    real(rt)        , allocatable :: pstar_hist(:), pstar_hist_extra(:)
 
     type (eos_t) :: eos_state
 
@@ -956,7 +960,8 @@ contains
 
     use prob_params_module, only : coord_type
 
-    double precision, parameter:: small = 1.d-8
+    use bl_fort_module, only : rt => c_real
+    real(rt)        , parameter:: small = 1.e-8_rt
 
     integer :: qpd_l1, qpd_l2, qpd_h1, qpd_h2
     integer :: gd_l1, gd_l2, gd_h1, gd_h2
@@ -968,20 +973,20 @@ contains
     integer :: idir, ilo1, ihi1, ilo2, ihi2
     integer :: domlo(2),domhi(2)
 
-    double precision :: ql(qpd_l1:qpd_h1,qpd_l2:qpd_h2,NQ)
-    double precision :: qr(qpd_l1:qpd_h1,qpd_l2:qpd_h2,NQ)
+    real(rt)         :: ql(qpd_l1:qpd_h1,qpd_l2:qpd_h2,NQ)
+    real(rt)         :: qr(qpd_l1:qpd_h1,qpd_l2:qpd_h2,NQ)
 
-    double precision :: gamcl(gd_l1:gd_h1,gd_l2:gd_h2)
-    double precision :: gamcr(gd_l1:gd_h1,gd_l2:gd_h2)
-    double precision :: cav(gd_l1:gd_h1,gd_l2:gd_h2)
-    double precision :: smallc(gd_l1:gd_h1,gd_l2:gd_h2)
-    double precision :: uflx(uflx_l1:uflx_h1,uflx_l2:uflx_h2,NVAR)
-    double precision :: qint(qg_l1:qg_h1,qg_l2:qg_h2,NGDNV)
+    real(rt)         :: gamcl(gd_l1:gd_h1,gd_l2:gd_h2)
+    real(rt)         :: gamcr(gd_l1:gd_h1,gd_l2:gd_h2)
+    real(rt)         :: cav(gd_l1:gd_h1,gd_l2:gd_h2)
+    real(rt)         :: smallc(gd_l1:gd_h1,gd_l2:gd_h2)
+    real(rt)         :: uflx(uflx_l1:uflx_h1,uflx_l2:uflx_h2,NVAR)
+    real(rt)         :: qint(qg_l1:qg_h1,qg_l2:qg_h2,NGDNV)
 #ifdef RADIATION
-    double precision ::    lam(gd_l1:gd_h1,gd_l2:gd_h2,0:ngroups-1)
-    double precision :: gamcgl(gd_l1:gd_h1,gd_l2:gd_h2)
-    double precision :: gamcgr(gd_l1:gd_h1,gd_l2:gd_h2)
-    double precision :: rflx(rflx_l1:rflx_h1,rflx_l2:rflx_h2,0:ngroups-1)
+    real(rt)         ::    lam(gd_l1:gd_h1,gd_l2:gd_h2,0:ngroups-1)
+    real(rt)         :: gamcgl(gd_l1:gd_h1,gd_l2:gd_h2)
+    real(rt)         :: gamcgr(gd_l1:gd_h1,gd_l2:gd_h2)
+    real(rt)         :: rflx(rflx_l1:rflx_h1,rflx_l2:rflx_h2,0:ngroups-1)
 #endif
 
     integer :: ilo,ihi,jlo,jhi
@@ -992,24 +997,24 @@ contains
     integer :: g
 #endif
 
-    double precision :: rgd, vgd, wgd, regd, ustar
+    real(rt)         :: rgd, vgd, wgd, regd, ustar
 #ifdef RADIATION
-    double precision, dimension(0:ngroups-1) :: erl, err
+    real(rt)        , dimension(0:ngroups-1) :: erl, err
 #endif
-    double precision :: rl, ul, vl, v2l, pl, rel
-    double precision :: rr, ur, vr, v2r, pr, rer
-    double precision :: wl, wr, rhoetot, scr
-    double precision :: rstar, cstar, estar, pstar
-    double precision :: ro, uo, po, reo, co, gamco, entho, drho
-    double precision :: sgnm, spin, spout, ushock, frac
-    double precision :: wsmall, csmall,qavg
+    real(rt)         :: rl, ul, vl, v2l, pl, rel
+    real(rt)         :: rr, ur, vr, v2r, pr, rer
+    real(rt)         :: wl, wr, rhoetot, scr
+    real(rt)         :: rstar, cstar, estar, pstar
+    real(rt)         :: ro, uo, po, reo, co, gamco, entho, drho
+    real(rt)         :: sgnm, spin, spout, ushock, frac
+    real(rt)         :: wsmall, csmall,qavg
 
 #ifdef RADIATION
-    double precision :: regdnv_g, pgdnv_g, pgdnv_t
-    double precision :: estar_g, pstar_g
-    double precision, dimension(0:ngroups-1) :: lambda, reo_r, po_r, estar_r, regdnv_r
-    double precision :: eddf, f1
-    double precision :: co_g, gamco_g, pl_g, po_g, pr_g, rel_g, reo_g, rer_g
+    real(rt)         :: regdnv_g, pgdnv_g, pgdnv_t
+    real(rt)         :: estar_g, pstar_g
+    real(rt)        , dimension(0:ngroups-1) :: lambda, reo_r, po_r, estar_r, regdnv_r
+    real(rt)         :: eddf, f1
+    real(rt)         :: co_g, gamco_g, pl_g, po_g, pr_g, rel_g, reo_g, rer_g
 #endif
 
     integer :: iu, iv1, iv2
@@ -1156,13 +1161,13 @@ contains
 #ifdef RADIATION
              if (idir == 1) then
                 do g = 0, ngroups-1
-                   lambda(g) = 2.0d0*(lam(i-1,j,g)*lam(i,j,g))/ &
-                        (lam(i-1,j,g)+lam(i,j,g)+1.d-50)
+                   lambda(g) = 2.0e0_rt*(lam(i-1,j,g)*lam(i,j,g))/ &
+                        (lam(i-1,j,g)+lam(i,j,g)+1.e-50_rt)
                 end do
              else
                 do g = 0, ngroups-1
-                   lambda(g) = 2.0d0*(lam(i,j-1,g)*lam(i,j,g))/ &
-                        (lam(i,j-1,g)+lam(i,j,g)+1.d-50)
+                   lambda(g) = 2.0e0_rt*(lam(i,j-1,g)*lam(i,j,g))/ &
+                        (lam(i,j-1,g)+lam(i,j,g)+1.e-50_rt)
                 end do
              end if
 #endif
@@ -1382,7 +1387,8 @@ contains
     ! to know the pressure and velocity on the interface for the grad p
     ! term in momentum and for an internal energy update
 
-    double precision, parameter:: small = 1.d-8
+    use bl_fort_module, only : rt => c_real
+    real(rt)        , parameter:: small = 1.e-8_rt
 
     integer :: qpd_l1, qpd_l2, qpd_h1, qpd_h2
     integer :: gd_l1, gd_l2, gd_h1, gd_h2
@@ -1391,31 +1397,31 @@ contains
     integer :: idir, ilo1, ihi1, ilo2, ihi2
     integer :: domlo(2),domhi(2)
 
-    double precision :: ql(qpd_l1:qpd_h1,qpd_l2:qpd_h2,NQ)
-    double precision :: qr(qpd_l1:qpd_h1,qpd_l2:qpd_h2,NQ)
-    double precision :: gamcl(gd_l1:gd_h1,gd_l2:gd_h2)
-    double precision :: gamcr(gd_l1:gd_h1,gd_l2:gd_h2)
-    double precision :: cav(gd_l1:gd_h1,gd_l2:gd_h2)
-    double precision :: smallc(gd_l1:gd_h1,gd_l2:gd_h2)
-    double precision :: uflx(uflx_l1:uflx_h1,uflx_l2:uflx_h2,NVAR)
-    double precision :: qint(qg_l1:qg_h1,qg_l2:qg_h2,NGDNV)
+    real(rt)         :: ql(qpd_l1:qpd_h1,qpd_l2:qpd_h2,NQ)
+    real(rt)         :: qr(qpd_l1:qpd_h1,qpd_l2:qpd_h2,NQ)
+    real(rt)         :: gamcl(gd_l1:gd_h1,gd_l2:gd_h2)
+    real(rt)         :: gamcr(gd_l1:gd_h1,gd_l2:gd_h2)
+    real(rt)         :: cav(gd_l1:gd_h1,gd_l2:gd_h2)
+    real(rt)         :: smallc(gd_l1:gd_h1,gd_l2:gd_h2)
+    real(rt)         :: uflx(uflx_l1:uflx_h1,uflx_l2:uflx_h2,NVAR)
+    real(rt)         :: qint(qg_l1:qg_h1,qg_l2:qg_h2,NGDNV)
 
     integer :: ilo,ihi,jlo,jhi
     integer :: i, j
     integer :: bnd_fac
     
-    !double precision :: regd
-    double precision :: ustar
-    double precision :: rl, ul, pl, rel
-    double precision :: rr, ur, pr, rer
-    double precision :: wl, wr, scr
-    double precision :: rstar, cstar, pstar
-    double precision :: ro, uo, po, co, gamco
-    double precision :: sgnm, spin, spout, ushock, frac
-    double precision :: wsmall, csmall
+    !real(rt)         :: regd
+    real(rt)         :: ustar
+    real(rt)         :: rl, ul, pl, rel
+    real(rt)         :: rr, ur, pr, rer
+    real(rt)         :: wl, wr, scr
+    real(rt)         :: rstar, cstar, pstar
+    real(rt)         :: ro, uo, po, co, gamco
+    real(rt)         :: sgnm, spin, spout, ushock, frac
+    real(rt)         :: wsmall, csmall
 
-    double precision :: U_hllc_state(nvar), U_state(nvar), F_state(nvar)
-    double precision :: S_l, S_r, S_c
+    real(rt)         :: U_hllc_state(nvar), U_state(nvar), F_state(nvar)
+    real(rt)         :: S_l, S_r, S_c
 
     integer :: iu, iv1, iv2
 

--- a/Source/Src_2d/slope_2d.f90
+++ b/Source/Src_2d/slope_2d.f90
@@ -1,5 +1,6 @@
 module slope_module
   
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   private
@@ -18,6 +19,7 @@ contains
 
     use bl_constants_module        
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer ilo,ihi
@@ -25,15 +27,15 @@ contains
     integer qpd_l1,qpd_l2,qpd_h1,qpd_h2
     integer ilo1,ilo2,ihi1,ihi2,nv,idir
     
-    double precision     q( qd_l1: qd_h1, qd_l2: qd_h2,nv)
-    double precision flatn( qd_l1: qd_h1, qd_l2: qd_h2)
-    double precision    dq(qpd_l1:qpd_h1,qpd_l2:qpd_h2,nv)
+    real(rt)             q( qd_l1: qd_h1, qd_l2: qd_h2,nv)
+    real(rt)         flatn( qd_l1: qd_h1, qd_l2: qd_h2)
+    real(rt)            dq(qpd_l1:qpd_h1,qpd_l2:qpd_h2,nv)
     
     ! local
-    double precision, allocatable::dsgn(:),dlim(:),df(:),dcen(:)
+    real(rt)        , allocatable::dsgn(:),dlim(:),df(:),dcen(:)
     
     integer i, j, n
-    double precision dlft, drgt, dq1
+    real(rt)         dlft, drgt, dq1
     
     ilo = MIN(ilo1,ilo2)
     ihi = MAX(ihi1,ihi2)
@@ -119,6 +121,7 @@ contains
     use bl_constants_module
     use meth_params_module, only: QU, QV, QVAR
     
+    use bl_fort_module, only : rt => c_real
     implicit none
     
     integer ilo,ihi
@@ -127,18 +130,18 @@ contains
     integer src_l1,src_l2,src_h1,src_h2
     integer ilo1,ilo2,ihi1,ihi2,idir
     
-    double precision, intent(in   ) ::      p( qd_l1: qd_h1, qd_l2: qd_h2)
-    double precision, intent(in   ) ::    rho( qd_l1: qd_h1, qd_l2: qd_h2)
-    double precision, intent(in   ) ::  flatn( qd_l1: qd_h1, qd_l2: qd_h2)
-    double precision, intent(  out) ::     dp(qpd_l1:qpd_h1,qpd_l2:qpd_h2)
-    double precision, intent(in   ) ::    src(src_l1:src_h1,src_l2:src_h2,QVAR)
-    double precision, intent(in   ) ::  dx,dy
+    real(rt)        , intent(in   ) ::      p( qd_l1: qd_h1, qd_l2: qd_h2)
+    real(rt)        , intent(in   ) ::    rho( qd_l1: qd_h1, qd_l2: qd_h2)
+    real(rt)        , intent(in   ) ::  flatn( qd_l1: qd_h1, qd_l2: qd_h2)
+    real(rt)        , intent(  out) ::     dp(qpd_l1:qpd_h1,qpd_l2:qpd_h2)
+    real(rt)        , intent(in   ) ::    src(src_l1:src_h1,src_l2:src_h2,QVAR)
+    real(rt)        , intent(in   ) ::  dx,dy
     
     ! local
-    double precision, allocatable :: dsgn(:), dlim(:), df(:), dcen(:)
+    real(rt)        , allocatable :: dsgn(:), dlim(:), df(:), dcen(:)
     
     integer          :: i, j
-    double precision :: dlft, drgt, dp1
+    real(rt)         :: dlft, drgt, dp1
     
     ilo = MIN(ilo1,ilo2)
     ihi = MAX(ihi1,ihi2)
@@ -227,29 +230,30 @@ contains
 
     use bl_constants_module        
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer, intent(in) :: qd_l1, qd_l2, qd_h1, qd_h2
     integer, intent(in) :: qpd_l1, qpd_l2, qpd_h1, qpd_h2
     integer, intent(in) :: ilo, jlo, ihi, jhi
 
-    double precision, intent(in) :: dx, dy
+    real(rt)        , intent(in) :: dx, dy
 
-    double precision, intent(in) ::     q( qd_l1: qd_h1, qd_l2: qd_h2)
-    double precision, intent(in) :: flatn( qd_l1: qd_h1, qd_l2: qd_h2)
+    real(rt)        , intent(in) ::     q( qd_l1: qd_h1, qd_l2: qd_h2)
+    real(rt)        , intent(in) :: flatn( qd_l1: qd_h1, qd_l2: qd_h2)
 
-    double precision, intent(inout) :: dqx(qpd_l1:qpd_h1,qpd_l2:qpd_h2)
-    double precision, intent(inout) :: dqy(qpd_l1:qpd_h1,qpd_l2:qpd_h2)
+    real(rt)        , intent(inout) :: dqx(qpd_l1:qpd_h1,qpd_l2:qpd_h2)
+    real(rt)        , intent(inout) :: dqy(qpd_l1:qpd_h1,qpd_l2:qpd_h2)
 
     integer :: i, j, m, n
     
-    double precision, allocatable :: q_nd(:,:)
+    real(rt)        , allocatable :: q_nd(:,:)
 
     integer, parameter :: ill = 1, ilh = 2, irl = 3, irh = 4
-    double precision :: ss(4), ss_temp(4), min_ss(4), max_ss(4), diff(4)
-    double precision :: A_x, A_y, A_xy
-    double precision :: sumdiff, sgndiff, redfac, redmax, div
-    double precision, parameter :: eps = 1.d-10
+    real(rt)         :: ss(4), ss_temp(4), min_ss(4), max_ss(4), diff(4)
+    real(rt)         :: A_x, A_y, A_xy
+    real(rt)         :: sumdiff, sgndiff, redfac, redmax, div
+    real(rt)        , parameter :: eps = 1.e-10_rt
     integer :: kdp
     integer, parameter :: niter = 3
     
@@ -267,11 +271,11 @@ contains
        do i = ilo-2, ihi+3
           
           q_nd(i,j) = &
-             (         q(i-2,j-2) -  7.0d0*(q(i-1,j-2) + q(i,j-2)) +       q(i+1,j-2) + &
-              (-7.0d0)*q(i-2,j-1) + 49.0d0*(q(i-1,j-1) + q(i,j-1)) - 7.0d0*q(i+1,j-1) + &
-              (-7.0d0)*q(i-2,j  ) + 49.0d0*(q(i-1,j  ) + q(i,j  )) - 7.0d0*q(i+1,j  ) + &
-                       q(i-2,j+1) -  7.0d0*(q(i-1,j+1) + q(i,j+1)) +       q(i+1,j+1))/ &
-             144.0d0
+             (         q(i-2,j-2) -  7.0e0_rt*(q(i-1,j-2) + q(i,j-2)) +       q(i+1,j-2) + &
+              (-7.0e0_rt)*q(i-2,j-1) + 49.0e0_rt*(q(i-1,j-1) + q(i,j-1)) - 7.0e0_rt*q(i+1,j-1) + &
+              (-7.0e0_rt)*q(i-2,j  ) + 49.0e0_rt*(q(i-1,j  ) + q(i,j  )) - 7.0e0_rt*q(i+1,j  ) + &
+                       q(i-2,j+1) -  7.0e0_rt*(q(i-1,j+1) + q(i,j+1)) +       q(i+1,j+1))/ &
+             144.0e0_rt
 
        enddo
     enddo
@@ -286,15 +290,15 @@ contains
           ss(irl) = q_nd(i+1,j)   ! a_{i+1/2,j-1/2}
           ss(irh) = q_nd(i+1,j+1) ! a_{i+1/2,j+1/2}
           
-          A_x  = ((ss(irh) + ss(irl)) - (ss(ilh) + ss(ill)))/(2.0d0*dx)
-          A_y  = ((ss(ilh) + ss(irh)) - (ss(ill) + ss(irl)))/(2.0d0*dy)
+          A_x  = ((ss(irh) + ss(irl)) - (ss(ilh) + ss(ill)))/(2.0e0_rt*dx)
+          A_y  = ((ss(ilh) + ss(irh)) - (ss(ill) + ss(irl)))/(2.0e0_rt*dy)
           A_xy = ((ss(irh) - ss(irl)) - (ss(ilh) - ss(ill)))/(dx*dy)
           
           ! check if we are within the cc-values
-          ss_temp(ill) = q(i,j) - HALF*dx*A_x - HALF*dy*A_y + 0.25d0*dx*dy*A_xy
-          ss_temp(ilh) = q(i,j) - HALF*dx*A_x + HALF*dy*A_y - 0.25d0*dx*dy*A_xy
-          ss_temp(irl) = q(i,j) + HALF*dx*A_x - HALF*dy*A_y - 0.25d0*dx*dy*A_xy
-          ss_temp(irh) = q(i,j) + HALF*dx*A_x + HALF*dy*A_y + 0.25d0*dx*dy*A_xy
+          ss_temp(ill) = q(i,j) - HALF*dx*A_x - HALF*dy*A_y + 0.25e0_rt*dx*dy*A_xy
+          ss_temp(ilh) = q(i,j) - HALF*dx*A_x + HALF*dy*A_y - 0.25e0_rt*dx*dy*A_xy
+          ss_temp(irl) = q(i,j) + HALF*dx*A_x - HALF*dy*A_y - 0.25e0_rt*dx*dy*A_xy
+          ss_temp(irh) = q(i,j) + HALF*dx*A_x + HALF*dy*A_y + 0.25e0_rt*dx*dy*A_xy
           
           min_ss(ill) = min(q(i-1,j-1), q(i,j-1), q(i-1,j), q(i,j))
           max_ss(ill) = max(q(i-1,j-1), q(i,j-1), q(i-1,j), q(i,j))
@@ -315,8 +319,8 @@ contains
 
           do n = 1, niter
              sumdiff = (ss_temp(ill) + ss_temp(ilh) + &
-                        ss_temp(irl) + ss_temp(irh)) - 4.0d0*q(i,j)
-             sgndiff = sign(1.d0,sumdiff)
+                        ss_temp(irl) + ss_temp(irh)) - 4.0e0_rt*q(i,j)
+             sgndiff = sign(1.e0_rt,sumdiff)
 
              do m = 1, 4
                 diff(m) = (ss_temp(m) - q(i,j))*sgndiff
@@ -330,7 +334,7 @@ contains
              
              do m = 1, 4
                 if (kdp < 1) then
-                   div = 1.d0
+                   div = 1.e0_rt
                 else
                    div = dble(kdp)
                 endif
@@ -339,10 +343,10 @@ contains
                    redfac = sumdiff*sgndiff/div
                    kdp = kdp-1
                 else
-                   redfac = 0.0d0
+                   redfac = 0.0e0_rt
                 endif
               
-                if (sgndiff > 0.0d0) then
+                if (sgndiff > 0.0e0_rt) then
                    redmax = ss_temp(m) - min_ss(m)
                 else
                    redmax = max_ss(m) - ss_temp(m)
@@ -356,10 +360,10 @@ contains
           
           ! construct the final slopes
           A_x  = ((ss_temp(irh) + ss_temp(irl)) - &
-                  (ss_temp(ilh) + ss_temp(ill)))/(2.0d0*dx)
+                  (ss_temp(ilh) + ss_temp(ill)))/(2.0e0_rt*dx)
 
           A_y  = ((ss_temp(ilh) + ss_temp(irh)) - &
-                  (ss_temp(ill) + ss_temp(irl)))/(2.0d0*dy)
+                  (ss_temp(ill) + ss_temp(irl)))/(2.0e0_rt*dy)
 
           A_xy = ((ss_temp(irh) - ss_temp(irl)) - &
                   (ss_temp(ilh) - ss_temp(ill)))/(dx*dy)

--- a/Source/Src_2d/trace_2d.f90
+++ b/Source/Src_2d/trace_2d.f90
@@ -1,5 +1,6 @@
 module trace_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   private
@@ -20,6 +21,7 @@ contains
     use slope_module, only : uslope, pslope, multid_slope
     use bl_constants_module
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer ilo1,ilo2,ihi1,ihi2
@@ -28,39 +30,39 @@ contains
     integer qpd_l1,qpd_l2,qpd_h1,qpd_h2
     integer src_l1,src_l2,src_h1,src_h2
 
-    double precision dx, dy, dt
-    double precision     q(qd_l1:qd_h1,qd_l2:qd_h2,QVAR)
-    double precision     c(qd_l1:qd_h1,qd_l2:qd_h2)
-    double precision flatn(qd_l1:qd_h1,qd_l2:qd_h2)
-    double precision dloga(dloga_l1:dloga_h1,dloga_l2:dloga_h2)
-    double precision qxm(qpd_l1:qpd_h1,qpd_l2:qpd_h2,QVAR)
-    double precision qxp(qpd_l1:qpd_h1,qpd_l2:qpd_h2,QVAR)
-    double precision qym(qpd_l1:qpd_h1,qpd_l2:qpd_h2,QVAR)
-    double precision qyp(qpd_l1:qpd_h1,qpd_l2:qpd_h2,QVAR)
-    double precision src(src_l1:src_h1,src_l2:src_h2,QVAR)
+    real(rt)         dx, dy, dt
+    real(rt)             q(qd_l1:qd_h1,qd_l2:qd_h2,QVAR)
+    real(rt)             c(qd_l1:qd_h1,qd_l2:qd_h2)
+    real(rt)         flatn(qd_l1:qd_h1,qd_l2:qd_h2)
+    real(rt)         dloga(dloga_l1:dloga_h1,dloga_l2:dloga_h2)
+    real(rt)         qxm(qpd_l1:qpd_h1,qpd_l2:qpd_h2,QVAR)
+    real(rt)         qxp(qpd_l1:qpd_h1,qpd_l2:qpd_h2,QVAR)
+    real(rt)         qym(qpd_l1:qpd_h1,qpd_l2:qpd_h2,QVAR)
+    real(rt)         qyp(qpd_l1:qpd_h1,qpd_l2:qpd_h2,QVAR)
+    real(rt)         src(src_l1:src_h1,src_l2:src_h2,QVAR)
 
-    double precision, allocatable :: dqx(:,:,:), dqy(:,:,:)
+    real(rt)        , allocatable :: dqx(:,:,:), dqy(:,:,:)
 
     ! Local variables
     integer i, j
     integer n, ipassive
 
-    double precision dtdx, dtdy
-    double precision cc, csq, rho, u, v, p, rhoe
-    double precision drho, du, dv, dp, drhoe
+    real(rt)         dtdx, dtdy
+    real(rt)         cc, csq, rho, u, v, p, rhoe
+    real(rt)         drho, du, dv, dp, drhoe
     
-    double precision enth, alpham, alphap, alpha0r, alpha0e
-    double precision alpha0u, alpha0v
-    double precision spzero
-    double precision apright, amright, azrright, azeright
-    double precision azu1rght, azv1rght
-    double precision apleft, amleft, azrleft, azeleft
-    double precision azu1left, azv1left
-    double precision acmprght, acmpleft, acmpbot, acmptop
-    double precision sourcr,sourcp,source,courn,eta,dlogatmp
+    real(rt)         enth, alpham, alphap, alpha0r, alpha0e
+    real(rt)         alpha0u, alpha0v
+    real(rt)         spzero
+    real(rt)         apright, amright, azrright, azeright
+    real(rt)         azu1rght, azv1rght
+    real(rt)         apleft, amleft, azrleft, azeleft
+    real(rt)         azu1left, azv1left
+    real(rt)         acmprght, acmpleft, acmpbot, acmptop
+    real(rt)         sourcr,sourcp,source,courn,eta,dlogatmp
     
-    double precision :: rho_ref, u_ref, v_ref, p_ref, rhoe_ref
-    double precision :: e(3)
+    real(rt)         :: rho_ref, u_ref, v_ref, p_ref, rhoe_ref
+    real(rt)         :: e(3)
 
     if (ppm_type .ne. 0) then
        print *,'Oops -- shouldnt be in trace with ppm_type != 0'
@@ -165,8 +167,8 @@ contains
           rhoe_ref = rhoe - HALF*(ONE + dtdx*min(e(1),ZERO))*drhoe
 
           ! this is -(1/2) ( 1 + dt/dx lambda) (l . dq) r
-          apright = 0.25d0*dtdx*(e(1) - e(3))*(ONE - sign(ONE,e(3)))*alphap
-          amright = 0.25d0*dtdx*(e(1) - e(1))*(ONE - sign(ONE,e(1)))*alpham
+          apright = 0.25e0_rt*dtdx*(e(1) - e(3))*(ONE - sign(ONE,e(3)))*alphap
+          amright = 0.25e0_rt*dtdx*(e(1) - e(1))*(ONE - sign(ONE,e(1)))*alpham
           
           azrright = 0.25e0*dtdx*(e(1)-e(2))*(ONE - sign(ONE,e(2)))*alpha0r
           azeright = 0.25e0*dtdx*(e(1)-e(2))*(ONE - sign(ONE,e(2)))*alpha0e
@@ -191,12 +193,12 @@ contains
           p_ref = p + HALF*(ONE - dtdx*max(e(3),ZERO))*dp
           rhoe_ref = rhoe + HALF*(ONE - dtdx*max(e(3),ZERO))*drhoe
 
-          apleft = 0.25d0*dtdx*(e(3) - e(3))*(ONE + sign(ONE,e(3)))*alphap
-          amleft = 0.25d0*dtdx*(e(3) - e(1))*(ONE + sign(ONE,e(1)))*alpham
+          apleft = 0.25e0_rt*dtdx*(e(3) - e(3))*(ONE + sign(ONE,e(3)))*alphap
+          amleft = 0.25e0_rt*dtdx*(e(3) - e(1))*(ONE + sign(ONE,e(1)))*alpham
           
-          azrleft = 0.25d0*dtdx*(e(3) - e(2))*(ONE + sign(ONE,e(2)))*alpha0r
-          azeleft = 0.25d0*dtdx*(e(3) - e(2))*(ONE + sign(ONE,e(2)))*alpha0e
-          azv1left = 0.25d0*dtdx*(e(3) - e(2))*(ONE + sign(ONE,e(2)))*alpha0v
+          azrleft = 0.25e0_rt*dtdx*(e(3) - e(2))*(ONE + sign(ONE,e(2)))*alpha0r
+          azeleft = 0.25e0_rt*dtdx*(e(3) - e(2))*(ONE + sign(ONE,e(2)))*alpha0e
+          azv1left = 0.25e0_rt*dtdx*(e(3) - e(2))*(ONE + sign(ONE,e(2)))*alpha0v
           
           if (i .le. ihi1) then
              qxm(i+1,j,QRHO) = rho_ref + apleft + amleft + azrleft
@@ -308,8 +310,8 @@ contains
           p_ref = p - HALF*(ONE + dtdy*min(e(1),ZERO))*dp
           rhoe_ref = rhoe - HALF*(ONE + dtdy*min(e(1),ZERO))*drhoe
 
-          apright = 0.25d0*dtdy*(e(1) - e(3))*(ONE - sign(ONE,e(3)))*alphap
-          amright = 0.25d0*dtdy*(e(1) - e(1))*(ONE - sign(ONE,e(1)))*alpham
+          apright = 0.25e0_rt*dtdy*(e(1) - e(3))*(ONE - sign(ONE,e(3)))*alphap
+          amright = 0.25e0_rt*dtdy*(e(1) - e(1))*(ONE - sign(ONE,e(1)))*alpham
           
           azrright = 0.25e0*dtdy*(e(1)-e(2))*(ONE - sign(ONE,e(2)))*alpha0r
           azeright = 0.25e0*dtdy*(e(1)-e(2))*(ONE - sign(ONE,e(2)))*alpha0e
@@ -334,12 +336,12 @@ contains
           p_ref = p + HALF*(ONE - dtdy*max(e(3),ZERO))*dp
           rhoe_ref = rhoe + HALF*(ONE - dtdy*max(e(3),ZERO))*drhoe
 
-          apleft = 0.25d0*dtdy*(e(3) - e(3))*(ONE + sign(ONE,e(3)))*alphap
-          amleft = 0.25d0*dtdy*(e(3) - e(1))*(ONE + sign(ONE,e(1)))*alpham
+          apleft = 0.25e0_rt*dtdy*(e(3) - e(3))*(ONE + sign(ONE,e(3)))*alphap
+          amleft = 0.25e0_rt*dtdy*(e(3) - e(1))*(ONE + sign(ONE,e(1)))*alpham
 
-          azrleft = 0.25d0*dtdy*(e(3) - e(2))*(ONE + sign(ONE,e(2)))*alpha0r
-          azeleft = 0.25d0*dtdy*(e(3) - e(2))*(ONE + sign(ONE,e(2)))*alpha0e
-          azu1left = 0.25d0*dtdy*(e(3) - e(2))*(ONE + sign(ONE,e(2)))*alpha0u
+          azrleft = 0.25e0_rt*dtdy*(e(3) - e(2))*(ONE + sign(ONE,e(2)))*alpha0r
+          azeleft = 0.25e0_rt*dtdy*(e(3) - e(2))*(ONE + sign(ONE,e(2)))*alpha0e
+          azu1left = 0.25e0_rt*dtdy*(e(3) - e(2))*(ONE + sign(ONE,e(2)))*alpha0u
           
           if (j .le. ihi2) then
              qym(i,j+1,QRHO) = rho_ref + apleft + amleft + azrleft

--- a/Source/Src_2d/trace_ppm_2d.f90
+++ b/Source/Src_2d/trace_ppm_2d.f90
@@ -3,6 +3,7 @@
 
 module trace_ppm_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   private
@@ -31,6 +32,7 @@ contains
          npassive, qpass_map
     use ppm_module, only : ppm
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer ilo1,ilo2,ihi1,ihi2
@@ -40,26 +42,26 @@ contains
     integer src_l1,src_l2,src_h1,src_h2
     integer gc_l1,gc_l2,gc_h1,gc_h2
 
-    double precision     q(qd_l1:qd_h1,qd_l2:qd_h2,QVAR)
-    double precision     c(qd_l1:qd_h1,qd_l2:qd_h2)
-    double precision flatn(qd_l1:qd_h1,qd_l2:qd_h2)
-    double precision dloga(dloga_l1:dloga_h1,dloga_l2:dloga_h2)
+    real(rt)             q(qd_l1:qd_h1,qd_l2:qd_h2,QVAR)
+    real(rt)             c(qd_l1:qd_h1,qd_l2:qd_h2)
+    real(rt)         flatn(qd_l1:qd_h1,qd_l2:qd_h2)
+    real(rt)         dloga(dloga_l1:dloga_h1,dloga_l2:dloga_h2)
 
-    double precision qxm(qpd_l1:qpd_h1,qpd_l2:qpd_h2,QVAR)
-    double precision qxp(qpd_l1:qpd_h1,qpd_l2:qpd_h2,QVAR)
-    double precision qym(qpd_l1:qpd_h1,qpd_l2:qpd_h2,QVAR)
-    double precision qyp(qpd_l1:qpd_h1,qpd_l2:qpd_h2,QVAR)
+    real(rt)         qxm(qpd_l1:qpd_h1,qpd_l2:qpd_h2,QVAR)
+    real(rt)         qxp(qpd_l1:qpd_h1,qpd_l2:qpd_h2,QVAR)
+    real(rt)         qym(qpd_l1:qpd_h1,qpd_l2:qpd_h2,QVAR)
+    real(rt)         qyp(qpd_l1:qpd_h1,qpd_l2:qpd_h2,QVAR)
 
-    double precision  srcQ(src_l1:src_h1,src_l2:src_h2,QVAR)
-    double precision gamc(gc_l1:gc_h1,gc_l2:gc_h2)
+    real(rt)          srcQ(src_l1:src_h1,src_l2:src_h2,QVAR)
+    real(rt)         gamc(gc_l1:gc_h1,gc_l2:gc_h2)
 
-    double precision dx, dy, dt
+    real(rt)         dx, dy, dt
 
     ! Local variables
     integer :: i, j, iwave, idim
     integer :: n, ipassive
 
-    double precision :: hdt, dtdx, dtdy
+    real(rt)         :: hdt, dtdx, dtdy
 
     ! To allow for easy integration of radiation, we adopt the
     ! following conventions:
@@ -79,35 +81,35 @@ contains
     ! for pure hydro, we will only consider:
     !   rho, u, v, w, ptot, rhoe_g, cc, h_g
 
-    double precision :: cc, csq, Clag
-    double precision :: rho, u, v, p, rhoe_g, h_g
-    double precision :: gam_g, game
+    real(rt)         :: cc, csq, Clag
+    real(rt)         :: rho, u, v, p, rhoe_g, h_g
+    real(rt)         :: gam_g, game
 
-    double precision :: drho, dptot, drhoe_g
-    double precision :: dge, dtau
-    double precision :: dup, dvp, dptotp
-    double precision :: dum, dvm, dptotm
+    real(rt)         :: drho, dptot, drhoe_g
+    real(rt)         :: dge, dtau
+    real(rt)         :: dup, dvp, dptotp
+    real(rt)         :: dum, dvm, dptotm
 
-    double precision :: rho_ref, u_ref, v_ref, p_ref, rhoe_g_ref, h_g_ref
-    double precision :: tau_ref
+    real(rt)         :: rho_ref, u_ref, v_ref, p_ref, rhoe_g_ref, h_g_ref
+    real(rt)         :: tau_ref
 
-    double precision :: cc_ref, csq_ref, Clag_ref, gam_g_ref, game_ref, gfactor
-    double precision :: cc_ev, csq_ev, Clag_ev, rho_ev, p_ev, h_g_ev, tau_ev
+    real(rt)         :: cc_ref, csq_ref, Clag_ref, gam_g_ref, game_ref, gfactor
+    real(rt)         :: cc_ev, csq_ev, Clag_ev, rho_ev, p_ev, h_g_ev, tau_ev
 
-    double precision :: alpham, alphap, alpha0r, alpha0e_g
-    double precision :: sourcr,sourcp,source,courn,eta,dlogatmp
+    real(rt)         :: alpham, alphap, alpha0r, alpha0e_g
+    real(rt)         :: sourcr,sourcp,source,courn,eta,dlogatmp
 
-    double precision :: tau_s
+    real(rt)         :: tau_s
 
-    double precision, allocatable :: Ip(:,:,:,:,:)
-    double precision, allocatable :: Im(:,:,:,:,:)
+    real(rt)        , allocatable :: Ip(:,:,:,:,:)
+    real(rt)        , allocatable :: Im(:,:,:,:,:)
 
-    double precision, allocatable :: Ip_src(:,:,:,:,:)
-    double precision, allocatable :: Im_src(:,:,:,:,:)
+    real(rt)        , allocatable :: Ip_src(:,:,:,:,:)
+    real(rt)        , allocatable :: Im_src(:,:,:,:,:)
 
     ! gamma_c/1 on the interfaces
-    double precision, allocatable :: Ip_gc(:,:,:,:,:)
-    double precision, allocatable :: Im_gc(:,:,:,:,:)
+    real(rt)        , allocatable :: Ip_gc(:,:,:,:,:)
+    real(rt)        , allocatable :: Im_gc(:,:,:,:,:)
 
     type (eos_t) :: eos_state
 

--- a/Source/Src_2d/trans_2d.F90
+++ b/Source/Src_2d/trans_2d.F90
@@ -25,6 +25,7 @@ module transverse_module
 
   use eos_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   private
@@ -46,6 +47,7 @@ contains
                     vol, vol_l1, vol_l2, vol_h1, vol_h2, &
                     ilo, ihi, jlo, jhi)
 
+    use bl_fort_module, only : rt => c_real
     integer qd_l1, qd_l2, qd_h1, qd_h2
     integer qa_l1, qa_l2, qa_h1, qa_h2
     integer fx_l1, fx_l2, fx_h1, fx_h2
@@ -57,42 +59,42 @@ contains
 
 #ifdef RADIATION
     integer rfx_l1, rfx_l2, rfx_h1, rfx_h2
-    double precision rfx(rfx_l1:rfx_h1,rfx_l2:rfx_h2,0:ngroups-1)
+    real(rt)         rfx(rfx_l1:rfx_h1,rfx_l2:rfx_h2,0:ngroups-1)
 #endif
 
-    double precision qm(qd_l1:qd_h1,qd_l2:qd_h2,NQ)
-    double precision qmo(qd_l1:qd_h1,qd_l2:qd_h2,NQ)
-    double precision qp(qd_l1:qd_h1,qd_l2:qd_h2,NQ)
-    double precision qpo(qd_l1:qd_h1,qd_l2:qd_h2,NQ)
+    real(rt)         qm(qd_l1:qd_h1,qd_l2:qd_h2,NQ)
+    real(rt)         qmo(qd_l1:qd_h1,qd_l2:qd_h2,NQ)
+    real(rt)         qp(qd_l1:qd_h1,qd_l2:qd_h2,NQ)
+    real(rt)         qpo(qd_l1:qd_h1,qd_l2:qd_h2,NQ)
 
-    double precision qaux(qa_l1:qa_h1,qa_l2:qa_h2,NQAUX)
+    real(rt)         qaux(qa_l1:qa_h1,qa_l2:qa_h2,NQAUX)
 
-    double precision fx(fx_l1:fx_h1,fx_l2:fx_h2,NVAR)
-    double precision qgdx(qgdx_l1:qgdx_h1,qgdx_l2:qgdx_h2,NGDNV)
-    double precision srcQ(src_l1:src_h1,src_l2:src_h2,QVAR)
-    double precision area1(area1_l1:area1_h1,area1_l2:area1_h2)
-    double precision vol(vol_l1:vol_h1,vol_l2:vol_h2)
-    double precision hdt, cdtdx
+    real(rt)         fx(fx_l1:fx_h1,fx_l2:fx_h2,NVAR)
+    real(rt)         qgdx(qgdx_l1:qgdx_h1,qgdx_l2:qgdx_h2,NGDNV)
+    real(rt)         srcQ(src_l1:src_h1,src_l2:src_h2,QVAR)
+    real(rt)         area1(area1_l1:area1_h1,area1_l2:area1_h2)
+    real(rt)         vol(vol_l1:vol_h1,vol_l2:vol_h2)
+    real(rt)         hdt, cdtdx
 
     integer          :: i, j, g
     integer          :: n, nqp, ipassive
 
-    double precision :: rr, rrnew, compo, compn
-    double precision :: rrr, rur, rvr, rer, ekinr, rhoekinr
-    double precision :: rrnewr, runewr, rvnewr, renewr
-    double precision :: rrl, rul, rvl, rel, ekinl, rhoekinl
-    double precision :: rrnewl, runewl, rvnewl, renewl
+    real(rt)         :: rr, rrnew, compo, compn
+    real(rt)         :: rrr, rur, rvr, rer, ekinr, rhoekinr
+    real(rt)         :: rrnewr, runewr, rvnewr, renewr
+    real(rt)         :: rrl, rul, rvl, rel, ekinl, rhoekinl
+    real(rt)         :: rrnewl, runewl, rvnewl, renewl
 
     ! here, pggp/pggm is the Godunov gas pressure (not radiation contribution)
-    double precision :: pggp, pggm, ugp, ugm, dAup, pav, uav, dAu, pnewl,pnewr
-    double precision :: geav, dge, gegp, gegm, gamc
-    double precision :: rhotmp
+    real(rt)         :: pggp, pggm, ugp, ugm, dAup, pav, uav, dAu, pnewl,pnewr
+    real(rt)         :: geav, dge, gegp, gegm, gamc
+    real(rt)         :: rhotmp
 
 #ifdef RADIATION
-    double precision dre, dmom
-    double precision, dimension(0:ngroups-1) :: lambda, ergp, ergm, err, erl, lamge, luge, &
+    real(rt)         dre, dmom
+    real(rt)        , dimension(0:ngroups-1) :: lambda, ergp, ergm, err, erl, lamge, luge, &
          der, ernewr, ernewl
-    double precision eddf, f1, ugc, divu
+    real(rt)         eddf, f1, ugc, divu
 #endif
 
     type (eos_t) :: eos_state
@@ -149,7 +151,7 @@ contains
 
 #ifdef RADIATION
           lambda(:) = qaux(i,j,QLAMS:QLAMS+ngroups-1)
-          ugc = 0.5d0*(ugp+ugm)
+          ugc = 0.5e0_rt*(ugp+ugm)
           ergp(:) = qgdx(i+1,j,GDERADS:GDERADS-1+ngroups)
           ergm(:) = qgdx(i  ,j,GDERADS:GDERADS-1+ngroups)
 #endif
@@ -180,15 +182,15 @@ contains
           if (fspace_type .eq. 1 .and. comoving) then
              do g=0, ngroups-1
                 eddf = Edd_factor(lambda(g))
-                f1 = 0.5d0*(1.d0-eddf)
+                f1 = 0.5e0_rt*(1.e0_rt-eddf)
                 der(g) = cdtdx * ugc * f1 * (ergp(g) - ergm(g))
              end do
           else if (fspace_type .eq. 2) then
              divu = (area1(i+1,j)*ugp-area1(i,j)*ugm)/vol(i,j)
              do g=0, ngroups-1
                 eddf = Edd_factor(lambda(g))
-                f1 = 0.5d0*(1.d0-eddf)
-                der(g) = -hdt * f1 * 0.5d0*(ergp(g)+ergm(g)) * divu
+                f1 = 0.5e0_rt*(1.e0_rt-eddf)
+                der(g) = -hdt * f1 * 0.5e0_rt*(ergp(g)+ergm(g)) * divu
              end do
           else ! mixed frame
              der(:) = cdtdx * luge(:)
@@ -497,6 +499,7 @@ contains
                     srcQ, src_l1, src_l2, src_h1, src_h2, &
                     hdt, cdtdy, ilo, ihi, jlo, jhi)
 
+    use bl_fort_module, only : rt => c_real
     integer qd_l1, qd_l2, qd_h1, qd_h2
     integer qa_l1, qa_l2, qa_h1, qa_h2
     integer fy_l1, fy_l2, fy_h1, fy_h2
@@ -506,39 +509,39 @@ contains
 
 #ifdef RADIATION
     integer rfy_l1, rfy_l2, rfy_h1, rfy_h2
-    double precision rfy(rfy_l1:rfy_h1,rfy_l2:rfy_h2,0:ngroups-1)
+    real(rt)         rfy(rfy_l1:rfy_h1,rfy_l2:rfy_h2,0:ngroups-1)
 #endif
 
-    double precision qm(qd_l1:qd_h1,qd_l2:qd_h2,NQ)
-    double precision qmo(qd_l1:qd_h1,qd_l2:qd_h2,NQ)
-    double precision qp(qd_l1:qd_h1,qd_l2:qd_h2,NQ)
-    double precision qpo(qd_l1:qd_h1,qd_l2:qd_h2,NQ)
+    real(rt)         qm(qd_l1:qd_h1,qd_l2:qd_h2,NQ)
+    real(rt)         qmo(qd_l1:qd_h1,qd_l2:qd_h2,NQ)
+    real(rt)         qp(qd_l1:qd_h1,qd_l2:qd_h2,NQ)
+    real(rt)         qpo(qd_l1:qd_h1,qd_l2:qd_h2,NQ)
 
-    double precision qaux(qa_l1:qa_h1,qa_l2:qa_h2,NQAUX)
+    real(rt)         qaux(qa_l1:qa_h1,qa_l2:qa_h2,NQAUX)
 
-    double precision fy(fy_l1:fy_h1,fy_l2:fy_h2,NVAR)
-    double precision qgdy(qgdy_l1:qgdy_h1,qgdy_l2:qgdy_h2,NGDNV)
-    double precision srcQ(src_l1:src_h1,src_l2:src_h2,QVAR)
-    double precision hdt, cdtdy
+    real(rt)         fy(fy_l1:fy_h1,fy_l2:fy_h2,NVAR)
+    real(rt)         qgdy(qgdy_l1:qgdy_h1,qgdy_l2:qgdy_h2,NGDNV)
+    real(rt)         srcQ(src_l1:src_h1,src_l2:src_h2,QVAR)
+    real(rt)         hdt, cdtdy
 
     integer          :: i, j, g
     integer          :: n, nqp, ipassive
 
-    double precision :: rr,rrnew
-    double precision :: pggp, pggm, ugp, ugm, dup, pav, uav, du, pnewr,pnewl
-    double precision :: gegp, gegm, geav, dge, gamc
-    double precision :: rrr, rur, rvr, rer, ekinr, rhoekinr
-    double precision :: rrnewr, runewr, rvnewr, renewr
-    double precision :: rrl, rul, rvl, rel, ekinl, rhoekinl
-    double precision :: rrnewl, runewl, rvnewl, renewl
-    double precision :: rhotmp
-    double precision :: compo, compn
+    real(rt)         :: rr,rrnew
+    real(rt)         :: pggp, pggm, ugp, ugm, dup, pav, uav, du, pnewr,pnewl
+    real(rt)         :: gegp, gegm, geav, dge, gamc
+    real(rt)         :: rrr, rur, rvr, rer, ekinr, rhoekinr
+    real(rt)         :: rrnewr, runewr, rvnewr, renewr
+    real(rt)         :: rrl, rul, rvl, rel, ekinl, rhoekinl
+    real(rt)         :: rrnewl, runewl, rvnewl, renewl
+    real(rt)         :: rhotmp
+    real(rt)         :: compo, compn
 
 #ifdef RADIATION
-    double precision :: dre, dmom
-    double precision, dimension(0:ngroups-1) :: lambda, ergp, ergm, err, erl, lamge, luge, &
+    real(rt)         :: dre, dmom
+    real(rt)        , dimension(0:ngroups-1) :: lambda, ergp, ergm, err, erl, lamge, luge, &
          der, ernewr, ernewl
-    double precision :: eddf, f1, ugc
+    real(rt)         :: eddf, f1, ugc
 #endif
 
     type (eos_t) :: eos_state
@@ -590,7 +593,7 @@ contains
 
 #ifdef RADIATION
           lambda(:) = qaux(i,j,QLAMS:QLAMS+ngroups-1)
-          ugc = 0.5d0*(ugp+ugm)
+          ugc = 0.5e0_rt*(ugp+ugm)
           ergp(:) = qgdy(i,j+1,GDERADS:GDERADS-1+ngroups)
           ergm(:) = qgdy(i,j  ,GDERADS:GDERADS-1+ngroups)
 #endif
@@ -621,14 +624,14 @@ contains
           if (fspace_type .eq. 1 .and. comoving) then
              do g=0, ngroups-1
                 eddf = Edd_factor(lambda(g))
-                f1 = 0.5d0*(1.d0-eddf)
+                f1 = 0.5e0_rt*(1.e0_rt-eddf)
                 der(g) = cdtdy * ugc * f1 * (ergp(g) - ergm(g))
              end do
           else if (fspace_type .eq. 2) then
              do g=0, ngroups-1
                 eddf = Edd_factor(lambda(g))
-                f1 = 0.5d0*(1.d0-eddf)
-                der(g) = cdtdy * f1 * 0.5d0*(ergp(g)+ergm(g)) * (ugm-ugp)
+                f1 = 0.5e0_rt*(1.e0_rt-eddf)
+                der(g) = cdtdy * f1 * 0.5e0_rt*(ergp(g)+ergm(g)) * (ugm-ugp)
              end do
           else ! mixed frame
              der(:) = cdtdy * luge

--- a/Source/Src_3d/Castro_3d.F90
+++ b/Source/Src_3d/Castro_3d.F90
@@ -48,6 +48,7 @@ subroutine ca_umdrv(is_finest_level, time, &
 #endif
   use advection_module, only : umeth3d, consup
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
 #ifdef RADIATION
@@ -79,48 +80,48 @@ subroutine ca_umdrv(is_finest_level, time, &
   integer, intent(in) :: area3_l1, area3_l2, area3_l3, area3_h1, area3_h2, area3_h3
   integer, intent(in) :: vol_l1, vol_l2, vol_l3, vol_h1, vol_h2, vol_h3
 
-  double precision, intent(in) :: uin(uin_l1:uin_h1, uin_l2:uin_h2, uin_l3:uin_h3, NVAR)
-  double precision, intent(inout) :: uout(uout_l1:uout_h1, uout_l2:uout_h2, uout_l3:uout_h3, NVAR)
+  real(rt)        , intent(in) :: uin(uin_l1:uin_h1, uin_l2:uin_h2, uin_l3:uin_h3, NVAR)
+  real(rt)        , intent(inout) :: uout(uout_l1:uout_h1, uout_l2:uout_h2, uout_l3:uout_h3, NVAR)
 #ifdef RADIATION
-  double precision, intent(in) :: Erin(Erin_l1:Erin_h1, Erin_l2:Erin_h2, Erin_l3:Erin_h3, 0:ngroups-1)
-  double precision, intent(inout) :: Erout(Erout_l1:Erout_h1, Erout_l2:Erout_h2, Erout_l3:Erout_h3, 0:ngroups-1)
+  real(rt)        , intent(in) :: Erin(Erin_l1:Erin_h1, Erin_l2:Erin_h2, Erin_l3:Erin_h3, 0:ngroups-1)
+  real(rt)        , intent(inout) :: Erout(Erout_l1:Erout_h1, Erout_l2:Erout_h2, Erout_l3:Erout_h3, 0:ngroups-1)
 #endif
-  double precision, intent(inout) :: q(q_l1:q_h1, q_l2:q_h2, q_l3:q_h3, NQ)
-  double precision, intent(inout) :: qaux(qa_l1:qa_h1, qa_l2:qa_h2, qa_l3:qa_h3, NQAUX)
-  double precision, intent(in) :: srcQ(srQ_l1:srQ_h1, srQ_l2:srQ_h2, srQ_l3:srQ_h3, QVAR)
-  double precision, intent(inout) :: update(updt_l1:updt_h1, updt_l2:updt_h2, updt_l3:updt_h3, NVAR)
-  double precision, intent(inout) :: flux1(flux1_l1:flux1_h1, flux1_l2:flux1_h2, flux1_l3:flux1_h3, NVAR)
-  double precision, intent(inout) :: flux2(flux2_l1:flux2_h1, flux2_l2:flux2_h2, flux2_l3:flux2_h3, NVAR)
-  double precision, intent(inout) :: flux3(flux3_l1:flux3_h1, flux3_l2:flux3_h2, flux3_l3:flux3_h3, NVAR)
+  real(rt)        , intent(inout) :: q(q_l1:q_h1, q_l2:q_h2, q_l3:q_h3, NQ)
+  real(rt)        , intent(inout) :: qaux(qa_l1:qa_h1, qa_l2:qa_h2, qa_l3:qa_h3, NQAUX)
+  real(rt)        , intent(in) :: srcQ(srQ_l1:srQ_h1, srQ_l2:srQ_h2, srQ_l3:srQ_h3, QVAR)
+  real(rt)        , intent(inout) :: update(updt_l1:updt_h1, updt_l2:updt_h2, updt_l3:updt_h3, NVAR)
+  real(rt)        , intent(inout) :: flux1(flux1_l1:flux1_h1, flux1_l2:flux1_h2, flux1_l3:flux1_h3, NVAR)
+  real(rt)        , intent(inout) :: flux2(flux2_l1:flux2_h1, flux2_l2:flux2_h2, flux2_l3:flux2_h3, NVAR)
+  real(rt)        , intent(inout) :: flux3(flux3_l1:flux3_h1, flux3_l2:flux3_h2, flux3_l3:flux3_h3, NVAR)
 #ifdef RADIATION
-  double precision, intent(inout) :: radflux1(radflux1_l1:radflux1_h1, radflux1_l2:radflux1_h2, &
+  real(rt)        , intent(inout) :: radflux1(radflux1_l1:radflux1_h1, radflux1_l2:radflux1_h2, &
                                               radflux1_l3:radflux1_h3, 0:ngroups-1)
-  double precision, intent(inout) :: radflux2(radflux2_l1:radflux2_h1, radflux2_l2:radflux2_h2, &
+  real(rt)        , intent(inout) :: radflux2(radflux2_l1:radflux2_h1, radflux2_l2:radflux2_h2, &
                                               radflux2_l3:radflux2_h3, 0:ngroups-1)
-  double precision, intent(inout) :: radflux3(radflux3_l1:radflux3_h1, radflux3_l2:radflux3_h2, &
+  real(rt)        , intent(inout) :: radflux3(radflux3_l1:radflux3_h1, radflux3_l2:radflux3_h2, &
                                               radflux3_l3:radflux3_h3, 0:ngroups-1)
 #endif
-  double precision, intent(in) :: area1(area1_l1:area1_h1, area1_l2:area1_h2, area1_l3:area1_h3)
-  double precision, intent(in) :: area2(area2_l1:area2_h1, area2_l2:area2_h2, area2_l3:area2_h3)
-  double precision, intent(in) :: area3(area3_l1:area3_h1, area3_l2:area3_h2, area3_l3:area3_h3)
-  double precision, intent(in) :: vol(vol_l1:vol_h1, vol_l2:vol_h2, vol_l3:vol_h3)
-  double precision, intent(in) :: delta(3), dt, time
-  double precision, intent(inout) :: courno
+  real(rt)        , intent(in) :: area1(area1_l1:area1_h1, area1_l2:area1_h2, area1_l3:area1_h3)
+  real(rt)        , intent(in) :: area2(area2_l1:area2_h1, area2_l2:area2_h2, area2_l3:area2_h3)
+  real(rt)        , intent(in) :: area3(area3_l1:area3_h1, area3_l2:area3_h2, area3_l3:area3_h3)
+  real(rt)        , intent(in) :: vol(vol_l1:vol_h1, vol_l2:vol_h2, vol_l3:vol_h3)
+  real(rt)        , intent(in) :: delta(3), dt, time
+  real(rt)        , intent(inout) :: courno
 
-  double precision, intent(inout) :: E_added_flux, mass_added_flux
-  double precision, intent(inout) :: xmom_added_flux, ymom_added_flux, zmom_added_flux
-  double precision, intent(inout) :: mass_lost, xmom_lost, ymom_lost, zmom_lost
-  double precision, intent(inout) :: eden_lost, xang_lost, yang_lost, zang_lost
+  real(rt)        , intent(inout) :: E_added_flux, mass_added_flux
+  real(rt)        , intent(inout) :: xmom_added_flux, ymom_added_flux, zmom_added_flux
+  real(rt)        , intent(inout) :: mass_lost, xmom_lost, ymom_lost, zmom_lost
+  real(rt)        , intent(inout) :: eden_lost, xang_lost, yang_lost, zang_lost
 
   ! Automatic arrays for workspace
-  double precision, pointer:: flatn(:,:,:)
-  double precision, pointer:: div(:,:,:)
-  double precision, pointer:: pdivu(:,:,:)
+  real(rt)        , pointer:: flatn(:,:,:)
+  real(rt)        , pointer:: div(:,:,:)
+  real(rt)        , pointer:: pdivu(:,:,:)
 
   ! Edge-centered primitive variables (Riemann state)
-  double precision, pointer:: q1(:,:,:,:)
-  double precision, pointer:: q2(:,:,:,:)
-  double precision, pointer:: q3(:,:,:,:)
+  real(rt)        , pointer:: q1(:,:,:,:)
+  real(rt)        , pointer:: q2(:,:,:,:)
+  real(rt)        , pointer:: q3(:,:,:,:)
 
   integer :: ngq, ngf
   integer :: uin_lo(3), uin_hi(3)

--- a/Source/Src_3d/Castro_advection_3d.F90
+++ b/Source/Src_3d/Castro_advection_3d.F90
@@ -2,6 +2,7 @@ module advection_module
 
   use bl_constants_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   private
@@ -79,6 +80,7 @@ contains
     use meth_params_module, only : USHK
 #endif
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer, intent(in) :: qd_lo(3), qd_hi(3)
@@ -99,77 +101,77 @@ contains
     integer, intent(in) :: rfd3_lo(3), rfd3_hi(3)
 #endif
 
-    double precision, intent(in) ::     q(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),NQ)
-    double precision, intent(inout) ::  qaux(qa_lo(1):qa_hi(1),qa_lo(2):qa_hi(2),qa_lo(3):qa_hi(3),NQAUX)
-    double precision, intent(in) :: flatn(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3))
-    double precision, intent(in) ::  srcQ(src_lo(1):src_hi(1),src_lo(2):src_hi(2),src_lo(3):src_hi(3),QVAR)
+    real(rt)        , intent(in) ::     q(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),NQ)
+    real(rt)        , intent(inout) ::  qaux(qa_lo(1):qa_hi(1),qa_lo(2):qa_hi(2),qa_lo(3):qa_hi(3),NQAUX)
+    real(rt)        , intent(in) :: flatn(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3))
+    real(rt)        , intent(in) ::  srcQ(src_lo(1):src_hi(1),src_lo(2):src_hi(2),src_lo(3):src_hi(3),QVAR)
 
-    double precision, intent(inout) ::  uout(uout_lo(1):uout_hi(1),uout_lo(2):uout_hi(2),uout_lo(3):uout_hi(3),NVAR)
-    double precision, intent(inout) :: flux1(fd1_lo(1):fd1_hi(1),fd1_lo(2):fd1_hi(2),fd1_lo(3):fd1_hi(3),NVAR)
-    double precision, intent(inout) :: flux2(fd2_lo(1):fd2_hi(1),fd2_lo(2):fd2_hi(2),fd2_lo(3):fd2_hi(3),NVAR)
-    double precision, intent(inout) :: flux3(fd3_lo(1):fd3_hi(1),fd3_lo(2):fd3_hi(2),fd3_lo(3):fd3_hi(3),NVAR)
-    double precision, intent(inout) ::    q1(q1_lo(1):q1_hi(1),q1_lo(2):q1_hi(2),q1_lo(3):q1_hi(3),NGDNV)
-    double precision, intent(inout) ::    q2(q2_lo(1):q2_hi(1),q2_lo(2):q2_hi(2),q2_lo(3):q2_hi(3),NGDNV)
-    double precision, intent(inout) ::    q3(q3_lo(1):q3_hi(1),q3_lo(2):q3_hi(2),q3_lo(3):q3_hi(3),NGDNV)
-    double precision, intent(inout) :: pdivu(lo(1):hi(1),lo(2):hi(2),lo(3):hi(3))
+    real(rt)        , intent(inout) ::  uout(uout_lo(1):uout_hi(1),uout_lo(2):uout_hi(2),uout_lo(3):uout_hi(3),NVAR)
+    real(rt)        , intent(inout) :: flux1(fd1_lo(1):fd1_hi(1),fd1_lo(2):fd1_hi(2),fd1_lo(3):fd1_hi(3),NVAR)
+    real(rt)        , intent(inout) :: flux2(fd2_lo(1):fd2_hi(1),fd2_lo(2):fd2_hi(2),fd2_lo(3):fd2_hi(3),NVAR)
+    real(rt)        , intent(inout) :: flux3(fd3_lo(1):fd3_hi(1),fd3_lo(2):fd3_hi(2),fd3_lo(3):fd3_hi(3),NVAR)
+    real(rt)        , intent(inout) ::    q1(q1_lo(1):q1_hi(1),q1_lo(2):q1_hi(2),q1_lo(3):q1_hi(3),NGDNV)
+    real(rt)        , intent(inout) ::    q2(q2_lo(1):q2_hi(1),q2_lo(2):q2_hi(2),q2_lo(3):q2_hi(3),NGDNV)
+    real(rt)        , intent(inout) ::    q3(q3_lo(1):q3_hi(1),q3_lo(2):q3_hi(2),q3_lo(3):q3_hi(3),NGDNV)
+    real(rt)        , intent(inout) :: pdivu(lo(1):hi(1),lo(2):hi(2),lo(3):hi(3))
 
-    double precision, intent(in) :: dx(3), dt
+    real(rt)        , intent(in) :: dx(3), dt
 
 #ifdef RADIATION
-    double precision rflux1(rfd1_lo(1):rfd1_hi(1),rfd1_lo(2):rfd1_hi(2),rfd1_lo(3):rfd1_hi(3),0:ngroups-1)
-    double precision rflux2(rfd2_lo(1):rfd2_hi(1),rfd2_lo(2):rfd2_hi(2),rfd2_lo(3):rfd2_hi(3),0:ngroups-1)
-    double precision rflux3(rfd3_lo(1):rfd3_hi(1),rfd3_lo(2):rfd3_hi(2),rfd3_lo(3):rfd3_hi(3),0:ngroups-1)
+    real(rt)         rflux1(rfd1_lo(1):rfd1_hi(1),rfd1_lo(2):rfd1_hi(2),rfd1_lo(3):rfd1_hi(3),0:ngroups-1)
+    real(rt)         rflux2(rfd2_lo(1):rfd2_hi(1),rfd2_lo(2):rfd2_hi(2),rfd2_lo(3):rfd2_hi(3),0:ngroups-1)
+    real(rt)         rflux3(rfd3_lo(1):rfd3_hi(1),rfd3_lo(2):rfd3_hi(2),rfd3_lo(3):rfd3_hi(3),0:ngroups-1)
 #endif
 
-    double precision :: dxinv, dyinv, dzinv
-    double precision :: dtdx, dtdy, dtdz, hdt
-    double precision :: cdtdx, cdtdy, cdtdz
-    double precision :: hdtdx, hdtdy, hdtdz
+    real(rt)         :: dxinv, dyinv, dzinv
+    real(rt)         :: dtdx, dtdy, dtdz, hdt
+    real(rt)         :: cdtdx, cdtdy, cdtdz
+    real(rt)         :: hdtdx, hdtdy, hdtdz
 
     integer :: km, kc, kt, k3d, n
     integer :: i, j, iwave, idim
 
     ! Left and right state arrays (edge centered, cell centered)
-    double precision, pointer :: dqx(:,:,:,:), dqy(:,:,:,:), dqz(:,:,:,:)
-    double precision, pointer :: qxm(:,:,:,:), qym(:,:,:,:), qzm(:,:,:,:)
-    double precision, pointer :: qxp(:,:,:,:), qyp(:,:,:,:), qzp(:,:,:,:)
+    real(rt)        , pointer :: dqx(:,:,:,:), dqy(:,:,:,:), dqz(:,:,:,:)
+    real(rt)        , pointer :: qxm(:,:,:,:), qym(:,:,:,:), qzm(:,:,:,:)
+    real(rt)        , pointer :: qxp(:,:,:,:), qyp(:,:,:,:), qzp(:,:,:,:)
 
-    double precision, pointer :: qmxy(:,:,:,:), qpxy(:,:,:,:)
-    double precision, pointer :: qmxz(:,:,:,:), qpxz(:,:,:,:)
+    real(rt)        , pointer :: qmxy(:,:,:,:), qpxy(:,:,:,:)
+    real(rt)        , pointer :: qmxz(:,:,:,:), qpxz(:,:,:,:)
 
-    double precision, pointer :: qmyx(:,:,:,:), qpyx(:,:,:,:)
-    double precision, pointer :: qmyz(:,:,:,:), qpyz(:,:,:,:)
+    real(rt)        , pointer :: qmyx(:,:,:,:), qpyx(:,:,:,:)
+    real(rt)        , pointer :: qmyz(:,:,:,:), qpyz(:,:,:,:)
 
-    double precision, pointer :: qmzx(:,:,:,:), qpzx(:,:,:,:)
-    double precision, pointer :: qmzy(:,:,:,:), qpzy(:,:,:,:)
+    real(rt)        , pointer :: qmzx(:,:,:,:), qpzx(:,:,:,:)
+    real(rt)        , pointer :: qmzy(:,:,:,:), qpzy(:,:,:,:)
 
-    double precision, pointer :: qxl(:,:,:,:), qxr(:,:,:,:)
-    double precision, pointer :: qyl(:,:,:,:), qyr(:,:,:,:)
-    double precision, pointer :: qzl(:,:,:,:), qzr(:,:,:,:)
+    real(rt)        , pointer :: qxl(:,:,:,:), qxr(:,:,:,:)
+    real(rt)        , pointer :: qyl(:,:,:,:), qyr(:,:,:,:)
+    real(rt)        , pointer :: qzl(:,:,:,:), qzr(:,:,:,:)
 
     ! Work arrays to hold 3 planes of riemann state and conservative fluxes
-    double precision, pointer ::  fx(:,:,:,:), fy(:,:,:,:), fz(:,:,:,:)
+    real(rt)        , pointer ::  fx(:,:,:,:), fy(:,:,:,:), fz(:,:,:,:)
 
-    double precision, pointer :: fxy(:,:,:,:), fxz(:,:,:,:)
-    double precision, pointer :: fyx(:,:,:,:), fyz(:,:,:,:)
-    double precision, pointer :: fzx(:,:,:,:), fzy(:,:,:,:)
+    real(rt)        , pointer :: fxy(:,:,:,:), fxz(:,:,:,:)
+    real(rt)        , pointer :: fyx(:,:,:,:), fyz(:,:,:,:)
+    real(rt)        , pointer :: fzx(:,:,:,:), fzy(:,:,:,:)
 
-    double precision, pointer :: qgdnvx(:,:,:,:), qgdnvxf(:,:,:,:), qgdnvtmpx(:,:,:,:)
-    double precision, pointer :: qgdnvy(:,:,:,:), qgdnvyf(:,:,:,:), qgdnvtmpy(:,:,:,:)
-    double precision, pointer :: qgdnvz(:,:,:,:), qgdnvzf(:,:,:,:), qgdnvtmpz1(:,:,:,:), qgdnvtmpz2(:,:,:,:)
+    real(rt)        , pointer :: qgdnvx(:,:,:,:), qgdnvxf(:,:,:,:), qgdnvtmpx(:,:,:,:)
+    real(rt)        , pointer :: qgdnvy(:,:,:,:), qgdnvyf(:,:,:,:), qgdnvtmpy(:,:,:,:)
+    real(rt)        , pointer :: qgdnvz(:,:,:,:), qgdnvzf(:,:,:,:), qgdnvtmpz1(:,:,:,:), qgdnvtmpz2(:,:,:,:)
 
 #ifdef RADIATION
-    double precision, pointer ::  rfx(:,:,:,:), rfy(:,:,:,:),rfz(:,:,:,:)
-    double precision, pointer ::rfxy(:,:,:,:),rfxz(:,:,:,:)
-    double precision, pointer ::rfyx(:,:,:,:),rfyz(:,:,:,:)
-    double precision, pointer ::rfzx(:,:,:,:),rfzy(:,:,:,:)
+    real(rt)        , pointer ::  rfx(:,:,:,:), rfy(:,:,:,:),rfz(:,:,:,:)
+    real(rt)        , pointer ::rfxy(:,:,:,:),rfxz(:,:,:,:)
+    real(rt)        , pointer ::rfyx(:,:,:,:),rfyz(:,:,:,:)
+    real(rt)        , pointer ::rfzx(:,:,:,:),rfzy(:,:,:,:)
 #endif
 
-    double precision, pointer :: Ip(:,:,:,:,:,:), Im(:,:,:,:,:,:)
-    double precision, pointer :: Ip_src(:,:,:,:,:,:), Im_src(:,:,:,:,:,:)
-    double precision, pointer :: Ip_gc(:,:,:,:,:,:), Im_gc(:,:,:,:,:,:)
+    real(rt)        , pointer :: Ip(:,:,:,:,:,:), Im(:,:,:,:,:,:)
+    real(rt)        , pointer :: Ip_src(:,:,:,:,:,:), Im_src(:,:,:,:,:,:)
+    real(rt)        , pointer :: Ip_gc(:,:,:,:,:,:), Im_gc(:,:,:,:,:,:)
 
-    double precision, pointer :: shk(:,:,:)
+    real(rt)        , pointer :: shk(:,:,:)
 
     type (eos_t) :: eos_state
 
@@ -938,6 +940,7 @@ contains
     use meth_params_module, only : USHK
 #endif
 
+    use bl_fort_module, only : rt => c_real
     integer, intent(in) ::       lo(3),       hi(3)
     integer, intent(in) ::   uin_lo(3),   uin_hi(3)
     integer, intent(in) ::     q_lo(3),     q_hi(3)
@@ -966,53 +969,53 @@ contains
     integer, intent(in) :: verbose
 
 
-    double precision, intent(in) :: uin(uin_lo(1):uin_hi(1),uin_lo(2):uin_hi(2),uin_lo(3):uin_hi(3),NVAR)
-    double precision, intent(in) :: q(q_lo(1):q_hi(1),q_lo(2):q_hi(2),q_lo(3):q_hi(3),NQ)
-    double precision, intent(inout) :: uout(uout_lo(1):uout_hi(1),uout_lo(2):uout_hi(2),uout_lo(3):uout_hi(3),NVAR)
-    double precision, intent(inout) :: update(updt_lo(1):updt_hi(1),updt_lo(2):updt_hi(2),updt_lo(3):updt_hi(3),NVAR)
-    double precision, intent(inout) :: flux1(flux1_lo(1):flux1_hi(1),flux1_lo(2):flux1_hi(2),flux1_lo(3):flux1_hi(3),NVAR)
-    double precision, intent(inout) :: flux2(flux2_lo(1):flux2_hi(1),flux2_lo(2):flux2_hi(2),flux2_lo(3):flux2_hi(3),NVAR)
-    double precision, intent(inout) :: flux3(flux3_lo(1):flux3_hi(1),flux3_lo(2):flux3_hi(2),flux3_lo(3):flux3_hi(3),NVAR)
-    double precision, intent(in) ::    qx(qx_lo(1):qx_hi(1),qx_lo(2):qx_hi(2),qx_lo(3):qx_hi(3),NGDNV)
-    double precision, intent(in) ::    qy(qy_lo(1):qy_hi(1),qy_lo(2):qy_hi(2),qy_lo(3):qy_hi(3),NGDNV)
-    double precision, intent(in) ::    qz(qz_lo(1):qz_hi(1),qz_lo(2):qz_hi(2),qz_lo(3):qz_hi(3),NGDNV)
-    double precision, intent(in) :: area1(area1_lo(1):area1_hi(1),area1_lo(2):area1_hi(2),area1_lo(3):area1_hi(3))
-    double precision, intent(in) :: area2(area2_lo(1):area2_hi(1),area2_lo(2):area2_hi(2),area2_lo(3):area2_hi(3))
-    double precision, intent(in) :: area3(area3_lo(1):area3_hi(1),area3_lo(2):area3_hi(2),area3_lo(3):area3_hi(3))
-    double precision, intent(in) :: vol(vol_lo(1):vol_hi(1),vol_lo(2):vol_hi(2),vol_lo(3):vol_hi(3))
-    double precision, intent(in) :: div(lo(1):hi(1)+1,lo(2):hi(2)+1,lo(3):hi(3)+1)
-    double precision, intent(in) :: pdivu(lo(1):hi(1),lo(2):hi(2),lo(3):hi(3))
-    double precision, intent(in) :: dx(3), dt
+    real(rt)        , intent(in) :: uin(uin_lo(1):uin_hi(1),uin_lo(2):uin_hi(2),uin_lo(3):uin_hi(3),NVAR)
+    real(rt)        , intent(in) :: q(q_lo(1):q_hi(1),q_lo(2):q_hi(2),q_lo(3):q_hi(3),NQ)
+    real(rt)        , intent(inout) :: uout(uout_lo(1):uout_hi(1),uout_lo(2):uout_hi(2),uout_lo(3):uout_hi(3),NVAR)
+    real(rt)        , intent(inout) :: update(updt_lo(1):updt_hi(1),updt_lo(2):updt_hi(2),updt_lo(3):updt_hi(3),NVAR)
+    real(rt)        , intent(inout) :: flux1(flux1_lo(1):flux1_hi(1),flux1_lo(2):flux1_hi(2),flux1_lo(3):flux1_hi(3),NVAR)
+    real(rt)        , intent(inout) :: flux2(flux2_lo(1):flux2_hi(1),flux2_lo(2):flux2_hi(2),flux2_lo(3):flux2_hi(3),NVAR)
+    real(rt)        , intent(inout) :: flux3(flux3_lo(1):flux3_hi(1),flux3_lo(2):flux3_hi(2),flux3_lo(3):flux3_hi(3),NVAR)
+    real(rt)        , intent(in) ::    qx(qx_lo(1):qx_hi(1),qx_lo(2):qx_hi(2),qx_lo(3):qx_hi(3),NGDNV)
+    real(rt)        , intent(in) ::    qy(qy_lo(1):qy_hi(1),qy_lo(2):qy_hi(2),qy_lo(3):qy_hi(3),NGDNV)
+    real(rt)        , intent(in) ::    qz(qz_lo(1):qz_hi(1),qz_lo(2):qz_hi(2),qz_lo(3):qz_hi(3),NGDNV)
+    real(rt)        , intent(in) :: area1(area1_lo(1):area1_hi(1),area1_lo(2):area1_hi(2),area1_lo(3):area1_hi(3))
+    real(rt)        , intent(in) :: area2(area2_lo(1):area2_hi(1),area2_lo(2):area2_hi(2),area2_lo(3):area2_hi(3))
+    real(rt)        , intent(in) :: area3(area3_lo(1):area3_hi(1),area3_lo(2):area3_hi(2),area3_lo(3):area3_hi(3))
+    real(rt)        , intent(in) :: vol(vol_lo(1):vol_hi(1),vol_lo(2):vol_hi(2),vol_lo(3):vol_hi(3))
+    real(rt)        , intent(in) :: div(lo(1):hi(1)+1,lo(2):hi(2)+1,lo(3):hi(3)+1)
+    real(rt)        , intent(in) :: pdivu(lo(1):hi(1),lo(2):hi(2),lo(3):hi(3))
+    real(rt)        , intent(in) :: dx(3), dt
 
 #ifdef RADIATION
-    double precision  Erin(Erin_lo(1):Erin_hi(1),Erin_lo(2):Erin_hi(2),Erin_lo(3):Erin_hi(3),0:ngroups-1)
-    double precision Erout(Erout_lo(1):Erout_hi(1),Erout_lo(2):Erout_hi(2),Erout_lo(3):Erout_hi(3),0:ngroups-1)
-    double precision radflux1(radflux1_lo(1):radflux1_hi(1),radflux1_lo(2):radflux1_hi(2),radflux1_lo(3):radflux1_hi(3),0:ngroups-1)
-    double precision radflux2(radflux2_lo(1):radflux2_hi(1),radflux2_lo(2):radflux2_hi(2),radflux2_lo(3):radflux2_hi(3),0:ngroups-1)
-    double precision radflux3(radflux3_lo(1):radflux3_hi(1),radflux3_lo(2):radflux3_hi(2),radflux3_lo(3):radflux3_hi(3),0:ngroups-1)
+    real(rt)          Erin(Erin_lo(1):Erin_hi(1),Erin_lo(2):Erin_hi(2),Erin_lo(3):Erin_hi(3),0:ngroups-1)
+    real(rt)         Erout(Erout_lo(1):Erout_hi(1),Erout_lo(2):Erout_hi(2),Erout_lo(3):Erout_hi(3),0:ngroups-1)
+    real(rt)         radflux1(radflux1_lo(1):radflux1_hi(1),radflux1_lo(2):radflux1_hi(2),radflux1_lo(3):radflux1_hi(3),0:ngroups-1)
+    real(rt)         radflux2(radflux2_lo(1):radflux2_hi(1),radflux2_lo(2):radflux2_hi(2),radflux2_lo(3):radflux2_hi(3),0:ngroups-1)
+    real(rt)         radflux3(radflux3_lo(1):radflux3_hi(1),radflux3_lo(2):radflux3_hi(2),radflux3_lo(3):radflux3_hi(3),0:ngroups-1)
 #endif
 
-    double precision, intent(inout) :: mass_added_flux, E_added_flux, xmom_added_flux, ymom_added_flux, zmom_added_flux
-    double precision, intent(inout) :: mass_lost, xmom_lost, ymom_lost, zmom_lost
-    double precision, intent(inout) :: eden_lost, xang_lost, yang_lost, zang_lost
+    real(rt)        , intent(inout) :: mass_added_flux, E_added_flux, xmom_added_flux, ymom_added_flux, zmom_added_flux
+    real(rt)        , intent(inout) :: mass_lost, xmom_lost, ymom_lost, zmom_lost
+    real(rt)        , intent(inout) :: eden_lost, xang_lost, yang_lost, zang_lost
 
-    double precision :: div1, volinv
+    real(rt)         :: div1, volinv
     integer          :: i, j, g, k, n
     integer          :: domlo(3), domhi(3)
-    double precision :: loc(3), ang_mom(3)
+    real(rt)         :: loc(3), ang_mom(3)
 
 #ifdef RADIATION
-    double precision, dimension(0:ngroups-1) :: Erscale
-    double precision, dimension(0:ngroups-1) :: ustar, af
-    double precision :: Eddf, Eddfxm, Eddfxp, Eddfym, Eddfyp, Eddfzm, Eddfzp
-    double precision :: f1, f2, f1xm, f1xp, f1ym, f1yp, f1zm, f1zp
-    double precision :: Gf1E(3)
-    double precision :: ux, uy, uz, divu, lamc, Egdc
-    double precision :: dudx(3), dudy(3), dudz(3), nhat(3), GnDotu(3), nnColonDotGu
-    double precision :: dprdx, dprdy, dprdz, ek1, ek2, dek
-    double precision :: urho_new
-    double precision :: umx_new1, umy_new1, umz_new1
-    double precision :: umx_new2, umy_new2, umz_new2
+    real(rt)        , dimension(0:ngroups-1) :: Erscale
+    real(rt)        , dimension(0:ngroups-1) :: ustar, af
+    real(rt)         :: Eddf, Eddfxm, Eddfxp, Eddfym, Eddfyp, Eddfzm, Eddfzp
+    real(rt)         :: f1, f2, f1xm, f1xp, f1ym, f1yp, f1zm, f1zp
+    real(rt)         :: Gf1E(3)
+    real(rt)         :: ux, uy, uz, divu, lamc, Egdc
+    real(rt)         :: dudx(3), dudy(3), dudz(3), nhat(3), GnDotu(3), nnColonDotGu
+    real(rt)         :: dprdx, dprdy, dprdz, ek1, ek2, dek
+    real(rt)         :: urho_new
+    real(rt)         :: umx_new1, umy_new1, umz_new1
+    real(rt)         :: umx_new2, umy_new2, umz_new2
 #endif
 
 #ifdef RADIATION
@@ -1204,7 +1207,7 @@ contains
              do g=0,ngroups-1
                 lamc = (qx(i,j,k,GDLAMS+g) + qx(i+1,j,k,GDLAMS+g) + &
                         qy(i,j,k,GDLAMS+g) + qy(i,j+1,k,GDLAMS+g) + &
-                        qz(i,j,k,GDLAMS+g) + qz(i,j,k+1,GDLAMS+g) ) / 6.d0
+                        qz(i,j,k,GDLAMS+g) + qz(i,j,k+1,GDLAMS+g) ) / 6.e0_rt
                 dprdx = dprdx + lamc*(qx(i+1,j,k,GDERADS+g) - qx(i,j,k,GDERADS+g))/dx(1)
                 dprdy = dprdy + lamc*(qy(i,j+1,k,GDERADS+g) - qy(i,j,k,GDERADS+g))/dx(2)
                 dprdz = dprdz + lamc*(qz(i,j,k+1,GDERADS+g) - qz(i,j,k,GDERADS+g))/dx(3)
@@ -1283,14 +1286,14 @@ contains
                    GnDotu(2) = dot_product(nhat, dudy)
                    GnDotu(3) = dot_product(nhat, dudz)
 
-                   nnColonDotGu = dot_product(nhat, GnDotu) / (dot_product(nhat,nhat)+1.d-50)
+                   nnColonDotGu = dot_product(nhat, GnDotu) / (dot_product(nhat,nhat)+1.e-50_rt)
 
                    lamc = (qx(i,j,k,GDLAMS+g) + qx(i+1,j,k,GDLAMS+g) + &
                            qy(i,j,k,GDLAMS+g) + qy(i,j+1,k,GDLAMS+g) + &
-                           qz(i,j,k,GDLAMS+g) + qz(i,j,k+1,GDLAMS+g) ) / 6.d0
+                           qz(i,j,k,GDLAMS+g) + qz(i,j,k+1,GDLAMS+g) ) / 6.e0_rt
                    Eddf = Edd_factor(lamc)
                    f1 = (ONE-Eddf)*HALF
-                   f2 = (3.d0*Eddf-ONE)*HALF
+                   f2 = (3.e0_rt*Eddf-ONE)*HALF
                    af(g) = -(f1*divu + f2*nnColonDotGu)
 
                    if (fspace_type .eq. 1) then
@@ -1314,7 +1317,7 @@ contains
 
                       Egdc = (qx(i,j,k,GDERADS+g) + qx(i+1,j,k,GDERADS+g) &
                            +  qy(i,j,k,GDERADS+g) + qy(i,j+1,k,GDERADS+g) &
-                           +  qz(i,j,k,GDERADS+g) + qz(i,j,k+1,GDERADS+g) ) / 6.d0
+                           +  qz(i,j,k,GDERADS+g) + qz(i,j,k+1,GDERADS+g) ) / 6.e0_rt
 
                       Erout(i,j,k,g) = Erout(i,j,k,g) + dt*(ux*Gf1E(1)+uy*Gf1E(2)+uz*Gf1E(3)) &
                            - dt*f2*Egdc*nnColonDotGu

--- a/Source/Src_3d/GR_Gravity_3d.f90
+++ b/Source/Src_3d/GR_Gravity_3d.f90
@@ -12,26 +12,27 @@
       use network, only : nspec, naux
       use bl_constants_module
 
+      use bl_fort_module, only : rt => c_real
       implicit none
 
       integer          :: lo(3),hi(3)
-      double precision :: dx(3),dr
-      double precision :: problo(3)
+      real(rt)         :: dx(3),dr
+      real(rt)         :: problo(3)
 
       integer          :: n1d,drdxfac,level
-      double precision :: radial_pres(0:n1d-1)
+      real(rt)         :: radial_pres(0:n1d-1)
 
       integer          :: r_l1,r_l2,r_l3,r_h1,r_h2,r_h3
-      double precision :: var(r_l1:r_h1,r_l2:r_h2,r_l3:r_h3,NVAR)
+      real(rt)         :: var(r_l1:r_h1,r_l2:r_h2,r_l3:r_h3,NVAR)
 
       integer          :: i,j,k,n,index
       integer          :: ii,jj,kk
-      double precision :: xc,yc,zc,r
-      double precision :: fac,xx,yy,zz,dx_frac,dy_frac,dz_frac
-      double precision :: lo_i,lo_j,lo_k
+      real(rt)         :: xc,yc,zc,r
+      real(rt)         :: fac,xx,yy,zz,dx_frac,dy_frac,dz_frac
+      real(rt)         :: lo_i,lo_j,lo_k
 
       type (eos_t) :: eos_state
-      double precision :: rhoInv
+      real(rt)         :: rhoInv
 
       fac     = dble(drdxfac)
       dx_frac = dx(1) / fac

--- a/Source/Src_3d/Gravity_3d.f90
+++ b/Source/Src_3d/Gravity_3d.f90
@@ -1,5 +1,6 @@
 module gravity_3D_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   public
@@ -13,6 +14,7 @@ contains
        ecz, eczl1, eczl2, eczl3, eczh1, eczh2, eczh3, &
        dx,problo,coord_type) bind(C, name="ca_test_residual")
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer          :: lo(3),hi(3)
@@ -21,15 +23,15 @@ contains
     integer          :: ecxl1, ecxl2, ecxl3, ecxh1, ecxh2, ecxh3
     integer          :: ecyl1, ecyl2, ecyl3, ecyh1, ecyh2, ecyh3
     integer          :: eczl1, eczl2, eczl3, eczh1, eczh2, eczh3
-    double precision :: rhs(rhl1:rhh1,rhl2:rhh2,rhl3:rhh3)
-    double precision :: ecx(ecxl1:ecxh1,ecxl2:ecxh2, ecxl3:ecxh3)
-    double precision :: ecy(ecyl1:ecyh1,ecyl2:ecyh2, ecyl3:ecyh3)
-    double precision :: ecz(eczl1:eczh1,eczl2:eczh2, eczl3:eczh3)
-    double precision :: dx(3),problo(3)
+    real(rt)         :: rhs(rhl1:rhh1,rhl2:rhh2,rhl3:rhh3)
+    real(rt)         :: ecx(ecxl1:ecxh1,ecxl2:ecxh2, ecxl3:ecxh3)
+    real(rt)         :: ecy(ecyl1:ecyh1,ecyl2:ecyh2, ecyl3:ecyh3)
+    real(rt)         :: ecz(eczl1:eczh1,eczl2:eczh2, eczl3:eczh3)
+    real(rt)         :: dx(3),problo(3)
 
     ! Local variables
     integer          :: i,j,k
-    double precision :: lapphi
+    real(rt)         :: lapphi
 
     do k=lo(3),hi(3)
        do j=lo(2),hi(2)
@@ -55,29 +57,30 @@ contains
     use prob_params_module, only: center
     use meth_params_module, only: NVAR, URHO
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer          :: lo(3),hi(3)
-    double precision :: dx(3),dr
-    double precision :: problo(3)
+    real(rt)         :: dx(3),dr
+    real(rt)         :: problo(3)
 
     integer          :: n1d,drdxfac,level
-    double precision :: radial_mass(0:n1d-1)
-    double precision :: radial_vol (0:n1d-1)
+    real(rt)         :: radial_mass(0:n1d-1)
+    real(rt)         :: radial_vol (0:n1d-1)
 
     integer          :: r_l1,r_l2,r_l3,r_h1,r_h2,r_h3
-    double precision :: state(r_l1:r_h1,r_l2:r_h2,r_l3:r_h3,NVAR)
+    real(rt)         :: state(r_l1:r_h1,r_l2:r_h2,r_l3:r_h3,NVAR)
 
     integer          :: i,j,k,index
     integer          :: ii,jj,kk
-    double precision :: xc,yc,zc,r,xxsq,yysq,zzsq,octant_factor
-    double precision :: fac,xx,yy,zz,dx_frac,dy_frac,dz_frac
-    double precision :: vol_frac, drinv
-    double precision :: lo_i,lo_j,lo_k
+    real(rt)         :: xc,yc,zc,r,xxsq,yysq,zzsq,octant_factor
+    real(rt)         :: fac,xx,yy,zz,dx_frac,dy_frac,dz_frac
+    real(rt)         :: vol_frac, drinv
+    real(rt)         :: lo_i,lo_j,lo_k
 
-    if (( abs(center(1) - problo(1)) .lt. 1.d-2 * dx(1) ) .and. &
-         ( abs(center(2) - problo(2)) .lt. 1.d-2 * dx(2) ) .and. &
-         ( abs(center(3) - problo(3)) .lt. 1.d-2 * dx(3) ) ) then
+    if (( abs(center(1) - problo(1)) .lt. 1.e-2_rt * dx(1) ) .and. &
+         ( abs(center(2) - problo(2)) .lt. 1.e-2_rt * dx(2) ) .and. &
+         ( abs(center(3) - problo(3)) .lt. 1.e-2_rt * dx(3) ) ) then
        octant_factor = EIGHT
     else
        octant_factor = ONE
@@ -156,21 +159,22 @@ contains
     use bl_constants_module
     use prob_params_module, only: center
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer          :: lo(3),hi(3)
-    double precision :: dx(3),dr
-    double precision :: problo(3)
+    real(rt)         :: dx(3),dr
+    real(rt)         :: problo(3)
 
     integer          :: n1d,level
-    double precision :: radial_grav(0:n1d-1)
+    real(rt)         :: radial_grav(0:n1d-1)
 
     integer          :: g_l1,g_l2,g_l3,g_h1,g_h2,g_h3
-    double precision :: grav(g_l1:g_h1,g_l2:g_h2,g_l3:g_h3,3)
+    real(rt)         :: grav(g_l1:g_h1,g_l2:g_h2,g_l3:g_h3,3)
 
     integer          :: i,j,k,index
-    double precision :: x,y,z,r,mag_grav
-    double precision :: cen,xi,slope,glo,gmd,ghi,minvar,maxvar
+    real(rt)         :: x,y,z,r,mag_grav
+    real(rt)         :: cen,xi,slope,glo,gmd,ghi,minvar,maxvar
     !
     ! Note that we are interpolating onto the entire range of grav,
     ! including the ghost cells.
@@ -223,7 +227,7 @@ contains
                 mag_grav = &
                      ( ghi -   TWO*gmd + glo)*xi**2/(TWO*dr**2) + &
                      ( ghi       - glo      )*xi   /(TWO*dr   ) + &
-                     (-ghi + 26.d0*gmd - glo)/24.d0
+                     (-ghi + 26.e0_rt*gmd - glo)/24.e0_rt
 
                 minvar = min(gmd, min(glo,ghi))
                 maxvar = max(gmd, max(glo,ghi))
@@ -252,23 +256,24 @@ contains
     use bl_constants_module
     use prob_params_module, only: center
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer          :: lo(3),hi(3)
     integer          :: domlo(3),domhi(3)
-    double precision :: dx(3),dr
-    double precision :: problo(3)
+    real(rt)         :: dx(3),dr
+    real(rt)         :: problo(3)
 
     integer          :: numpts_1d
-    double precision :: radial_phi(0:numpts_1d-1)
+    real(rt)         :: radial_phi(0:numpts_1d-1)
     integer          :: fill_interior
 
     integer          :: p_l1,p_l2,p_l3,p_h1,p_h2,p_h3
-    double precision :: phi(p_l1:p_h1,p_l2:p_h2,p_l3:p_h3)
+    real(rt)         :: phi(p_l1:p_h1,p_l2:p_h2,p_l3:p_h3)
 
     integer          :: i,j,k,index
-    double precision :: x,y,z,r
-    double precision :: cen,xi,slope,p_lo,p_md,p_hi,minvar,maxvar
+    real(rt)         :: x,y,z,r
+    real(rt)         :: cen,xi,slope,p_lo,p_md,p_hi,minvar,maxvar
     !
     ! Note that when we interpolate into the ghost cells we use the
     ! location of the edge, not the cell center
@@ -338,7 +343,7 @@ contains
                    phi(i,j,k) = &
                         ( p_hi -   TWO*p_md + p_lo)*xi**2/(TWO*dr**2) + &
                         ( p_hi       - p_lo      )*xi    /(TWO*dr   ) + &
-                        (-p_hi + 26.d0*p_md - p_lo)/24.d0
+                        (-p_hi + 26.e0_rt*p_md - p_lo)/24.e0_rt
                    minvar     = min(p_md, min(p_lo,p_hi))
                    maxvar     = max(p_md, max(p_lo,p_hi))
                    phi(i,j,k) = max(phi(i,j,k),minvar)
@@ -366,31 +371,32 @@ contains
     use fundamental_constants_module, only: Gconst
     use bl_constants_module
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer          :: lo(3), hi(3)
     integer          :: bclo(3), bchi(3)
     integer          :: r_lo(3), r_hi(3)
     integer          :: v_lo(3), v_hi(3)
-    double precision :: dx(3), bcdx(3)
-    double precision :: problo(3), probhi(3)
+    real(rt)         :: dx(3), bcdx(3)
+    real(rt)         :: problo(3), probhi(3)
 
     integer          :: symmetry_type
     integer          :: lo_bc(3), hi_bc(3)
 
-    double precision :: bcXYLo(bclo(1):bchi(1),bclo(2):bchi(2))
-    double precision :: bcXYHi(bclo(1):bchi(1),bclo(2):bchi(2))
-    double precision :: bcXZLo(bclo(1):bchi(1),bclo(3):bchi(3))
-    double precision :: bcXZHi(bclo(1):bchi(1),bclo(3):bchi(3))
-    double precision :: bcYZLo(bclo(2):bchi(2),bclo(3):bchi(3))
-    double precision :: bcYZHi(bclo(2):bchi(2),bclo(3):bchi(3))
+    real(rt)         :: bcXYLo(bclo(1):bchi(1),bclo(2):bchi(2))
+    real(rt)         :: bcXYHi(bclo(1):bchi(1),bclo(2):bchi(2))
+    real(rt)         :: bcXZLo(bclo(1):bchi(1),bclo(3):bchi(3))
+    real(rt)         :: bcXZHi(bclo(1):bchi(1),bclo(3):bchi(3))
+    real(rt)         :: bcYZLo(bclo(2):bchi(2),bclo(3):bchi(3))
+    real(rt)         :: bcYZHi(bclo(2):bchi(2),bclo(3):bchi(3))
 
-    double precision :: rho(r_lo(1):r_hi(1),r_lo(2):r_hi(2),r_lo(3):r_hi(3))
-    double precision :: vol(v_lo(1):v_hi(1),v_lo(2):v_hi(2),v_lo(3):v_hi(3))
+    real(rt)         :: rho(r_lo(1):r_hi(1),r_lo(2):r_hi(2),r_lo(3):r_hi(3))
+    real(rt)         :: vol(v_lo(1):v_hi(1),v_lo(2):v_hi(2),v_lo(3):v_hi(3))
 
     integer          :: i, j, k, l, m, n, b
-    double precision :: r
-    double precision :: loc(3), locb(3), dx2, dy2, dz2
+    real(rt)         :: r
+    real(rt)         :: loc(3), locb(3), dx2, dy2, dz2
 
     logical          :: doSymmetricAddLo(3), doSymmetricAddHi(3), doSymmetricAdd
 
@@ -617,20 +623,21 @@ contains
                                    bcYZLo, bcYZHi, &
                                    bclo, bchi) bind(C, name="ca_put_direct_sum_bc")
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer          :: lo(3), hi(3)
     integer          :: bclo(3), bchi(3)
     integer          :: p_lo(3), p_hi(3)
 
-    double precision :: bcXYLo(bclo(1):bchi(1),bclo(2):bchi(2))
-    double precision :: bcXYHi(bclo(1):bchi(1),bclo(2):bchi(2))
-    double precision :: bcXZLo(bclo(1):bchi(1),bclo(3):bchi(3))
-    double precision :: bcXZHi(bclo(1):bchi(1),bclo(3):bchi(3))
-    double precision :: bcYZLo(bclo(2):bchi(2),bclo(3):bchi(3))
-    double precision :: bcYZHi(bclo(2):bchi(2),bclo(3):bchi(3))
+    real(rt)         :: bcXYLo(bclo(1):bchi(1),bclo(2):bchi(2))
+    real(rt)         :: bcXYHi(bclo(1):bchi(1),bclo(2):bchi(2))
+    real(rt)         :: bcXZLo(bclo(1):bchi(1),bclo(3):bchi(3))
+    real(rt)         :: bcXZHi(bclo(1):bchi(1),bclo(3):bchi(3))
+    real(rt)         :: bcYZLo(bclo(2):bchi(2),bclo(3):bchi(3))
+    real(rt)         :: bcYZHi(bclo(2):bchi(2),bclo(3):bchi(3))
 
-    double precision :: phi(p_lo(1):p_hi(1),p_lo(2):p_hi(2),p_lo(3):p_hi(3))
+    real(rt)         :: phi(p_lo(1):p_hi(1),p_lo(2):p_hi(2),p_lo(3):p_hi(3))
 
     integer          :: i, j, k
 
@@ -702,15 +709,16 @@ contains
     use fundamental_constants_module, only: Gconst
     use bl_constants_module
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
-    double precision :: loc(3), locb(3)
-    double precision :: problo(3), probhi(3)
+    real(rt)         :: loc(3), locb(3)
+    real(rt)         :: problo(3), probhi(3)
     logical          :: doSymmetricAddLo(3), doSymmetricAddHi(3)
 
-    double precision :: x, y, z, r
-    double precision :: rho, dV
-    double precision :: bcTerm
+    real(rt)         :: x, y, z, r
+    real(rt)         :: rho, dV
+    real(rt)         :: bcTerm
 
     ! Add contributions from any symmetric boundaries.
 

--- a/Source/Src_3d/Prob_3d.f90
+++ b/Source/Src_3d/Prob_3d.f90
@@ -1,10 +1,11 @@
 subroutine PROBINIT (init,name,namlen,problo,probhi)
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer          :: init, namlen
   integer          :: name(namlen)
-  double precision :: problo(3), probhi(3)
+  real(rt)         :: problo(3), probhi(3)
 
 end subroutine PROBINIT
 
@@ -36,13 +37,14 @@ subroutine ca_initdata(level,time,lo,hi,nvar, &
 
   use bl_error_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer :: level, nvar
   integer :: lo(3), hi(3)
   integer :: state_l1,state_l2,state_l3,state_h1,state_h2,state_h3
-  double precision :: xlo(3), xhi(3), time, dx(3)
-  double precision :: state(state_l1:state_h1, &
+  real(rt)         :: xlo(3), xhi(3), time, dx(3)
+  real(rt)         :: state(state_l1:state_h1, &
                             state_l2:state_h2, &
                             state_l3:state_h3,nvar)
 

--- a/Source/Src_3d/advection_util_3d.F90
+++ b/Source/Src_3d/advection_util_3d.F90
@@ -1,5 +1,6 @@
 module advection_util_3d_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   private
@@ -21,19 +22,20 @@ contains
     use meth_params_module, only : NVAR, URHO, UFS
     use bl_constants_module
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer, intent(in) :: lo(3), hi(3)
     integer, intent(in) :: flux1_lo(3), flux1_hi(3)
     integer, intent(in) :: flux2_lo(3), flux2_hi(3)
     integer, intent(in) :: flux3_lo(3), flux3_hi(3)
-    double precision, intent(inout) :: flux1(flux1_lo(1):flux1_hi(1),flux1_lo(2):flux1_hi(2),flux1_lo(3):flux1_hi(3),NVAR)
-    double precision, intent(inout) :: flux2(flux2_lo(1):flux2_hi(1),flux2_lo(2):flux2_hi(2),flux2_lo(3):flux2_hi(3),NVAR)
-    double precision, intent(inout) :: flux3(flux3_lo(1):flux3_hi(1),flux3_lo(2):flux3_hi(2),flux3_lo(3):flux3_hi(3),NVAR)
+    real(rt)        , intent(inout) :: flux1(flux1_lo(1):flux1_hi(1),flux1_lo(2):flux1_hi(2),flux1_lo(3):flux1_hi(3),NVAR)
+    real(rt)        , intent(inout) :: flux2(flux2_lo(1):flux2_hi(1),flux2_lo(2):flux2_hi(2),flux2_lo(3):flux2_hi(3),NVAR)
+    real(rt)        , intent(inout) :: flux3(flux3_lo(1):flux3_hi(1),flux3_lo(2):flux3_hi(2),flux3_lo(3):flux3_hi(3),NVAR)
 
     ! Local variables
     integer          :: i, j, k, n
-    double precision :: sum, fac
+    real(rt)         :: sum, fac
 
     do k = lo(3),hi(3)
        do j = lo(2),hi(2)
@@ -103,17 +105,18 @@ contains
     use meth_params_module, only : QU, QV, QW, QVAR
     use bl_constants_module
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer, intent(in) :: lo(3), hi(3)
     integer, intent(in) :: q_lo(3), q_hi(3)
     integer, intent(in) :: div_lo(3), div_hi(3)
-    double precision, intent(in) :: dx(3)
-    double precision, intent(inout) :: div(div_lo(1):div_hi(1),div_lo(2):div_hi(2),div_lo(3):div_hi(3))
-    double precision, intent(in) :: q(q_lo(1):q_hi(1),q_lo(2):q_hi(2),q_lo(3):q_hi(3),QVAR)
+    real(rt)        , intent(in) :: dx(3)
+    real(rt)        , intent(inout) :: div(div_lo(1):div_hi(1),div_lo(2):div_hi(2),div_lo(3):div_hi(3))
+    real(rt)        , intent(in) :: q(q_lo(1):q_hi(1),q_lo(2):q_hi(2),q_lo(3):q_hi(3),QVAR)
 
     integer          :: i, j, k
-    double precision :: ux, vy, wz, dxinv, dyinv, dzinv
+    real(rt)         :: ux, vy, wz, dxinv, dyinv, dzinv
 
     dxinv = ONE/dx(1)
     dyinv = ONE/dx(2)

--- a/Source/Src_3d/bc_fill_3d.F90
+++ b/Source/Src_3d/bc_fill_3d.F90
@@ -1,5 +1,6 @@
 module bc_fill_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   public
@@ -12,6 +13,7 @@ contains
 
     use meth_params_module, only: NVAR
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     include 'bc_types.fi'
@@ -19,8 +21,8 @@ contains
     integer          :: adv_l1,adv_l2,adv_l3,adv_h1,adv_h2,adv_h3
     integer          :: bc(3,2,*)
     integer          :: domlo(3), domhi(3)
-    double precision :: delta(3), xlo(3), time
-    double precision :: adv(adv_l1:adv_h1,adv_l2:adv_h2,adv_l3:adv_h3,NVAR)
+    real(rt)         :: delta(3), xlo(3), time
+    real(rt)         :: adv(adv_l1:adv_h1,adv_l2:adv_h2,adv_l3:adv_h3,NVAR)
 
     integer          :: n
 
@@ -38,6 +40,7 @@ contains
                         adv_h3,domlo,domhi,delta,xlo,time,bc) &
                         bind(C, name="ca_denfill")
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     include 'bc_types.fi'
@@ -45,8 +48,8 @@ contains
     integer          :: adv_l1,adv_l2,adv_l3,adv_h1,adv_h2,adv_h3
     integer          :: bc(3,2,*)
     integer          :: domlo(3), domhi(3)
-    double precision :: delta(3), xlo(3), time
-    double precision :: adv(adv_l1:adv_h1,adv_l2:adv_h2,adv_l3:adv_h3)
+    real(rt)         :: delta(3), xlo(3), time
+    real(rt)         :: adv(adv_l1:adv_h1,adv_l2:adv_h2,adv_l3:adv_h3)
 
     call filcc(adv,adv_l1,adv_l2,adv_l3,adv_h1,adv_h2,adv_h3, &
                domlo,domhi,delta,xlo,bc)
@@ -60,6 +63,7 @@ contains
                             phi_h1,phi_h2,phi_h3,domlo,domhi,delta,xlo,time,bc) &
                             bind(C, name="ca_phigravfill")
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     include 'bc_types.fi'
@@ -67,8 +71,8 @@ contains
     integer          :: phi_l1,phi_l2,phi_l3,phi_h1,phi_h2,phi_h3
     integer          :: bc(3,2,*)
     integer          :: domlo(3), domhi(3)
-    double precision :: delta(3), xlo(3), time
-    double precision :: phi(phi_l1:phi_h1,phi_l2:phi_h2,phi_l3:phi_h3)
+    real(rt)         :: delta(3), xlo(3), time
+    real(rt)         :: phi(phi_l1:phi_h1,phi_l2:phi_h2,phi_l3:phi_h3)
 
     call filcc(phi,phi_l1,phi_l2,phi_l3,phi_h1,phi_h2,phi_h3, &
                domlo,domhi,delta,xlo,bc)
@@ -81,6 +85,7 @@ contains
                           domlo,domhi,delta,xlo,time,bc) &
                           bind(C, name="ca_gravxfill")
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     include 'bc_types.fi'
@@ -88,8 +93,8 @@ contains
     integer          :: grav_l1,grav_l2,grav_l3,grav_h1,grav_h2,grav_h3
     integer          :: bc(3,2,*)
     integer          :: domlo(3), domhi(3)
-    double precision :: delta(3), xlo(3), time
-    double precision :: grav(grav_l1:grav_h1,grav_l2:grav_h2,grav_l3:grav_h3)
+    real(rt)         :: delta(3), xlo(3), time
+    real(rt)         :: grav(grav_l1:grav_h1,grav_l2:grav_h2,grav_l3:grav_h3)
 
     call filcc(grav,grav_l1,grav_l2,grav_l3,grav_h1,grav_h2,grav_h3, &
                domlo,domhi,delta,xlo,bc)
@@ -102,6 +107,7 @@ contains
                           domlo,domhi,delta,xlo,time,bc) &
                           bind(C, name="ca_gravyfill")
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     include 'bc_types.fi'
@@ -109,8 +115,8 @@ contains
     integer          :: grav_l1,grav_l2,grav_l3,grav_h1,grav_h2,grav_h3
     integer          :: bc(3,2,*)
     integer          :: domlo(3), domhi(3)
-    double precision :: delta(3), xlo(3), time
-    double precision :: grav(grav_l1:grav_h1,grav_l2:grav_h2,grav_l3:grav_h3)
+    real(rt)         :: delta(3), xlo(3), time
+    real(rt)         :: grav(grav_l1:grav_h1,grav_l2:grav_h2,grav_l3:grav_h3)
 
     call filcc(grav,grav_l1,grav_l2,grav_l3,grav_h1,grav_h2,grav_h3, &
                domlo,domhi,delta,xlo,bc)
@@ -123,6 +129,7 @@ contains
                           domlo,domhi,delta,xlo,time,bc) &
                           bind(C, name="ca_gravzfill")
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     include 'bc_types.fi'
@@ -130,8 +137,8 @@ contains
     integer          :: grav_l1,grav_l2,grav_l3,grav_h1,grav_h2,grav_h3
     integer          :: bc(3,2,*)
     integer          :: domlo(3), domhi(3)
-    double precision :: delta(3), xlo(3), time
-    double precision :: grav(grav_l1:grav_h1,grav_l2:grav_h2,grav_l3:grav_h3)
+    real(rt)         :: delta(3), xlo(3), time
+    real(rt)         :: grav(grav_l1:grav_h1,grav_l2:grav_h2,grav_l3:grav_h3)
 
     call filcc(grav,grav_l1,grav_l2,grav_l3,grav_h1,grav_h2,grav_h3, &
          domlo,domhi,delta,xlo,bc)
@@ -146,6 +153,7 @@ contains
                            phi_h1,phi_h2,phi_h3,domlo,domhi,delta,xlo,time,bc) &
                            bind(C, name="ca_phirotfill")
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     include 'bc_types.fi'
@@ -153,8 +161,8 @@ contains
     integer          :: phi_l1,phi_l2,phi_l3,phi_h1,phi_h2,phi_h3
     integer          :: bc(3,2,*)
     integer          :: domlo(3), domhi(3)
-    double precision :: delta(3), xlo(3), time
-    double precision :: phi(phi_l1:phi_h1,phi_l2:phi_h2,phi_l3:phi_h3)
+    real(rt)         :: delta(3), xlo(3), time
+    real(rt)         :: phi(phi_l1:phi_h1,phi_l2:phi_h2,phi_l3:phi_h3)
 
     call filcc(phi,phi_l1,phi_l2,phi_l3,phi_h1,phi_h2,phi_h3, &
                domlo,domhi,delta,xlo,bc)
@@ -167,6 +175,7 @@ contains
                          domlo,domhi,delta,xlo,time,bc) &
                          bind(C, name="ca_rotxfill")
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     include 'bc_types.fi'
@@ -174,8 +183,8 @@ contains
     integer          :: rot_l1,rot_l2,rot_l3,rot_h1,rot_h2,rot_h3
     integer          :: bc(3,2,*)
     integer          :: domlo(3), domhi(3)
-    double precision :: delta(3), xlo(3), time
-    double precision :: rot(rot_l1:rot_h1,rot_l2:rot_h2,rot_l3:rot_h3)
+    real(rt)         :: delta(3), xlo(3), time
+    real(rt)         :: rot(rot_l1:rot_h1,rot_l2:rot_h2,rot_l3:rot_h3)
 
     call filcc(rot,rot_l1,rot_l2,rot_l3,rot_h1,rot_h2,rot_h3, &
          domlo,domhi,delta,xlo,bc)
@@ -188,6 +197,7 @@ contains
                          domlo,domhi,delta,xlo,time,bc) &
                          bind(C, name="ca_rotyfill")
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     include 'bc_types.fi'
@@ -195,8 +205,8 @@ contains
     integer          :: rot_l1,rot_l2,rot_l3,rot_h1,rot_h2,rot_h3
     integer          :: bc(3,2,*)
     integer          :: domlo(3), domhi(3)
-    double precision :: delta(3), xlo(3), time
-    double precision :: rot(rot_l1:rot_h1,rot_l2:rot_h2,rot_l3:rot_h3)
+    real(rt)         :: delta(3), xlo(3), time
+    real(rt)         :: rot(rot_l1:rot_h1,rot_l2:rot_h2,rot_l3:rot_h3)
 
     call filcc(rot,rot_l1,rot_l2,rot_l3,rot_h1,rot_h2,rot_h3, &
                domlo,domhi,delta,xlo,bc)
@@ -209,6 +219,7 @@ contains
                          domlo,domhi,delta,xlo,time,bc) &
                          bind(C, name="ca_rotzfill")
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     include 'bc_types.fi'
@@ -216,8 +227,8 @@ contains
     integer          :: rot_l1,rot_l2,rot_l3,rot_h1,rot_h2,rot_h3
     integer          :: bc(3,2,*)
     integer          :: domlo(3), domhi(3)
-    double precision :: delta(3), xlo(3), time
-    double precision :: rot(rot_l1:rot_h1,rot_l2:rot_h2,rot_l3:rot_h3)
+    real(rt)         :: delta(3), xlo(3), time
+    real(rt)         :: rot(rot_l1:rot_h1,rot_l2:rot_h2,rot_l3:rot_h3)
 
     call filcc(rot,rot_l1,rot_l2,rot_l3,rot_h1,rot_h2,rot_h3, &
                domlo,domhi,delta,xlo,bc)
@@ -232,6 +243,7 @@ contains
        react_h1,react_h2,react_h3,domlo,domhi,delta,xlo,time,bc) &
        bind(C, name="ca_reactfill")
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     include 'bc_types.fi'
@@ -239,8 +251,8 @@ contains
     integer          :: react_l1,react_l2,react_l3,react_h1,react_h2,react_h3
     integer          :: bc(3,2,*)
     integer          :: domlo(3), domhi(3)
-    double precision :: delta(3), xlo(3), time
-    double precision :: react(react_l1:react_h1,react_l2:react_h2,react_l3:react_h3)
+    real(rt)         :: delta(3), xlo(3), time
+    real(rt)         :: react(react_l1:react_h1,react_l2:react_h2,react_l3:react_h3)
 
     call filcc(react,react_l1,react_l2,react_l3,react_h1,react_h2,react_h3, &
                domlo,domhi,delta,xlo,bc)
@@ -255,6 +267,7 @@ contains
                         rad_h1,rad_h2,rad_h3,domlo,domhi,delta,xlo,time,bc) &
                         bind(C, name="ca_radfill")
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     include 'bc_types.fi'
@@ -262,8 +275,8 @@ contains
     integer          :: rad_l1,rad_l2,rad_l3,rad_h1,rad_h2,rad_h3
     integer          :: bc(3,2,*)
     integer          :: domlo(3), domhi(3)
-    double precision :: delta(3), xlo(3), time
-    double precision :: rad(rad_l1:rad_h1,rad_l2:rad_h2,rad_l3:rad_h3)
+    real(rt)         :: delta(3), xlo(3), time
+    real(rt)         :: rad(rad_l1:rad_h1,rad_l2:rad_h2,rad_l3:rad_h3)
 
     call filcc(rad,rad_l1,rad_l2,rad_l3,rad_h1,rad_h2,rad_h3, &
                domlo,domhi,delta,xlo,bc)

--- a/Source/Src_3d/ext_src_3d.f90
+++ b/Source/Src_3d/ext_src_3d.f90
@@ -28,6 +28,7 @@
     use bl_constants_module, only: ZERO
     use meth_params_module, only : NVAR
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer         ,intent(in   ) :: lo(3),hi(3)
@@ -36,16 +37,16 @@
     integer         ,intent(in   ) :: new_state_l1,new_state_l2,new_state_l3, &
          new_state_h1,new_state_h2,new_state_h3
     integer         ,intent(in   ) :: src_l1,src_l2,src_l3,src_h1,src_h2,src_h3
-    double precision,intent(in   ) :: old_state(old_state_l1:old_state_h1, &
+    real(rt)        ,intent(in   ) :: old_state(old_state_l1:old_state_h1, &
          old_state_l2:old_state_h2, &
          old_state_l3:old_state_h3,NVAR)
-    double precision,intent(in   ) :: new_state(new_state_l1:new_state_h1, &
+    real(rt)        ,intent(in   ) :: new_state(new_state_l1:new_state_h1, &
          new_state_l2:new_state_h2, &
          new_state_l3:new_state_h3,NVAR)
-    double precision,intent(  out) :: src(src_l1:src_h1, &
+    real(rt)        ,intent(  out) :: src(src_l1:src_h1, &
          src_l2:src_h2, &
          src_l3:src_h3,NVAR)
-    double precision,intent(in   ) :: problo(3),dx(3),time,dt
+    real(rt)        ,intent(in   ) :: problo(3),dx(3),time,dt
 
     ! lo and hi specify work region
     src(lo(1):hi(1),lo(2):hi(2),lo(3):hi(3),:) = ZERO ! Fill work region only

--- a/Source/Src_3d/ppm_3d.f90
+++ b/Source/Src_3d/ppm_3d.f90
@@ -1,5 +1,6 @@
 module ppm_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   private
@@ -19,6 +20,7 @@ contains
 
     use meth_params_module, only : ppm_type
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer, intent(in) ::  s_lo(3),  s_hi(3)
@@ -28,14 +30,14 @@ contains
     integer, intent(in) :: ilo1, ilo2, ihi1, ihi2
     integer, intent(in) :: k3d, kc
 
-    double precision, intent(in) ::     s( s_lo(1): s_hi(1), s_lo(2): s_hi(2), s_lo(3): s_hi(3))
-    double precision, intent(in) ::     u(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),3)
-    double precision, intent(in) ::  cspd(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3))
-    double precision, intent(in) :: flatn( f_lo(1): f_hi(1), f_lo(2): f_hi(2), f_lo(3): f_hi(3))
-    double precision, intent(inout) :: Ip(I_lo(1):I_hi(1),I_lo(2):I_hi(2),I_lo(3):I_hi(3),1:3,1:3)
-    double precision, intent(inout) :: Im(I_lo(1):I_hi(1),I_lo(2):I_hi(2),I_lo(3):I_hi(3),1:3,1:3)
+    real(rt)        , intent(in) ::     s( s_lo(1): s_hi(1), s_lo(2): s_hi(2), s_lo(3): s_hi(3))
+    real(rt)        , intent(in) ::     u(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),3)
+    real(rt)        , intent(in) ::  cspd(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3))
+    real(rt)        , intent(in) :: flatn( f_lo(1): f_hi(1), f_lo(2): f_hi(2), f_lo(3): f_hi(3))
+    real(rt)        , intent(inout) :: Ip(I_lo(1):I_hi(1),I_lo(2):I_hi(2),I_lo(3):I_hi(3),1:3,1:3)
+    real(rt)        , intent(inout) :: Im(I_lo(1):I_hi(1),I_lo(2):I_hi(2),I_lo(3):I_hi(3),1:3,1:3)
 
-    double precision, intent(in) :: dx(3), dt
+    real(rt)        , intent(in) :: dx(3), dt
 
     integer, intent(in), optional :: force_type_in
 
@@ -78,6 +80,7 @@ contains
     use meth_params_module, only : ppm_type
     use bl_constants_module
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer, intent(in) ::  s_lo(3),  s_hi(3)
@@ -87,33 +90,33 @@ contains
     integer, intent(in) :: ilo1, ilo2, ihi1, ihi2
     integer, intent(in) :: k3d, kc
 
-    double precision, intent(in) ::     s( s_lo(1): s_hi(1), s_lo(2): s_hi(2), s_lo(3): s_hi(3))
-    double precision, intent(in) ::     u(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),3)
-    double precision, intent(in) ::  cspd(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3))
-    double precision, intent(in) :: flatn( f_lo(1): f_hi(1), f_lo(2): f_hi(2), f_lo(3): f_hi(3))
+    real(rt)        , intent(in) ::     s( s_lo(1): s_hi(1), s_lo(2): s_hi(2), s_lo(3): s_hi(3))
+    real(rt)        , intent(in) ::     u(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),3)
+    real(rt)        , intent(in) ::  cspd(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3))
+    real(rt)        , intent(in) :: flatn( f_lo(1): f_hi(1), f_lo(2): f_hi(2), f_lo(3): f_hi(3))
 
-    double precision, intent(inout) :: Ip(I_lo(1):I_hi(1),I_lo(2):I_hi(2),I_lo(3):I_hi(3),1:3,1:3)
-    double precision, intent(inout) :: Im(I_lo(1):I_hi(1),I_lo(2):I_hi(2),I_lo(3):I_hi(3),1:3,1:3)
+    real(rt)        , intent(inout) :: Ip(I_lo(1):I_hi(1),I_lo(2):I_hi(2),I_lo(3):I_hi(3),1:3,1:3)
+    real(rt)        , intent(inout) :: Im(I_lo(1):I_hi(1),I_lo(2):I_hi(2),I_lo(3):I_hi(3),1:3,1:3)
 
-    double precision, intent(in) :: dx(3), dt
+    real(rt)        , intent(in) :: dx(3), dt
 
     ! local
     integer i,j,k
 
-    double precision dtdx, dtdy, dtdz
+    real(rt)         dtdx, dtdy, dtdz
 
-    double precision dsl, dsr, dsc
-    double precision sigma, s6
+    real(rt)         dsl, dsr, dsc
+    real(rt)         sigma, s6
 
     ! s_{\ib,+}, s_{\ib,-}
-    double precision :: sm, sp
+    real(rt)         :: sm, sp
 
     ! \delta s_{\ib}^{vL}
-    double precision, pointer :: dsvl(:,:)
-    double precision :: dsvlm, dsvl0, dsvlp
+    real(rt)        , pointer :: dsvl(:,:)
+    real(rt)         :: dsvlm, dsvl0, dsvlp
 
     ! s_{i+\half}^{H.O.}
-    double precision, pointer :: sedge(:,:)
+    real(rt)        , pointer :: sedge(:,:)
 
     dtdx = dt/dx(1)
     dtdy = dt/dx(2)
@@ -537,6 +540,7 @@ contains
     use meth_params_module, only : ppm_type
     use bl_constants_module
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer, intent(in) ::  s_lo(3),  s_hi(3)
@@ -546,37 +550,37 @@ contains
     integer, intent(in) :: ilo1, ilo2, ihi1, ihi2
     integer, intent(in) :: k3d, kc
 
-    double precision, intent(in) ::     s( s_lo(1): s_hi(1), s_lo(2): s_hi(2), s_lo(3): s_hi(3))
-    double precision, intent(in) ::     u(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),3)
-    double precision, intent(in) ::  cspd(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3))
-    double precision, intent(in) :: flatn(f_lo(1):f_hi(1),f_lo(2):f_hi(2),f_lo(3):f_hi(3))
-    double precision, intent(inout) :: Ip(I_lo(1):I_hi(1),I_lo(2):I_hi(2),I_lo(3):I_hi(3),1:3,1:3)
-    double precision, intent(inout) :: Im(I_lo(1):I_hi(1),I_lo(2):I_hi(2),I_lo(3):I_hi(3),1:3,1:3)
+    real(rt)        , intent(in) ::     s( s_lo(1): s_hi(1), s_lo(2): s_hi(2), s_lo(3): s_hi(3))
+    real(rt)        , intent(in) ::     u(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),3)
+    real(rt)        , intent(in) ::  cspd(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3))
+    real(rt)        , intent(in) :: flatn(f_lo(1):f_hi(1),f_lo(2):f_hi(2),f_lo(3):f_hi(3))
+    real(rt)        , intent(inout) :: Ip(I_lo(1):I_hi(1),I_lo(2):I_hi(2),I_lo(3):I_hi(3),1:3,1:3)
+    real(rt)        , intent(inout) :: Im(I_lo(1):I_hi(1),I_lo(2):I_hi(2),I_lo(3):I_hi(3),1:3,1:3)
 
-    double precision, intent(in) :: dx(3), dt
+    real(rt)        , intent(in) :: dx(3), dt
 
 
     ! local
     integer i,j,k
     logical extremum, bigp, bigm
 
-    double precision dtdx, dtdy, dtdz
+    real(rt)         dtdx, dtdy, dtdz
 
-    double precision D2, D2C, D2L, D2R, D2LIM, alphap, alpham
-    double precision sgn, sigma, s6
-    double precision dafacem, dafacep, dabarm, dabarp, dafacemin, dabarmin
-    double precision dachkm, dachkp
-    double precision amax, delam, delap
+    real(rt)         D2, D2C, D2L, D2R, D2LIM, alphap, alpham
+    real(rt)         sgn, sigma, s6
+    real(rt)         dafacem, dafacep, dabarm, dabarp, dafacemin, dabarmin
+    real(rt)         dachkm, dachkp
+    real(rt)         amax, delam, delap
 
     ! s_{\ib,+}, s_{\ib,-}
-    double precision :: sm, sp
+    real(rt)         :: sm, sp
 
     ! s_{i+\half}^{H.O.}
-    double precision, pointer :: sedge(:,:)
-    double precision, pointer :: sedgez(:,:,:)
+    real(rt)        , pointer :: sedge(:,:)
+    real(rt)        , pointer :: sedgez(:,:,:)
 
     ! constant used in Colella 2008
-    double precision, parameter :: C = 1.25d0
+    real(rt)        , parameter :: C = 1.25e0_rt
 
     dtdx = dt/dx(1)
     dtdy = dt/dx(2)
@@ -671,15 +675,15 @@ contains
              D2C    = s(i-1,j,k3d)-TWO*s(i,j,k3d)+s(i+1,j,k3d)
              sgn    = sign(ONE,D2)
              D2LIM  = max(min(sgn*D2,C*sgn*D2L,C*sgn*D2R,C*sgn*D2C),ZERO)
-             alpham = alpham*D2LIM/max(abs(D2),1.d-10)
-             alphap = alphap*D2LIM/max(abs(D2),1.d-10)
+             alpham = alpham*D2LIM/max(abs(D2),1.e-10_rt)
+             alphap = alphap*D2LIM/max(abs(D2),1.e-10_rt)
           else
              if (bigp) then
                 sgn   = sign(ONE,alpham)
                 amax  = -alphap**2 / (4*(alpham + alphap))
                 delam = s(i-1,j,k3d) - s(i,j,k3d)
                 if (sgn*amax .ge. sgn*delam) then
-                   if (sgn*(delam - alpham).ge.1.d-10) then
+                   if (sgn*(delam - alpham).ge.1.e-10_rt) then
                       alphap = (-TWO*delam - TWO*sgn*sqrt(delam**2 - delam*alpham))
                    else
                       alphap = -TWO*alpham
@@ -691,7 +695,7 @@ contains
                 amax  = -alpham**2 / (4*(alpham + alphap))
                 delap = s(i+1,j,k3d) - s(i,j,k3d)
                 if (sgn*amax .ge. sgn*delap) then
-                   if (sgn*(delap - alphap).ge.1.d-10) then
+                   if (sgn*(delap - alphap).ge.1.e-10_rt) then
                       alpham = (-TWO*delap - TWO*sgn*sqrt(delap**2 - delap*alphap))
                    else
                       alpham = -TWO*alphap
@@ -836,15 +840,15 @@ contains
              D2C    = s(i,j-1,k3d)-TWO*s(i,j,k3d)+s(i,j+1,k3d)
              sgn    = sign(ONE,D2)
              D2LIM  = max(min(sgn*D2,C*sgn*D2L,C*sgn*D2R,C*sgn*D2C),ZERO)
-             alpham = alpham*D2LIM/max(abs(D2),1.d-10)
-             alphap = alphap*D2LIM/max(abs(D2),1.d-10)
+             alpham = alpham*D2LIM/max(abs(D2),1.e-10_rt)
+             alphap = alphap*D2LIM/max(abs(D2),1.e-10_rt)
           else
              if (bigp) then
                 sgn   = sign(ONE,alpham)
                 amax  = -alphap**2 / (4*(alpham + alphap))
                 delam = s(i,j-1,k3d) - s(i,j,k3d)
                 if (sgn*amax .ge. sgn*delam) then
-                   if (sgn*(delam - alpham).ge.1.d-10) then
+                   if (sgn*(delam - alpham).ge.1.e-10_rt) then
                       alphap = (-TWO*delam - TWO*sgn*sqrt(delam**2 - delam*alpham))
                    else
                       alphap = -TWO*alpham
@@ -856,7 +860,7 @@ contains
                 amax  = -alpham**2 / (4*(alpham + alphap))
                 delap = s(i,j+1,k3d) - s(i,j,k3d)
                 if (sgn*amax .ge. sgn*delap) then
-                   if (sgn*(delap - alphap).ge.1.d-10) then
+                   if (sgn*(delap - alphap).ge.1.e-10_rt) then
                       alpham = (-TWO*delap - TWO*sgn*sqrt(delap**2 - delap*alphap))
                    else
                       alpham = -TWO*alphap
@@ -1006,15 +1010,15 @@ contains
              D2C    = s(i,j,k-1)-TWO*s(i,j,k)+s(i,j,k+1)
              sgn    = sign(ONE,D2)
              D2LIM  = max(min(sgn*D2,C*sgn*D2L,C*sgn*D2R,C*sgn*D2C),ZERO)
-             alpham = alpham*D2LIM/max(abs(D2),1.d-10)
-             alphap = alphap*D2LIM/max(abs(D2),1.d-10)
+             alpham = alpham*D2LIM/max(abs(D2),1.e-10_rt)
+             alphap = alphap*D2LIM/max(abs(D2),1.e-10_rt)
           else
              if (bigp) then
                 sgn   = sign(ONE,alpham)
                 amax  = -alphap**2 / (4*(alpham + alphap))
                 delam = s(i,j,k-1) - s(i,j,k)
                 if (sgn*amax .ge. sgn*delam) then
-                   if (sgn*(delam - alpham).ge.1.d-10) then
+                   if (sgn*(delam - alpham).ge.1.e-10_rt) then
                       alphap = (-TWO*delam - TWO*sgn*sqrt(delam**2 - delam*alpham))
                    else
                       alphap = -TWO*alpham
@@ -1026,7 +1030,7 @@ contains
                 amax  = -alpham**2 / (4*(alpham + alphap))
                 delap = s(i,j,k+1) - s(i,j,k)
                 if (sgn*amax .ge. sgn*delap) then
-                   if (sgn*(delap - alphap).ge.1.d-10) then
+                   if (sgn*(delap - alphap).ge.1.e-10_rt) then
                       alpham = (-TWO*delap - TWO*sgn*sqrt(delap**2 - delap*alphap))
                    else
                       alpham = -TWO*alphap

--- a/Source/Src_3d/problem_tagging_3d.f90
+++ b/Source/Src_3d/problem_tagging_3d.f90
@@ -1,5 +1,6 @@
 module problem_tagging_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   public
@@ -18,17 +19,18 @@ contains
 
     use meth_params_module, only: NVAR
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer         ,intent(in   ) :: lo(3),hi(3)
     integer         ,intent(in   ) :: state_l1,state_l2,state_l3, &
                                       state_h1,state_h2,state_h3
     integer         ,intent(in   ) :: tagl1,tagl2,tagl3,tagh1,tagh2,tagh3
-    double precision,intent(in   ) :: state(state_l1:state_h1, &
+    real(rt)        ,intent(in   ) :: state(state_l1:state_h1, &
                                       state_l2:state_h2, &
                                       state_l3:state_h3,NVAR)
     integer         ,intent(inout) :: tag(tagl1:tagh1,tagl2:tagh2,tagl3:tagh3)
-    double precision,intent(in   ) :: problo(3),dx(3),time
+    real(rt)        ,intent(in   ) :: problo(3),dx(3),time
     integer         ,intent(in   ) :: level,set,clear
 
   end subroutine set_problem_tags

--- a/Source/Src_3d/riemann_3d.F90
+++ b/Source/Src_3d/riemann_3d.F90
@@ -24,13 +24,14 @@ module riemann_module
   use rad_params_module, only : ngroups
 #endif
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   private
 
   public cmpflx, shock
 
-  real (kind=dp_t), parameter :: smallu = 1.e-12_dp_t
+  real(rt)        , parameter :: smallu = 1.e-12_rt
 
 contains
 
@@ -52,6 +53,7 @@ contains
     use eos_module
     use network, only: nspec, naux
 
+    use bl_fort_module, only : rt => c_real
     integer, intent(in) :: qpd_lo(3), qpd_hi(3)
     integer, intent(in) :: flx_lo(3), flx_hi(3)
     integer, intent(in) :: q_lo(3), q_hi(3)
@@ -72,39 +74,39 @@ contains
     ! comes in dimensioned as the full box.  We index the flux with
     ! kflux -- this will be set correctly for the different cases.
 
-    double precision, intent(inout) :: qm(qpd_lo(1):qpd_hi(1),qpd_lo(2):qpd_hi(2),qpd_lo(3):qpd_hi(3),NQ)
-    double precision, intent(inout) :: qp(qpd_lo(1):qpd_hi(1),qpd_lo(2):qpd_hi(2),qpd_lo(3):qpd_hi(3),NQ)
+    real(rt)        , intent(inout) :: qm(qpd_lo(1):qpd_hi(1),qpd_lo(2):qpd_hi(2),qpd_lo(3):qpd_hi(3),NQ)
+    real(rt)        , intent(inout) :: qp(qpd_lo(1):qpd_hi(1),qpd_lo(2):qpd_hi(2),qpd_lo(3):qpd_hi(3),NQ)
 
-    double precision, intent(inout) ::    flx(flx_lo(1):flx_hi(1),flx_lo(2):flx_hi(2),flx_lo(3):flx_hi(3),NVAR)
-    double precision, intent(inout) ::   qint(q_lo(1):q_hi(1),q_lo(2):q_hi(2),q_lo(3):q_hi(3),NGDNV)
+    real(rt)        , intent(inout) ::    flx(flx_lo(1):flx_hi(1),flx_lo(2):flx_hi(2),flx_lo(3):flx_hi(3),NVAR)
+    real(rt)        , intent(inout) ::   qint(q_lo(1):q_hi(1),q_lo(2):q_hi(2),q_lo(3):q_hi(3),NGDNV)
 
 #ifdef RADIATION
-    double precision, intent(inout) :: rflx(rflx_lo(1):rflx_hi(1), rflx_lo(2):rflx_hi(2), rflx_lo(3):rflx_hi(3),0:ngroups-1)
+    real(rt)        , intent(inout) :: rflx(rflx_lo(1):rflx_hi(1), rflx_lo(2):rflx_hi(2), rflx_lo(3):rflx_hi(3),0:ngroups-1)
 #endif
 
     ! qaux come in dimensioned as the full box, so we use k3d here to
     ! index it in z
 
-    double precision, intent(in) :: qaux(qa_lo(1):qa_hi(1),qa_lo(2):qa_hi(2),qa_lo(3):qa_hi(3),NQAUX)
+    real(rt)        , intent(in) :: qaux(qa_lo(1):qa_hi(1),qa_lo(2):qa_hi(2),qa_lo(3):qa_hi(3),NQAUX)
 
-    double precision, intent(in) ::  shk(s_lo(1):s_hi(1),s_lo(2):s_hi(2),s_lo(3):s_hi(3))
+    real(rt)        , intent(in) ::  shk(s_lo(1):s_hi(1),s_lo(2):s_hi(2),s_lo(3):s_hi(3))
 
     ! local variables
 
     integer i, j
     integer :: gd_lo(2), gd_hi(2)
-    double precision, pointer :: smallc(:,:), cavg(:,:)
-    double precision, pointer :: gamcm(:,:), gamcp(:,:)
+    real(rt)        , pointer :: smallc(:,:), cavg(:,:)
+    real(rt)        , pointer :: gamcm(:,:), gamcp(:,:)
 #ifdef RADIATION
-    double precision, pointer :: gamcgm(:,:), gamcgp(:,:)
-    double precision, pointer :: lam(:,:,:,:)
+    real(rt)        , pointer :: gamcgm(:,:), gamcgp(:,:)
+    real(rt)        , pointer :: lam(:,:,:,:)
 #endif
 
     integer :: is_shock
-    double precision :: cl, cr
+    real(rt)         :: cl, cr
     type (eos_t) :: eos_state
 
-    double precision :: rhoInv
+    real(rt)         :: rhoInv
 
     gd_lo = (/ ilo, jlo /)
     gd_hi = (/ ihi, jhi /)
@@ -180,7 +182,7 @@ contains
 
              ! this is an initial guess for iterations, since we
              ! can't be certain that temp is on interfaces
-             eos_state % T = 10000.0d0
+             eos_state % T = 10000.0e0_rt
 
              ! minus state
              eos_state % rho = qm(i,j,kc,QRHO)
@@ -311,23 +313,24 @@ contains
     use prob_params_module, only : coord_type
     use bl_constants_module
 
+    use bl_fort_module, only : rt => c_real
     integer, intent(in) :: qd_lo(3), qd_hi(3)
     integer, intent(in) :: s_lo(3), s_hi(3)
     integer, intent(in) :: lo(3), hi(3)
-    double precision, intent(in) :: dx(3)
-    double precision, intent(in) :: q(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),NQ)
-    double precision, intent(inout) :: shk(s_lo(1):s_hi(1),s_lo(2):s_hi(2),s_lo(3):s_hi(3))
+    real(rt)        , intent(in) :: dx(3)
+    real(rt)        , intent(in) :: q(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),NQ)
+    real(rt)        , intent(inout) :: shk(s_lo(1):s_hi(1),s_lo(2):s_hi(2),s_lo(3):s_hi(3))
 
     integer :: i, j, k
 
-    double precision :: dxinv, dyinv, dzinv
-    double precision :: divU
-    double precision :: px_pre, px_post, py_pre, py_post, pz_pre, pz_post
-    double precision :: e_x, e_y, e_z, d
-    double precision :: p_pre, p_post, pjump
+    real(rt)         :: dxinv, dyinv, dzinv
+    real(rt)         :: divU
+    real(rt)         :: px_pre, px_post, py_pre, py_post, pz_pre, pz_post
+    real(rt)         :: e_x, e_y, e_z, d
+    real(rt)         :: p_pre, p_post, pjump
 
-    double precision, parameter :: small = 1.d-10
-    double precision, parameter :: eps = 0.33d0
+    real(rt)        , parameter :: small = 1.e-10_rt
+    real(rt)        , parameter :: eps = 0.33e0_rt
 
     ! This is a basic multi-dimensional shock detection algorithm.
     ! This implementation follows Flash, which in turn follows
@@ -435,7 +438,8 @@ contains
     use hybrid_advection_module, only : compute_hybrid_flux
 #endif
 
-    double precision, parameter:: small = 1.d-8
+    use bl_fort_module, only : rt => c_real
+    real(rt)        , parameter:: small = 1.e-8_rt
 
     integer :: qpd_lo(3),qpd_hi(3)
     integer :: gd_lo(2),gd_hi(2)
@@ -444,14 +448,14 @@ contains
     integer :: idir,ilo,ihi,jlo,jhi
     integer :: domlo(3),domhi(3)
 
-    double precision :: ql(qpd_lo(1):qpd_hi(1),qpd_lo(2):qpd_hi(2),qpd_lo(3):qpd_hi(3),NQ)
-    double precision :: qr(qpd_lo(1):qpd_hi(1),qpd_lo(2):qpd_hi(2),qpd_lo(3):qpd_hi(3),NQ)
-    double precision ::  gamcl(gd_lo(1):gd_hi(1),gd_lo(2):gd_hi(2))
-    double precision ::  gamcr(gd_lo(1):gd_hi(1),gd_lo(2):gd_hi(2))
-    double precision ::    cav(gd_lo(1):gd_hi(1),gd_lo(2):gd_hi(2))
-    double precision :: smallc(gd_lo(1):gd_hi(1),gd_lo(2):gd_hi(2))
-    double precision :: uflx(uflx_lo(1):uflx_hi(1),uflx_lo(2):uflx_hi(2),uflx_lo(3):uflx_hi(3),NVAR)
-    double precision :: qint(q_lo(1):q_hi(1),q_lo(2):q_hi(2),q_lo(3):q_hi(3),NGDNV)
+    real(rt)         :: ql(qpd_lo(1):qpd_hi(1),qpd_lo(2):qpd_hi(2),qpd_lo(3):qpd_hi(3),NQ)
+    real(rt)         :: qr(qpd_lo(1):qpd_hi(1),qpd_lo(2):qpd_hi(2),qpd_lo(3):qpd_hi(3),NQ)
+    real(rt)         ::  gamcl(gd_lo(1):gd_hi(1),gd_lo(2):gd_hi(2))
+    real(rt)         ::  gamcr(gd_lo(1):gd_hi(1),gd_lo(2):gd_hi(2))
+    real(rt)         ::    cav(gd_lo(1):gd_hi(1),gd_lo(2):gd_hi(2))
+    real(rt)         :: smallc(gd_lo(1):gd_hi(1),gd_lo(2):gd_hi(2))
+    real(rt)         :: uflx(uflx_lo(1):uflx_hi(1),uflx_lo(2):uflx_hi(2),uflx_lo(3):uflx_hi(3),NVAR)
+    real(rt)         :: qint(q_lo(1):q_hi(1),q_lo(2):q_hi(2),q_lo(3):q_hi(3),NGDNV)
 
     ! Note:  Here k3d is the k corresponding to the full 3d array --
     !         it should be used for print statements or tests against domlo, domhi, etc
@@ -463,51 +467,51 @@ contains
     integer :: i,j,kc,kflux,k3d
     integer :: n, nqp, ipassive
 
-    double precision :: ustar,gamgdnv
-    double precision :: rl, ul, v1l, v2l, pl, rel
-    double precision :: rr, ur, v1r, v2r, pr, rer
-    double precision :: wl, wr, rhoetot
-   !double precision :: scr
-    double precision :: rstar, cstar, pstar
-    double precision :: ro, uo, po, co, gamco
-    double precision :: sgnm, spin, spout, ushock, frac
-    double precision :: wsmall, csmall,qavg
+    real(rt)         :: ustar,gamgdnv
+    real(rt)         :: rl, ul, v1l, v2l, pl, rel
+    real(rt)         :: rr, ur, v1r, v2r, pr, rer
+    real(rt)         :: wl, wr, rhoetot
+   !real(rt)         :: scr
+    real(rt)         :: rstar, cstar, pstar
+    real(rt)         :: ro, uo, po, co, gamco
+    real(rt)         :: sgnm, spin, spout, ushock, frac
+    real(rt)         :: wsmall, csmall,qavg
 
-    double precision :: gcl, gcr
-    double precision :: clsq, clsql, clsqr, wlsq, wosq, wrsq, wo
-    double precision :: zm, zp
-    double precision :: denom, dpditer, dpjmp
-    double precision :: gamc_bar, game_bar
-    double precision :: gamel, gamer, gameo, gamstar, gmin, gmax, gdot
+    real(rt)         :: gcl, gcr
+    real(rt)         :: clsq, clsql, clsqr, wlsq, wosq, wrsq, wo
+    real(rt)         :: zm, zp
+    real(rt)         :: denom, dpditer, dpjmp
+    real(rt)         :: gamc_bar, game_bar
+    real(rt)         :: gamel, gamer, gameo, gamstar, gmin, gmax, gdot
 
     integer :: iter, iter_max
-    double precision :: tol
-    double precision :: err
+    real(rt)         :: tol
+    real(rt)         :: err
 
     logical :: converged
 
-    double precision :: pstnm1
-    double precision :: taul, taur, tauo
-    double precision :: ustarm, ustarp, ustnm1, ustnp1
-    double precision :: pstarl, pstarc, pstaru, pfuncc, pfuncu
+    real(rt)         :: pstnm1
+    real(rt)         :: taul, taur, tauo
+    real(rt)         :: ustarm, ustarp, ustnm1, ustnp1
+    real(rt)         :: pstarl, pstarc, pstaru, pfuncc, pfuncu
 
-    double precision, parameter :: weakwv = 1.d-3
+    real(rt)        , parameter :: weakwv = 1.e-3_rt
 
-    double precision, pointer :: pstar_hist(:), pstar_hist_extra(:)
+    real(rt)        , pointer :: pstar_hist(:), pstar_hist_extra(:)
 
     type (eos_t) :: eos_state
 
-    double precision, pointer :: us1d(:)
+    real(rt)        , pointer :: us1d(:)
 
 #ifdef ROTATION
-    double precision :: vel(3)
+    real(rt)         :: vel(3)
 #endif
 
-    double precision :: u_adv
+    real(rt)         :: u_adv
 
     integer :: iu, iv1, iv2, im1, im2, im3
     logical :: special_bnd_lo, special_bnd_hi, special_bnd_lo_x, special_bnd_hi_x
-    double precision :: bnd_fac_x, bnd_fac_y, bnd_fac_z
+    real(rt)         :: bnd_fac_x, bnd_fac_y, bnd_fac_z
 
     if (cg_blend .eq. 2 .and. cg_maxiter < 5) then
 
@@ -1067,7 +1071,8 @@ contains
     use hybrid_advection_module, only : compute_hybrid_flux
 #endif
 
-    double precision, parameter:: small = 1.d-8
+    use bl_fort_module, only : rt => c_real
+    real(rt)        , parameter:: small = 1.e-8_rt
 
     integer :: qpd_lo(3),qpd_hi(3)
     integer :: gd_lo(2),gd_hi(2)
@@ -1081,21 +1086,21 @@ contains
     integer rflx_lo(3),rflx_hi(3)
 #endif
 
-    double precision :: ql(qpd_lo(1):qpd_hi(1),qpd_lo(2):qpd_hi(2),qpd_lo(3):qpd_hi(3),NQ)
-    double precision :: qr(qpd_lo(1):qpd_hi(1),qpd_lo(2):qpd_hi(2),qpd_lo(3):qpd_hi(3),NQ)
+    real(rt)         :: ql(qpd_lo(1):qpd_hi(1),qpd_lo(2):qpd_hi(2),qpd_lo(3):qpd_hi(3),NQ)
+    real(rt)         :: qr(qpd_lo(1):qpd_hi(1),qpd_lo(2):qpd_hi(2),qpd_lo(3):qpd_hi(3),NQ)
 
-    double precision ::  gamcl(gd_lo(1):gd_hi(1),gd_lo(2):gd_hi(2))
-    double precision ::  gamcr(gd_lo(1):gd_hi(1),gd_lo(2):gd_hi(2))
-    double precision ::    cav(gd_lo(1):gd_hi(1),gd_lo(2):gd_hi(2))
-    double precision :: smallc(gd_lo(1):gd_hi(1),gd_lo(2):gd_hi(2))
-    double precision :: uflx(uflx_lo(1):uflx_hi(1),uflx_lo(2):uflx_hi(2),uflx_lo(3):uflx_hi(3),NVAR)
-    double precision ::    qint(q_lo(1):q_hi(1),q_lo(2):q_hi(2),q_lo(3):q_hi(3),NGDNV)
+    real(rt)         ::  gamcl(gd_lo(1):gd_hi(1),gd_lo(2):gd_hi(2))
+    real(rt)         ::  gamcr(gd_lo(1):gd_hi(1),gd_lo(2):gd_hi(2))
+    real(rt)         ::    cav(gd_lo(1):gd_hi(1),gd_lo(2):gd_hi(2))
+    real(rt)         :: smallc(gd_lo(1):gd_hi(1),gd_lo(2):gd_hi(2))
+    real(rt)         :: uflx(uflx_lo(1):uflx_hi(1),uflx_lo(2):uflx_hi(2),uflx_lo(3):uflx_hi(3),NVAR)
+    real(rt)         ::    qint(q_lo(1):q_hi(1),q_lo(2):q_hi(2),q_lo(3):q_hi(3),NGDNV)
 
 #ifdef RADIATION
-    double precision lam(lam_lo(1):lam_hi(1),lam_lo(2):lam_hi(2),lam_lo(3):lam_hi(3),0:ngroups-1)
-    double precision gamcgl(gd_lo(1):gd_hi(1),gd_lo(2):gd_hi(2))
-    double precision gamcgr(gd_lo(1):gd_hi(1),gd_lo(2):gd_hi(2))
-    double precision rflx(rflx_lo(1):rflx_hi(1),rflx_lo(2):rflx_hi(2),rflx_lo(3):rflx_hi(3),0:ngroups-1)
+    real(rt)         lam(lam_lo(1):lam_hi(1),lam_lo(2):lam_hi(2),lam_lo(3):lam_hi(3),0:ngroups-1)
+    real(rt)         gamcgl(gd_lo(1):gd_hi(1),gd_lo(2):gd_hi(2))
+    real(rt)         gamcgr(gd_lo(1):gd_hi(1),gd_lo(2):gd_hi(2))
+    real(rt)         rflx(rflx_lo(1):rflx_hi(1),rflx_lo(2):rflx_hi(2),rflx_lo(3):rflx_hi(3),0:ngroups-1)
 #endif
 
     ! Note:  Here k3d is the k corresponding to the full 3d array --
@@ -1108,38 +1113,38 @@ contains
     integer :: i,j,kc,kflux,k3d
     integer :: n, nqp, ipassive
 
-    double precision :: regdnv
-    double precision :: rl, ul, v1l, v2l, pl, rel
-    double precision :: rr, ur, v1r, v2r, pr, rer
-    double precision :: wl, wr, rhoetot, scr
-    double precision :: rstar, cstar, estar, pstar, ustar
-    double precision :: ro, uo, po, reo, co, gamco, entho, drho
-    double precision :: sgnm, spin, spout, ushock, frac
-    double precision :: wsmall, csmall,qavg
+    real(rt)         :: regdnv
+    real(rt)         :: rl, ul, v1l, v2l, pl, rel
+    real(rt)         :: rr, ur, v1r, v2r, pr, rer
+    real(rt)         :: wl, wr, rhoetot, scr
+    real(rt)         :: rstar, cstar, estar, pstar, ustar
+    real(rt)         :: ro, uo, po, reo, co, gamco, entho, drho
+    real(rt)         :: sgnm, spin, spout, ushock, frac
+    real(rt)         :: wsmall, csmall,qavg
 
 #ifdef RADIATION
-    double precision, dimension(0:ngroups-1) :: erl, err
-    double precision :: reo_g, po_g, co_g, gamco_g
-    double precision :: pl_g, rel_g, pr_g, rer_g
-    double precision :: regdnv_g, pgdnv_g, pgdnv_t
-    double precision :: estar_g, pstar_g
-    double precision, dimension(0:ngroups-1) :: lambda, laml, lamr, reo_r, po_r, estar_r, regdnv_r
-    double precision :: eddf, f1
+    real(rt)        , dimension(0:ngroups-1) :: erl, err
+    real(rt)         :: reo_g, po_g, co_g, gamco_g
+    real(rt)         :: pl_g, rel_g, pr_g, rer_g
+    real(rt)         :: regdnv_g, pgdnv_g, pgdnv_t
+    real(rt)         :: estar_g, pstar_g
+    real(rt)        , dimension(0:ngroups-1) :: lambda, laml, lamr, reo_r, po_r, estar_r, regdnv_r
+    real(rt)         :: eddf, f1
     integer :: g
 #endif
 
-    double precision, pointer :: us1d(:)
+    real(rt)        , pointer :: us1d(:)
 
 #ifdef ROTATION
-    double precision :: vel(3)
+    real(rt)         :: vel(3)
 #endif
 
-    double precision :: u_adv
+    real(rt)         :: u_adv
 
     integer :: iu, iv1, iv2, im1, im2, im3
     logical :: special_bnd_lo, special_bnd_hi, special_bnd_lo_x, special_bnd_hi_x
-    double precision :: bnd_fac_x, bnd_fac_y, bnd_fac_z
-    double precision :: wwinv, roinv, co2inv
+    real(rt)         :: bnd_fac_x, bnd_fac_y, bnd_fac_z
+    real(rt)         :: wwinv, roinv, co2inv
 
     call bl_allocate(us1d,ilo,ihi)
 
@@ -1305,13 +1310,13 @@ contains
              gamco = HALF*(gamcl(i,j)+gamcr(i,j))
 #ifdef RADIATION
              do g=0, ngroups-1
-                lambda(g) = 2.0d0*(laml(g)*lamr(g))/(laml(g)+lamr(g)+1.d-50)
+                lambda(g) = 2.0e0_rt*(laml(g)*lamr(g))/(laml(g)+lamr(g)+1.e-50_rt)
              end do
 
-             reo_r(:) = 0.5d0*(erl(:)+err(:))
-             reo_g = 0.5d0*(rel_g+rer_g)
+             reo_r(:) = 0.5e0_rt*(erl(:)+err(:))
+             reo_g = 0.5e0_rt*(rel_g+rer_g)
              po_r(:) = lambda(:) * reo_r(:)
-             gamco_g = 0.5d0*(gamcgl(i,j)+gamcgr(i,j))
+             gamco_g = 0.5e0_rt*(gamcgl(i,j)+gamcgr(i,j))
              po_g = 0.5*(pr_g+pl_g)
 #endif
 
@@ -1376,10 +1381,10 @@ contains
           qint(i,j,kc,iu  ) = frac*ustar + (ONE - frac)*uo
 
 #ifdef RADIATION
-          pgdnv_t       = frac*pstar + (1.d0 - frac)*po
-          pgdnv_g       = frac*pstar_g + (1.d0 - frac)*po_g
-          regdnv_g = frac*estar_g + (1.d0 - frac)*reo_g
-          regdnv_r(:) = frac*estar_r(:) + (1.d0 - frac)*reo_r(:)
+          pgdnv_t       = frac*pstar + (1.e0_rt - frac)*po
+          pgdnv_g       = frac*pstar_g + (1.e0_rt - frac)*po_g
+          regdnv_g = frac*estar_g + (1.e0_rt - frac)*reo_g
+          regdnv_r(:) = frac*estar_r(:) + (1.e0_rt - frac)*reo_r(:)
 #else
           qint(i,j,kc,GDPRES) = frac*pstar + (ONE - frac)*po
           regdnv = frac*estar + (ONE - frac)*reo
@@ -1416,7 +1421,7 @@ contains
 
 #ifdef RADIATION
           do g=0, ngroups-1
-             qint(i,j,kc,GDERADS+g) = max(regdnv_r(g), 0.d0)
+             qint(i,j,kc,GDERADS+g) = max(regdnv_r(g), 0.e0_rt)
           end do
 
           qint(i,j,kc,GDPRES) = pgdnv_g
@@ -1471,8 +1476,8 @@ contains
           if (fspace_type.eq.1) then
              do g=0,ngroups-1
                 eddf = Edd_factor(lambda(g))
-                f1 = 0.5d0*(1.d0-eddf)
-                rflx(i,j,kflux,g) = (1.d0+f1) * qint(i,j,kc,GDERADS+g) * u_adv
+                f1 = 0.5e0_rt*(1.e0_rt-eddf)
+                rflx(i,j,kflux,g) = (1.e0_rt+f1) * qint(i,j,kc,GDERADS+g) * u_adv
              end do
           else ! type 2
              do g=0,ngroups-1
@@ -1530,7 +1535,8 @@ contains
     use mempool_module, only : bl_allocate, bl_deallocate
     use prob_params_module, only : physbc_lo, physbc_hi, Symmetry, SlipWall, NoSlipWall
 
-    double precision, parameter:: small = 1.d-8
+    use bl_fort_module, only : rt => c_real
+    real(rt)        , parameter:: small = 1.e-8_rt
 
     integer :: qpd_lo(3),qpd_hi(3)
     integer :: gd_lo(2),gd_hi(2)
@@ -1539,14 +1545,14 @@ contains
     integer :: idir,ilo,ihi,jlo,jhi
     integer :: domlo(3),domhi(3)
 
-    double precision :: ql(qpd_lo(1):qpd_hi(1),qpd_lo(2):qpd_hi(2),qpd_lo(3):qpd_hi(3),NQ)
-    double precision :: qr(qpd_lo(1):qpd_hi(1),qpd_lo(2):qpd_hi(2),qpd_lo(3):qpd_hi(3),NQ)
-    double precision ::  gamcl(gd_lo(1):gd_hi(1),gd_lo(2):gd_hi(2))
-    double precision ::  gamcr(gd_lo(1):gd_hi(1),gd_lo(2):gd_hi(2))
-    double precision ::    cav(gd_lo(1):gd_hi(1),gd_lo(2):gd_hi(2))
-    double precision :: smallc(gd_lo(1):gd_hi(1),gd_lo(2):gd_hi(2))
-    double precision :: uflx(uflx_lo(1):uflx_hi(1),uflx_lo(2):uflx_hi(2),uflx_lo(3):uflx_hi(3),NVAR)
-    double precision :: qint(q_lo(1):q_hi(1),q_lo(2):q_hi(2),q_lo(3):q_hi(3),NGDNV)
+    real(rt)         :: ql(qpd_lo(1):qpd_hi(1),qpd_lo(2):qpd_hi(2),qpd_lo(3):qpd_hi(3),NQ)
+    real(rt)         :: qr(qpd_lo(1):qpd_hi(1),qpd_lo(2):qpd_hi(2),qpd_lo(3):qpd_hi(3),NQ)
+    real(rt)         ::  gamcl(gd_lo(1):gd_hi(1),gd_lo(2):gd_hi(2))
+    real(rt)         ::  gamcr(gd_lo(1):gd_hi(1),gd_lo(2):gd_hi(2))
+    real(rt)         ::    cav(gd_lo(1):gd_hi(1),gd_lo(2):gd_hi(2))
+    real(rt)         :: smallc(gd_lo(1):gd_hi(1),gd_lo(2):gd_hi(2))
+    real(rt)         :: uflx(uflx_lo(1):uflx_hi(1),uflx_lo(2):uflx_hi(2),uflx_lo(3):uflx_hi(3),NVAR)
+    real(rt)         :: qint(q_lo(1):q_hi(1),q_lo(2):q_hi(2),q_lo(3):q_hi(3),NGDNV)
 
     ! Note:  Here k3d is the k corresponding to the full 3d array --
     !         it should be used for print statements or tests against domlo, domhi, etc
@@ -1557,22 +1563,22 @@ contains
     !             but in later calls, when uflx = {flux1,flux2,flux3}  , kflux = k3d
     integer :: i,j,kc,kflux,k3d
 
-    double precision :: rgdnv,regdnv
-    double precision :: rl, ul, v1l, v2l, pl, rel
-    double precision :: rr, ur, v1r, v2r, pr, rer
-    double precision :: wl, wr, scr
-    double precision :: rstar, cstar, estar, pstar, ustar
-    double precision :: ro, uo, po, reo, co, gamco, entho
-    double precision :: sgnm, spin, spout, ushock, frac
-    double precision :: wsmall, csmall
+    real(rt)         :: rgdnv,regdnv
+    real(rt)         :: rl, ul, v1l, v2l, pl, rel
+    real(rt)         :: rr, ur, v1r, v2r, pr, rer
+    real(rt)         :: wl, wr, scr
+    real(rt)         :: rstar, cstar, estar, pstar, ustar
+    real(rt)         :: ro, uo, po, reo, co, gamco, entho
+    real(rt)         :: sgnm, spin, spout, ushock, frac
+    real(rt)         :: wsmall, csmall
 
     integer :: iu, iv1, iv2, im1, im2, im3
     logical :: special_bnd_lo, special_bnd_hi, special_bnd_lo_x, special_bnd_hi_x
     integer :: bnd_fac_x, bnd_fac_y, bnd_fac_z, bnd_fac
-    double precision :: wwinv, roinv, co2inv
+    real(rt)         :: wwinv, roinv, co2inv
 
-    double precision :: U_hllc_state(nvar), U_state(nvar), F_state(nvar)
-    double precision :: S_l, S_r, S_c
+    real(rt)         :: U_hllc_state(nvar), U_state(nvar), F_state(nvar)
+    real(rt)         :: S_l, S_r, S_c
 
     if (idir .eq. 1) then
        iu = QU

--- a/Source/Src_3d/slope_3d.f90
+++ b/Source/Src_3d/slope_3d.f90
@@ -1,5 +1,6 @@
 module slope_module
   
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   private
@@ -20,26 +21,27 @@ contains
       use meth_params_module
       use bl_constants_module
 
+      use bl_fort_module, only : rt => c_real
       implicit none
 
       integer          :: qd_lo(3), qd_hi(3)
       integer          :: qpd_lo(3),qpd_hi(3)
       integer          :: ilo1, ilo2, ihi1, ihi2, kc, k3d, nv
 
-      double precision :: q(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),nv)
-      double precision :: flatn(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3))
-      double precision :: dqx(qpd_lo(1):qpd_hi(1),qpd_lo(2):qpd_hi(2),qpd_lo(3):qpd_hi(3),nv)
-      double precision :: dqy(qpd_lo(1):qpd_hi(1),qpd_lo(2):qpd_hi(2),qpd_lo(3):qpd_hi(3),nv)
-      double precision :: dqz(qpd_lo(1):qpd_hi(1),qpd_lo(2):qpd_hi(2),qpd_lo(3):qpd_hi(3),nv)
+      real(rt)         :: q(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),nv)
+      real(rt)         :: flatn(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3))
+      real(rt)         :: dqx(qpd_lo(1):qpd_hi(1),qpd_lo(2):qpd_hi(2),qpd_lo(3):qpd_hi(3),nv)
+      real(rt)         :: dqy(qpd_lo(1):qpd_hi(1),qpd_lo(2):qpd_hi(2),qpd_lo(3):qpd_hi(3),nv)
+      real(rt)         :: dqz(qpd_lo(1):qpd_hi(1),qpd_lo(2):qpd_hi(2),qpd_lo(3):qpd_hi(3),nv)
 
       integer i, j, k, n
 
-      double precision dlft, drgt, slop, dq1
-      double precision dm, dp, dc, ds, sl, dl, dfm, dfp
+      real(rt)         dlft, drgt, slop, dq1
+      real(rt)         dm, dp, dc, ds, sl, dl, dfm, dfp
 
       integer ilo, ihi      
       
-      double precision, pointer::dsgn(:,:),dlim(:,:),df(:,:),dcen(:,:)
+      real(rt)        , pointer::dsgn(:,:),dlim(:,:),df(:,:),dcen(:,:)
 
       ilo = MIN(ilo1,ilo2)
       ihi = MAX(ihi1,ihi2)
@@ -189,6 +191,7 @@ contains
         use meth_params_module
         use bl_constants_module
 
+        use bl_fort_module, only : rt => c_real
         implicit none
 
         integer          :: qd_lo(3), qd_hi(3)
@@ -196,24 +199,24 @@ contains
         integer          :: src_lo(3),src_hi(3)
         integer          :: ilo1, ilo2, ihi1, ihi2, kc, k3d
 
-        double precision :: p  (qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3))
-        double precision :: rho(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3))
-        double precision :: flatn(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3))
-        double precision :: dpx(qpd_lo(1):qpd_hi(1),qpd_lo(2):qpd_hi(2),qpd_lo(3):qpd_hi(3))
-        double precision :: dpy(qpd_lo(1):qpd_hi(1),qpd_lo(2):qpd_hi(2),qpd_lo(3):qpd_hi(3))
-        double precision :: dpz(qpd_lo(1):qpd_hi(1),qpd_lo(2):qpd_hi(2),qpd_lo(3):qpd_hi(3))
-        double precision :: src(src_lo(1):src_hi(1),src_lo(2):src_hi(2),src_lo(3):src_hi(3),QVAR)
-        double precision :: dx(3)
+        real(rt)         :: p  (qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3))
+        real(rt)         :: rho(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3))
+        real(rt)         :: flatn(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3))
+        real(rt)         :: dpx(qpd_lo(1):qpd_hi(1),qpd_lo(2):qpd_hi(2),qpd_lo(3):qpd_hi(3))
+        real(rt)         :: dpy(qpd_lo(1):qpd_hi(1),qpd_lo(2):qpd_hi(2),qpd_lo(3):qpd_hi(3))
+        real(rt)         :: dpz(qpd_lo(1):qpd_hi(1),qpd_lo(2):qpd_hi(2),qpd_lo(3):qpd_hi(3))
+        real(rt)         :: src(src_lo(1):src_hi(1),src_lo(2):src_hi(2),src_lo(3):src_hi(3),QVAR)
+        real(rt)         :: dx(3)
 
         integer i, j, k
 
         integer ilo,ihi        
         
-        double precision dlft, drgt, dp1
-        double precision dm, dp, dc, dl, dfm, dfp, ds
+        real(rt)         dlft, drgt, dp1
+        real(rt)         dm, dp, dc, dl, dfm, dfp, ds
 
         !     Local arrays
-        double precision, pointer::dsgn(:,:),dlim(:,:),df(:,:),dcen(:,:)
+        real(rt)        , pointer::dsgn(:,:),dlim(:,:),df(:,:),dcen(:,:)
 
         ilo = MIN(ilo1,ilo2)
         ihi = MAX(ihi1,ihi2)

--- a/Source/Src_3d/trace_3d.f90
+++ b/Source/Src_3d/trace_3d.f90
@@ -1,5 +1,6 @@
 module trace_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   private
@@ -19,6 +20,7 @@ contains
                                      npassive, qpass_map, small_dens, small_pres, ppm_type
       use bl_constants_module
 
+      use bl_fort_module, only : rt => c_real
       implicit none
 
       integer          :: qd_lo(3), qd_hi(3)
@@ -27,36 +29,36 @@ contains
       integer          :: ilo1,ilo2,ihi1,ihi2
       integer          :: kc,k3d
 
-      double precision ::    q(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),QVAR)
-      double precision ::    c(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3))
+      real(rt)         ::    q(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),QVAR)
+      real(rt)         ::    c(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3))
 
-      double precision ::  dqx(dq_lo(1):dq_hi(1),dq_lo(2):dq_hi(2),dq_lo(3):dq_hi(3),QVAR)
-      double precision ::  dqy(dq_lo(1):dq_hi(1),dq_lo(2):dq_hi(2),dq_lo(3):dq_hi(3),QVAR)
+      real(rt)         ::  dqx(dq_lo(1):dq_hi(1),dq_lo(2):dq_hi(2),dq_lo(3):dq_hi(3),QVAR)
+      real(rt)         ::  dqy(dq_lo(1):dq_hi(1),dq_lo(2):dq_hi(2),dq_lo(3):dq_hi(3),QVAR)
 
-      double precision :: qxm(qpd_lo(1):qpd_hi(1),qpd_lo(2):qpd_hi(2),qpd_lo(3):qpd_hi(3),QVAR)
-      double precision :: qxp(qpd_lo(1):qpd_hi(1),qpd_lo(2):qpd_hi(2),qpd_lo(3):qpd_hi(3),QVAR)
-      double precision :: qym(qpd_lo(1):qpd_hi(1),qpd_lo(2):qpd_hi(2),qpd_lo(3):qpd_hi(3),QVAR)
-      double precision :: qyp(qpd_lo(1):qpd_hi(1),qpd_lo(2):qpd_hi(2),qpd_lo(3):qpd_hi(3),QVAR)
-      double precision :: dx(3), dt
+      real(rt)         :: qxm(qpd_lo(1):qpd_hi(1),qpd_lo(2):qpd_hi(2),qpd_lo(3):qpd_hi(3),QVAR)
+      real(rt)         :: qxp(qpd_lo(1):qpd_hi(1),qpd_lo(2):qpd_hi(2),qpd_lo(3):qpd_hi(3),QVAR)
+      real(rt)         :: qym(qpd_lo(1):qpd_hi(1),qpd_lo(2):qpd_hi(2),qpd_lo(3):qpd_hi(3),QVAR)
+      real(rt)         :: qyp(qpd_lo(1):qpd_hi(1),qpd_lo(2):qpd_hi(2),qpd_lo(3):qpd_hi(3),QVAR)
+      real(rt)         :: dx(3), dt
 
       ! Local variables
       integer i, j, n, ipassive
 
-      double precision dtdx, dtdy
-      double precision cc, csq, rho, u, v, w, p, rhoe
-      double precision drho, du, dv, dw, dp, drhoe
+      real(rt)         dtdx, dtdy
+      real(rt)         cc, csq, rho, u, v, w, p, rhoe
+      real(rt)         drho, du, dv, dw, dp, drhoe
 
-      double precision enth, alpham, alphap, alpha0r, alpha0e
-      double precision alpha0u, alpha0v, alpha0w
-      double precision spminus, spplus, spzero
-      double precision apright, amright, azrright, azeright
-      double precision azu1rght, azv1rght, azw1rght
-      double precision apleft, amleft, azrleft, azeleft
-      double precision azu1left, azv1left, azw1left
-      double precision acmprght, acmpleft, acmpbot, acmptop
+      real(rt)         enth, alpham, alphap, alpha0r, alpha0e
+      real(rt)         alpha0u, alpha0v, alpha0w
+      real(rt)         spminus, spplus, spzero
+      real(rt)         apright, amright, azrright, azeright
+      real(rt)         azu1rght, azv1rght, azw1rght
+      real(rt)         apleft, amleft, azrleft, azeleft
+      real(rt)         azu1left, azv1left, azw1left
+      real(rt)         acmprght, acmpleft, acmpbot, acmptop
 
-      double precision rho_ref, u_ref, v_ref, w_ref, p_ref, rhoe_ref
-      double precision e(3)
+      real(rt)         rho_ref, u_ref, v_ref, w_ref, p_ref, rhoe_ref
+      real(rt)         e(3)
 
       dtdx = dt/dx(1)
       dtdy = dt/dx(2)
@@ -133,8 +135,8 @@ contains
             rhoe_ref = rhoe - HALF*(ONE + dtdx*min(e(1),ZERO))*drhoe
 
             ! this is -(1/2) ( 1 + dt/dx lambda) (l . dq) r
-            apright = 0.25d0*dtdx*(e(1) - e(3))*(ONE - sign(ONE,e(3)))*alphap
-            amright = 0.25d0*dtdx*(e(1) - e(1))*(ONE - sign(ONE,e(1)))*alpham
+            apright = 0.25e0_rt*dtdx*(e(1) - e(3))*(ONE - sign(ONE,e(3)))*alphap
+            amright = 0.25e0_rt*dtdx*(e(1) - e(1))*(ONE - sign(ONE,e(1)))*alpham
 
             azrright = 0.25e0*dtdx*(e(1)-e(2))*(ONE - sign(ONE,e(2)))*alpha0r
             azeright = 0.25e0*dtdx*(e(1)-e(2))*(ONE - sign(ONE,e(2)))*alpha0e
@@ -185,13 +187,13 @@ contains
             p_ref = p + HALF*(ONE - dtdx*max(e(3),ZERO))*dp
             rhoe_ref = rhoe + HALF*(ONE - dtdx*max(e(3),ZERO))*drhoe
 
-            apleft = 0.25d0*dtdx*(e(3) - e(3))*(ONE + sign(ONE,e(3)))*alphap
-            amleft = 0.25d0*dtdx*(e(3) - e(1))*(ONE + sign(ONE,e(1)))*alpham
+            apleft = 0.25e0_rt*dtdx*(e(3) - e(3))*(ONE + sign(ONE,e(3)))*alphap
+            amleft = 0.25e0_rt*dtdx*(e(3) - e(1))*(ONE + sign(ONE,e(1)))*alpham
 
-            azrleft = 0.25d0*dtdx*(e(3) - e(2))*(ONE + sign(ONE,e(2)))*alpha0r
-            azeleft = 0.25d0*dtdx*(e(3) - e(2))*(ONE + sign(ONE,e(2)))*alpha0e
-            azv1left = 0.25d0*dtdx*(e(3) - e(2))*(ONE + sign(ONE,e(2)))*alpha0v
-            azw1left = 0.25d0*dtdx*(e(3) - e(2))*(ONE + sign(ONE,e(2)))*alpha0w
+            azrleft = 0.25e0_rt*dtdx*(e(3) - e(2))*(ONE + sign(ONE,e(2)))*alpha0r
+            azeleft = 0.25e0_rt*dtdx*(e(3) - e(2))*(ONE + sign(ONE,e(2)))*alpha0e
+            azv1left = 0.25e0_rt*dtdx*(e(3) - e(2))*(ONE + sign(ONE,e(2)))*alpha0v
+            azw1left = 0.25e0_rt*dtdx*(e(3) - e(2))*(ONE + sign(ONE,e(2)))*alpha0w
 
             !apleft = HALF*(ONE - spplus )*alphap
             !amleft = HALF*(ONE - spminus)*alpham
@@ -305,8 +307,8 @@ contains
             p_ref = p - HALF*(ONE + dtdy*min(e(1),ZERO))*dp
             rhoe_ref = rhoe - HALF*(ONE + dtdy*min(e(1),ZERO))*drhoe
 
-            apright = 0.25d0*dtdy*(e(1) - e(3))*(ONE - sign(ONE,e(3)))*alphap
-            amright = 0.25d0*dtdy*(e(1) - e(1))*(ONE - sign(ONE,e(1)))*alpham
+            apright = 0.25e0_rt*dtdy*(e(1) - e(3))*(ONE - sign(ONE,e(3)))*alphap
+            amright = 0.25e0_rt*dtdy*(e(1) - e(1))*(ONE - sign(ONE,e(1)))*alpham
 
             azrright = 0.25e0*dtdy*(e(1)-e(2))*(ONE - sign(ONE,e(2)))*alpha0r
             azeright = 0.25e0*dtdy*(e(1)-e(2))*(ONE - sign(ONE,e(2)))*alpha0e
@@ -355,13 +357,13 @@ contains
             p_ref = p + HALF*(ONE - dtdy*max(e(3),ZERO))*dp
             rhoe_ref = rhoe + HALF*(ONE - dtdy*max(e(3),ZERO))*drhoe
 
-            apleft = 0.25d0*dtdy*(e(3) - e(3))*(ONE + sign(ONE,e(3)))*alphap
-            amleft = 0.25d0*dtdy*(e(3) - e(1))*(ONE + sign(ONE,e(1)))*alpham
+            apleft = 0.25e0_rt*dtdy*(e(3) - e(3))*(ONE + sign(ONE,e(3)))*alphap
+            amleft = 0.25e0_rt*dtdy*(e(3) - e(1))*(ONE + sign(ONE,e(1)))*alpham
 
-            azrleft = 0.25d0*dtdy*(e(3) - e(2))*(ONE + sign(ONE,e(2)))*alpha0r
-            azeleft = 0.25d0*dtdy*(e(3) - e(2))*(ONE + sign(ONE,e(2)))*alpha0e
-            azu1left = 0.25d0*dtdy*(e(3) - e(2))*(ONE + sign(ONE,e(2)))*alpha0u
-            azw1left = 0.25d0*dtdy*(e(3) - e(2))*(ONE + sign(ONE,e(2)))*alpha0w
+            azrleft = 0.25e0_rt*dtdy*(e(3) - e(2))*(ONE + sign(ONE,e(2)))*alpha0r
+            azeleft = 0.25e0_rt*dtdy*(e(3) - e(2))*(ONE + sign(ONE,e(2)))*alpha0e
+            azu1left = 0.25e0_rt*dtdy*(e(3) - e(2))*(ONE + sign(ONE,e(2)))*alpha0u
+            azw1left = 0.25e0_rt*dtdy*(e(3) - e(2))*(ONE + sign(ONE,e(2)))*alpha0w
 
             !apleft = HALF*(ONE - spplus )*alphap
             !amleft = HALF*(ONE - spminus)*alpham
@@ -433,6 +435,7 @@ contains
                                      npassive, qpass_map, small_dens, small_pres, ppm_type
       use bl_constants_module
 
+      use bl_fort_module, only : rt => c_real
       implicit none
 
       integer          :: qd_lo(3), qd_hi(3)
@@ -441,33 +444,33 @@ contains
       integer          :: ilo1,ilo2,ihi1,ihi2
       integer          :: km,kc,k3d
 
-      double precision ::    q(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),QVAR)
-      double precision ::    c(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3))
+      real(rt)         ::    q(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),QVAR)
+      real(rt)         ::    c(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3))
 
-      double precision :: dqz(dq_lo(1):dq_hi(1),dq_lo(2):dq_hi(2),dq_lo(3):dq_hi(3),QVAR)
-      double precision :: qzm(qpd_lo(1):qpd_hi(1),qpd_lo(2):qpd_hi(2),qpd_lo(3):qpd_hi(3),QVAR)
-      double precision :: qzp(qpd_lo(1):qpd_hi(1),qpd_lo(2):qpd_hi(2),qpd_lo(3):qpd_hi(3),QVAR)
-      double precision :: dx(3), dt
+      real(rt)         :: dqz(dq_lo(1):dq_hi(1),dq_lo(2):dq_hi(2),dq_lo(3):dq_hi(3),QVAR)
+      real(rt)         :: qzm(qpd_lo(1):qpd_hi(1),qpd_lo(2):qpd_hi(2),qpd_lo(3):qpd_hi(3),QVAR)
+      real(rt)         :: qzp(qpd_lo(1):qpd_hi(1),qpd_lo(2):qpd_hi(2),qpd_lo(3):qpd_hi(3),QVAR)
+      real(rt)         :: dx(3), dt
 
       ! Local variables
       integer i, j
       integer n, ipassive
 
-      double precision dtdz
-      double precision cc, csq, rho, u, v, w, p, rhoe
+      real(rt)         dtdz
+      real(rt)         cc, csq, rho, u, v, w, p, rhoe
 
-      double precision drho, du, dv, dw, dp, drhoe
-      double precision enth, alpham, alphap, alpha0r, alpha0e
-      double precision alpha0u, alpha0v
-      double precision spminus, spplus, spzero
-      double precision apright, amright, azrright, azeright
-      double precision azu1rght, azv1rght
-      double precision apleft, amleft, azrleft, azeleft
-      double precision azu1left, azv1left
-      double precision acmpbot, acmptop
+      real(rt)         drho, du, dv, dw, dp, drhoe
+      real(rt)         enth, alpham, alphap, alpha0r, alpha0e
+      real(rt)         alpha0u, alpha0v
+      real(rt)         spminus, spplus, spzero
+      real(rt)         apright, amright, azrright, azeright
+      real(rt)         azu1rght, azv1rght
+      real(rt)         apleft, amleft, azrleft, azeleft
+      real(rt)         azu1left, azv1left
+      real(rt)         acmpbot, acmptop
 
-      double precision rho_ref, u_ref, v_ref, w_ref, p_ref, rhoe_ref
-      double precision e(3)
+      real(rt)         rho_ref, u_ref, v_ref, w_ref, p_ref, rhoe_ref
+      real(rt)         e(3)
 
       if (ppm_type .ne. 0) then
         print *,'Oops -- shouldnt be in tracez with ppm_type != 0'
@@ -534,8 +537,8 @@ contains
             p_ref = p - HALF*(ONE + dtdz*min(e(1),ZERO))*dp
             rhoe_ref = rhoe - HALF*(ONE + dtdz*min(e(1),ZERO))*drhoe
 
-            apright = 0.25d0*dtdz*(e(1) - e(3))*(ONE - sign(ONE,e(3)))*alphap
-            amright = 0.25d0*dtdz*(e(1) - e(1))*(ONE - sign(ONE,e(1)))*alpham
+            apright = 0.25e0_rt*dtdz*(e(1) - e(3))*(ONE - sign(ONE,e(3)))*alphap
+            amright = 0.25e0_rt*dtdz*(e(1) - e(1))*(ONE - sign(ONE,e(1)))*alpham
 
             azrright = 0.25e0*dtdz*(e(1)-e(2))*(ONE - sign(ONE,e(2)))*alpha0r
             azeright = 0.25e0*dtdz*(e(1)-e(2))*(ONE - sign(ONE,e(2)))*alpha0e
@@ -610,13 +613,13 @@ contains
             p_ref = p + HALF*(ONE - dtdz*max(e(3),ZERO))*dp
             rhoe_ref = rhoe + HALF*(ONE - dtdz*max(e(3),ZERO))*drhoe
 
-            apleft = 0.25d0*dtdz*(e(3) - e(3))*(ONE + sign(ONE,e(3)))*alphap
-            amleft = 0.25d0*dtdz*(e(3) - e(1))*(ONE + sign(ONE,e(1)))*alpham
+            apleft = 0.25e0_rt*dtdz*(e(3) - e(3))*(ONE + sign(ONE,e(3)))*alphap
+            amleft = 0.25e0_rt*dtdz*(e(3) - e(1))*(ONE + sign(ONE,e(1)))*alpham
 
-            azrleft = 0.25d0*dtdz*(e(3) - e(2))*(ONE + sign(ONE,e(2)))*alpha0r
-            azeleft = 0.25d0*dtdz*(e(3) - e(2))*(ONE + sign(ONE,e(2)))*alpha0e
-            azu1left = 0.25d0*dtdz*(e(3) - e(2))*(ONE + sign(ONE,e(2)))*alpha0u
-            azv1left = 0.25d0*dtdz*(e(3) - e(2))*(ONE + sign(ONE,e(2)))*alpha0v
+            azrleft = 0.25e0_rt*dtdz*(e(3) - e(2))*(ONE + sign(ONE,e(2)))*alpha0r
+            azeleft = 0.25e0_rt*dtdz*(e(3) - e(2))*(ONE + sign(ONE,e(2)))*alpha0e
+            azu1left = 0.25e0_rt*dtdz*(e(3) - e(2))*(ONE + sign(ONE,e(2)))*alpha0u
+            azv1left = 0.25e0_rt*dtdz*(e(3) - e(2))*(ONE + sign(ONE,e(2)))*alpha0v
 
             !apleft = HALF*(ONE - spplus )*alphap
             !amleft = HALF*(ONE - spminus)*alpham

--- a/Source/Src_3d/trace_ppm_3d.f90
+++ b/Source/Src_3d/trace_ppm_3d.f90
@@ -3,6 +3,7 @@
 
 module trace_ppm_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   private
@@ -26,6 +27,7 @@ contains
          npassive, qpass_map
     use bl_constants_module
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer, intent(in) :: qd_lo(3), qd_hi(3)
@@ -35,33 +37,33 @@ contains
     integer, intent(in) :: ilo1, ilo2, ihi1, ihi2
     integer, intent(in) :: kc, k3d
 
-    double precision, intent(in) ::     q(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),QVAR)
-    double precision, intent(in) ::     c(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3))
-    double precision, intent(in) :: flatn(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3))
+    real(rt)        , intent(in) ::     q(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),QVAR)
+    real(rt)        , intent(in) ::     c(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3))
+    real(rt)        , intent(in) :: flatn(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3))
 
-    double precision, intent(in) :: Ip(I_lo(1):I_hi(1),I_lo(2):I_hi(2),I_lo(3):I_hi(3),1:3,1:3,QVAR)
-    double precision, intent(in) :: Im(I_lo(1):I_hi(1),I_lo(2):I_hi(2),I_lo(3):I_hi(3),1:3,1:3,QVAR)
+    real(rt)        , intent(in) :: Ip(I_lo(1):I_hi(1),I_lo(2):I_hi(2),I_lo(3):I_hi(3),1:3,1:3,QVAR)
+    real(rt)        , intent(in) :: Im(I_lo(1):I_hi(1),I_lo(2):I_hi(2),I_lo(3):I_hi(3),1:3,1:3,QVAR)
 
-    double precision, intent(in) :: Ip_src(I_lo(1):I_hi(1),I_lo(2):I_hi(2),I_lo(3):I_hi(3),1:3,1:3,QVAR)
-    double precision, intent(in) :: Im_src(I_lo(1):I_hi(1),I_lo(2):I_hi(2),I_lo(3):I_hi(3),1:3,1:3,QVAR)
+    real(rt)        , intent(in) :: Ip_src(I_lo(1):I_hi(1),I_lo(2):I_hi(2),I_lo(3):I_hi(3),1:3,1:3,QVAR)
+    real(rt)        , intent(in) :: Im_src(I_lo(1):I_hi(1),I_lo(2):I_hi(2),I_lo(3):I_hi(3),1:3,1:3,QVAR)
 
-    double precision, intent(in) :: Ip_gc(I_lo(1):I_hi(1),I_lo(2):I_hi(2),I_lo(3):I_hi(3),1:3,1:3,1)
-    double precision, intent(in) :: Im_gc(I_lo(1):I_hi(1),I_lo(2):I_hi(2),I_lo(3):I_hi(3),1:3,1:3,1)
+    real(rt)        , intent(in) :: Ip_gc(I_lo(1):I_hi(1),I_lo(2):I_hi(2),I_lo(3):I_hi(3),1:3,1:3,1)
+    real(rt)        , intent(in) :: Im_gc(I_lo(1):I_hi(1),I_lo(2):I_hi(2),I_lo(3):I_hi(3),1:3,1:3,1)
 
-    double precision, intent(inout) :: qxm(qs_lo(1):qs_hi(1),qs_lo(2):qs_hi(2),qs_lo(3):qs_hi(3),QVAR)
-    double precision, intent(inout) :: qxp(qs_lo(1):qs_hi(1),qs_lo(2):qs_hi(2),qs_lo(3):qs_hi(3),QVAR)
-    double precision, intent(inout) :: qym(qs_lo(1):qs_hi(1),qs_lo(2):qs_hi(2),qs_lo(3):qs_hi(3),QVAR)
-    double precision, intent(inout) :: qyp(qs_lo(1):qs_hi(1),qs_lo(2):qs_hi(2),qs_lo(3):qs_hi(3),QVAR)
+    real(rt)        , intent(inout) :: qxm(qs_lo(1):qs_hi(1),qs_lo(2):qs_hi(2),qs_lo(3):qs_hi(3),QVAR)
+    real(rt)        , intent(inout) :: qxp(qs_lo(1):qs_hi(1),qs_lo(2):qs_hi(2),qs_lo(3):qs_hi(3),QVAR)
+    real(rt)        , intent(inout) :: qym(qs_lo(1):qs_hi(1),qs_lo(2):qs_hi(2),qs_lo(3):qs_hi(3),QVAR)
+    real(rt)        , intent(inout) :: qyp(qs_lo(1):qs_hi(1),qs_lo(2):qs_hi(2),qs_lo(3):qs_hi(3),QVAR)
 
-    double precision, intent(in) :: gamc(gc_lo(1):gc_hi(1),gc_lo(2):gc_hi(2),gc_lo(3):gc_hi(3))
+    real(rt)        , intent(in) :: gamc(gc_lo(1):gc_hi(1),gc_lo(2):gc_hi(2),gc_lo(3):gc_hi(3))
 
-    double precision, intent(in) :: dt
+    real(rt)        , intent(in) :: dt
 
     ! Local variables
     integer :: i, j
     integer :: n, ipassive
 
-    double precision :: hdt
+    real(rt)         :: hdt
 
     ! To allow for easy integration of radiation, we adopt the
     ! following conventions:
@@ -81,24 +83,24 @@ contains
     ! for pure hydro, we will only consider:
     !   rho, u, v, w, ptot, rhoe_g, cc, h_g
 
-    double precision :: cc, csq, cgassq, Clag
-    double precision :: rho, u, v, w, p, rhoe_g, h_g
-    double precision :: gam_g, game
+    real(rt)         :: cc, csq, cgassq, Clag
+    real(rt)         :: rho, u, v, w, p, rhoe_g, h_g
+    real(rt)         :: gam_g, game
 
-    double precision :: drho, dptot, drhoe_g
-    double precision :: de, dge, dtau
-    double precision :: dup, dvp, dptotp
-    double precision :: dum, dvm, dptotm
+    real(rt)         :: drho, dptot, drhoe_g
+    real(rt)         :: de, dge, dtau
+    real(rt)         :: dup, dvp, dptotp
+    real(rt)         :: dum, dvm, dptotm
 
-    double precision :: rho_ref, u_ref, v_ref, p_ref, rhoe_g_ref, h_g_ref
-    double precision :: tau_ref
+    real(rt)         :: rho_ref, u_ref, v_ref, p_ref, rhoe_g_ref, h_g_ref
+    real(rt)         :: tau_ref
 
-    double precision :: cc_ref, csq_ref, Clag_ref, gam_g_ref, game_ref, gfactor
-    double precision :: cc_ev, csq_ev, Clag_ev, rho_ev, p_ev, h_g_ev, tau_ev
+    real(rt)         :: cc_ref, csq_ref, Clag_ref, gam_g_ref, game_ref, gfactor
+    real(rt)         :: cc_ev, csq_ev, Clag_ev, rho_ev, p_ev, h_g_ev, tau_ev
 
-    double precision :: alpham, alphap, alpha0r, alpha0e_g
+    real(rt)         :: alpham, alphap, alpha0r, alpha0e_g
 
-    double precision :: tau_s, e_s
+    real(rt)         :: tau_s, e_s
 
     if (ppm_type == 0) then
        print *,'Oops -- shouldnt be in tracexy_ppm with ppm_type = 0'
@@ -973,6 +975,7 @@ contains
          npassive, qpass_map
     use bl_constants_module
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer, intent(in) :: qd_lo(3), qd_hi(3)
@@ -982,31 +985,31 @@ contains
     integer, intent(in) :: ilo1, ilo2, ihi1, ihi2
     integer, intent(in) :: km, kc, k3d
 
-    double precision, intent(in) ::     q(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),QVAR)
-    double precision, intent(in) ::     c(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3))
-    double precision, intent(in) :: flatn(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3))
+    real(rt)        , intent(in) ::     q(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),QVAR)
+    real(rt)        , intent(in) ::     c(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3))
+    real(rt)        , intent(in) :: flatn(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3))
 
-    double precision, intent(in) :: Ip(I_lo(1):I_hi(1),I_lo(2):I_hi(2),I_lo(3):I_hi(3),1:3,1:3,QVAR)
-    double precision, intent(in) :: Im(I_lo(1):I_hi(1),I_lo(2):I_hi(2),I_lo(3):I_hi(3),1:3,1:3,QVAR)
+    real(rt)        , intent(in) :: Ip(I_lo(1):I_hi(1),I_lo(2):I_hi(2),I_lo(3):I_hi(3),1:3,1:3,QVAR)
+    real(rt)        , intent(in) :: Im(I_lo(1):I_hi(1),I_lo(2):I_hi(2),I_lo(3):I_hi(3),1:3,1:3,QVAR)
 
-    double precision, intent(in) :: Ip_src(I_lo(1):I_hi(1),I_lo(2):I_hi(2),I_lo(3):I_hi(3),1:3,1:3,QVAR)
-    double precision, intent(in) :: Im_src(I_lo(1):I_hi(1),I_lo(2):I_hi(2),I_lo(3):I_hi(3),1:3,1:3,QVAR)
+    real(rt)        , intent(in) :: Ip_src(I_lo(1):I_hi(1),I_lo(2):I_hi(2),I_lo(3):I_hi(3),1:3,1:3,QVAR)
+    real(rt)        , intent(in) :: Im_src(I_lo(1):I_hi(1),I_lo(2):I_hi(2),I_lo(3):I_hi(3),1:3,1:3,QVAR)
 
-    double precision, intent(in) :: Ip_gc(I_lo(1):I_hi(1),I_lo(2):I_hi(2),I_lo(3):I_hi(3),1:3,1:3,1)
-    double precision, intent(in) :: Im_gc(I_lo(1):I_hi(1),I_lo(2):I_hi(2),I_lo(3):I_hi(3),1:3,1:3,1)
+    real(rt)        , intent(in) :: Ip_gc(I_lo(1):I_hi(1),I_lo(2):I_hi(2),I_lo(3):I_hi(3),1:3,1:3,1)
+    real(rt)        , intent(in) :: Im_gc(I_lo(1):I_hi(1),I_lo(2):I_hi(2),I_lo(3):I_hi(3),1:3,1:3,1)
 
-    double precision, intent(inout) :: qzm(qs_lo(1):qs_hi(1),qs_lo(2):qs_hi(2),qs_lo(3):qs_hi(3),QVAR)
-    double precision, intent(inout) :: qzp(qs_lo(1):qs_hi(1),qs_lo(2):qs_hi(2),qs_lo(3):qs_hi(3),QVAR)
+    real(rt)        , intent(inout) :: qzm(qs_lo(1):qs_hi(1),qs_lo(2):qs_hi(2),qs_lo(3):qs_hi(3),QVAR)
+    real(rt)        , intent(inout) :: qzp(qs_lo(1):qs_hi(1),qs_lo(2):qs_hi(2),qs_lo(3):qs_hi(3),QVAR)
 
-    double precision, intent(in) :: gamc(gc_lo(1):gc_hi(1),gc_lo(2):gc_hi(2),gc_lo(3):gc_hi(3))
+    real(rt)        , intent(in) :: gamc(gc_lo(1):gc_hi(1),gc_lo(2):gc_hi(2),gc_lo(3):gc_hi(3))
 
-    double precision, intent(in) :: dt
+    real(rt)        , intent(in) :: dt
 
     !     Local variables
     integer :: i, j
     integer :: n, ipassive
 
-    double precision :: hdt
+    real(rt)         :: hdt
 
     ! To allow for easy integration of radiation, we adopt the
     ! following conventions:
@@ -1026,24 +1029,24 @@ contains
     ! for pure hydro, we will only consider:
     !   rho, u, v, w, ptot, rhoe_g, cc, h_g
 
-    double precision :: cc, csq, cgassq, Clag
-    double precision :: rho, u, v, w, p, rhoe_g, h_g
-    double precision :: gam_g, game
+    real(rt)         :: cc, csq, cgassq, Clag
+    real(rt)         :: rho, u, v, w, p, rhoe_g, h_g
+    real(rt)         :: gam_g, game
 
-    double precision :: drho, dptot, drhoe_g
-    double precision :: de, dge, dtau
-    double precision :: dwp, dptotp
-    double precision :: dwm, dptotm
+    real(rt)         :: drho, dptot, drhoe_g
+    real(rt)         :: de, dge, dtau
+    real(rt)         :: dwp, dptotp
+    real(rt)         :: dwm, dptotm
 
-    double precision :: rho_ref, w_ref, p_ref, rhoe_g_ref, h_g_ref
-    double precision :: tau_ref
+    real(rt)         :: rho_ref, w_ref, p_ref, rhoe_g_ref, h_g_ref
+    real(rt)         :: tau_ref
 
-    double precision :: cc_ref, csq_ref, Clag_ref, gam_g_ref, game_ref, gfactor
-    double precision :: cc_ev, csq_ev, Clag_ev, rho_ev, p_ev, h_g_ev, tau_ev
+    real(rt)         :: cc_ref, csq_ref, Clag_ref, gam_g_ref, game_ref, gfactor
+    real(rt)         :: cc_ev, csq_ev, Clag_ev, rho_ev, p_ev, h_g_ev, tau_ev
 
-    double precision :: alpham, alphap, alpha0r, alpha0e_g
+    real(rt)         :: alpham, alphap, alpha0r, alpha0e_g
 
-    double precision :: tau_s, e_s
+    real(rt)         :: tau_s, e_s
 
     hdt = HALF * dt
 

--- a/Source/Src_3d/trans_3d.F90
+++ b/Source/Src_3d/trans_3d.F90
@@ -25,6 +25,7 @@ module transverse_module
 
   use eos_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   private
@@ -34,9 +35,10 @@ contains
 
   subroutine reset_edge_state_thermo(qedge, qd_lo, qd_hi, ii, jj, kk)
 
+    use bl_fort_module, only : rt => c_real
     integer, intent(in) :: ii, jj, kk
     integer, intent(in) :: qd_lo(3), qd_hi(3)
-    double precision, intent(inout) :: qedge(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),QVAR)
+    real(rt)        , intent(inout) :: qedge(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),QVAR)
 
     logical :: reset
     type (eos_t) :: eos_state
@@ -106,6 +108,7 @@ contains
     ! Note that what we call jlo here is jlo = lo(2) - 1
     ! Note that what we call jhi here is jhi = hi(2) + 1
 
+    use bl_fort_module, only : rt => c_real
     integer :: qd_lo(3),qd_hi(3)
     integer :: qa_lo(3),qa_hi(3)
     integer :: fx_lo(3),fx_hi(3)
@@ -113,46 +116,46 @@ contains
     integer ilo,ihi,jlo,jhi,kc,k3d
 
 #ifdef RADIATION
-    double precision rfx(fx_lo(1):fx_hi(1),fx_lo(2):fx_hi(2),fx_lo(3):fx_hi(3),0:ngroups-1)
+    real(rt)         rfx(fx_lo(1):fx_hi(1),fx_lo(2):fx_hi(2),fx_lo(3):fx_hi(3),0:ngroups-1)
 #endif
 
-    double precision  qym(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),NQ)
-    double precision  qyp(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),NQ)
-    double precision qymo(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),NQ)
-    double precision qypo(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),NQ)
+    real(rt)          qym(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),NQ)
+    real(rt)          qyp(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),NQ)
+    real(rt)         qymo(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),NQ)
+    real(rt)         qypo(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),NQ)
 
-    double precision qaux(qa_lo(1):qa_hi(1),qa_lo(2):qa_hi(2),qa_lo(3):qa_hi(3),NQAUX)
-    double precision fx(fx_lo(1):fx_hi(1),fx_lo(2):fx_hi(2),fx_lo(3):fx_hi(3),NVAR)
-    double precision qx(qx_lo(1):qx_hi(1),qx_lo(2):qx_hi(2),qx_lo(3):qx_hi(3),NGDNV)
-    double precision cdtdx
+    real(rt)         qaux(qa_lo(1):qa_hi(1),qa_lo(2):qa_hi(2),qa_lo(3):qa_hi(3),NQAUX)
+    real(rt)         fx(fx_lo(1):fx_hi(1),fx_lo(2):fx_hi(2),fx_lo(3):fx_hi(3),NVAR)
+    real(rt)         qx(qx_lo(1):qx_hi(1),qx_lo(2):qx_hi(2),qx_lo(3):qx_hi(3),NGDNV)
+    real(rt)         cdtdx
 
     integer i, j, n, nqp, ipassive
 
-    double precision rhoinv
-    double precision rrnew, rr
-    double precision rrry, rrly
-    double precision rury, ruly
-    double precision rvry, rvly
-    double precision rwry, rwly
-    double precision ekenry, ekenly
-    double precision rery, rely
-    double precision rrnewry, rrnewly
-    double precision runewry, runewly
-    double precision rvnewry, rvnewly
-    double precision rwnewry, rwnewly
-    double precision renewry, renewly
-    double precision pnewry, pnewly
-    double precision rhoekenry, rhoekenly
-    double precision compn, compu
-    double precision pggp, pggm, ugp, ugm, gegp, gegm, dup, pav, du, dge, uav, geav
+    real(rt)         rhoinv
+    real(rt)         rrnew, rr
+    real(rt)         rrry, rrly
+    real(rt)         rury, ruly
+    real(rt)         rvry, rvly
+    real(rt)         rwry, rwly
+    real(rt)         ekenry, ekenly
+    real(rt)         rery, rely
+    real(rt)         rrnewry, rrnewly
+    real(rt)         runewry, runewly
+    real(rt)         rvnewry, rvnewly
+    real(rt)         rwnewry, rwnewly
+    real(rt)         renewry, renewly
+    real(rt)         pnewry, pnewly
+    real(rt)         rhoekenry, rhoekenly
+    real(rt)         compn, compu
+    real(rt)         pggp, pggm, ugp, ugm, gegp, gegm, dup, pav, du, dge, uav, geav
 
-    double precision :: gamc
+    real(rt)         :: gamc
 
 #ifdef RADIATION
-    double precision :: dre, dmom
-    double precision, dimension(0:ngroups-1) :: lambda, ergp, ergm, err, erl, ernewr, ernewl, &
+    real(rt)         :: dre, dmom
+    real(rt)        , dimension(0:ngroups-1) :: lambda, ergp, ergm, err, erl, ernewr, ernewl, &
          lamge, luge, der
-    double precision eddf, f1, ugc
+    real(rt)         eddf, f1, ugc
     integer :: g
 #endif
 
@@ -462,6 +465,7 @@ contains
                      qx, qx_lo, qx_hi, &
                      cdtdx, ilo, ihi, jlo, jhi, kc, km, k3d)
 
+    use bl_fort_module, only : rt => c_real
     integer :: qd_lo(3),qd_hi(3)
     integer :: qa_lo(3),qa_hi(3)
     integer :: fx_lo(3),fx_hi(3)
@@ -469,45 +473,45 @@ contains
     integer ilo,ihi,jlo,jhi,kc,km,k3d
 
 #ifdef RADIATION
-    double precision rfx(fx_lo(1):fx_hi(1),fx_lo(2):fx_hi(2),fx_lo(3):fx_hi(3),0:ngroups-1)
+    real(rt)         rfx(fx_lo(1):fx_hi(1),fx_lo(2):fx_hi(2),fx_lo(3):fx_hi(3),0:ngroups-1)
 #endif
 
-    double precision  qzm(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),NQ)
-    double precision  qzp(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),NQ)
-    double precision qzmo(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),NQ)
-    double precision qzpo(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),NQ)
+    real(rt)          qzm(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),NQ)
+    real(rt)          qzp(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),NQ)
+    real(rt)         qzmo(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),NQ)
+    real(rt)         qzpo(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),NQ)
 
-    double precision qaux(qa_lo(1):qa_hi(1),qa_lo(2):qa_hi(2),qa_lo(3):qa_hi(3),NQAUX)
-    double precision fx(fx_lo(1):fx_hi(1),fx_lo(2):fx_hi(2),fx_lo(3):fx_hi(3),NVAR)
-    double precision qx(qx_lo(1):qx_hi(1),qx_lo(2):qx_hi(2),qx_lo(3):qx_hi(3),NGDNV)
-    double precision cdtdx
+    real(rt)         qaux(qa_lo(1):qa_hi(1),qa_lo(2):qa_hi(2),qa_lo(3):qa_hi(3),NQAUX)
+    real(rt)         fx(fx_lo(1):fx_hi(1),fx_lo(2):fx_hi(2),fx_lo(3):fx_hi(3),NVAR)
+    real(rt)         qx(qx_lo(1):qx_hi(1),qx_lo(2):qx_hi(2),qx_lo(3):qx_hi(3),NGDNV)
+    real(rt)         cdtdx
 
     integer i, j, n, nqp, ipassive
 
-    double precision rhoinv
-    double precision rrnew, rr
-    double precision rrrz, rrlz
-    double precision rurz, rulz
-    double precision rvrz, rvlz
-    double precision rwrz, rwlz
-    double precision ekenrz, ekenlz
-    double precision rerz, relz
-    double precision rrnewrz, rrnewlz
-    double precision runewrz, runewlz
-    double precision rvnewrz, rvnewlz
-    double precision rwnewrz, rwnewlz
-    double precision renewrz, renewlz
-    double precision pnewrz, pnewlz
-    double precision rhoekenrz, rhoekenlz
-    double precision compn, compu
-    double precision pggp, pggm, ugp, ugm, gegp, gegm, dup, pav, du, dge, uav, geav
-    double precision :: gamc
+    real(rt)         rhoinv
+    real(rt)         rrnew, rr
+    real(rt)         rrrz, rrlz
+    real(rt)         rurz, rulz
+    real(rt)         rvrz, rvlz
+    real(rt)         rwrz, rwlz
+    real(rt)         ekenrz, ekenlz
+    real(rt)         rerz, relz
+    real(rt)         rrnewrz, rrnewlz
+    real(rt)         runewrz, runewlz
+    real(rt)         rvnewrz, rvnewlz
+    real(rt)         rwnewrz, rwnewlz
+    real(rt)         renewrz, renewlz
+    real(rt)         pnewrz, pnewlz
+    real(rt)         rhoekenrz, rhoekenlz
+    real(rt)         compn, compu
+    real(rt)         pggp, pggm, ugp, ugm, gegp, gegm, dup, pav, du, dge, uav, geav
+    real(rt)         :: gamc
 
 #ifdef RADIATION
-    double precision :: dre, dmom
-    double precision, dimension(0:ngroups-1) :: lambda, ergp, ergm, err, erl, ernewr, ernewl, &
+    real(rt)         :: dre, dmom
+    real(rt)        , dimension(0:ngroups-1) :: lambda, ergp, ergm, err, erl, ernewr, ernewl, &
          lamge, luge, der
-    double precision eddf, f1, ugc
+    real(rt)         eddf, f1, ugc
     integer :: g
 #endif
 
@@ -861,6 +865,7 @@ contains
                      qy, qy_lo, qy_hi, &
                      cdtdy, ilo, ihi, jlo, jhi, kc, k3d)
 
+    use bl_fort_module, only : rt => c_real
     integer :: qd_lo(3),qd_hi(3)
     integer :: qa_lo(3),qa_hi(3)
     integer :: fy_lo(3),fy_hi(3)
@@ -868,46 +873,46 @@ contains
     integer ilo,ihi,jlo,jhi,kc,k3d
 
 #ifdef RADIATION
-    double precision rfy(fy_lo(1):fy_hi(1),fy_lo(2):fy_hi(2),fy_lo(3):fy_hi(3),0:ngroups-1)
+    real(rt)         rfy(fy_lo(1):fy_hi(1),fy_lo(2):fy_hi(2),fy_lo(3):fy_hi(3),0:ngroups-1)
 #endif
 
-    double precision  qxm(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),NQ)
-    double precision  qxp(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),NQ)
-    double precision qxmo(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),NQ)
-    double precision qxpo(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),NQ)
+    real(rt)          qxm(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),NQ)
+    real(rt)          qxp(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),NQ)
+    real(rt)         qxmo(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),NQ)
+    real(rt)         qxpo(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),NQ)
 
-    double precision qaux(qa_lo(1):qa_hi(1),qa_lo(2):qa_hi(2),qa_lo(3):qa_hi(3),NQAUX)
+    real(rt)         qaux(qa_lo(1):qa_hi(1),qa_lo(2):qa_hi(2),qa_lo(3):qa_hi(3),NQAUX)
 
-    double precision fy(fy_lo(1):fy_hi(1),fy_lo(2):fy_hi(2),fy_lo(3):fy_hi(3),NVAR)
-    double precision qy(qy_lo(1):qy_hi(1),qy_lo(2):qy_hi(2),qy_lo(3):qy_hi(3),NGDNV)
-    double precision cdtdy
+    real(rt)         fy(fy_lo(1):fy_hi(1),fy_lo(2):fy_hi(2),fy_lo(3):fy_hi(3),NVAR)
+    real(rt)         qy(qy_lo(1):qy_hi(1),qy_lo(2):qy_hi(2),qy_lo(3):qy_hi(3),NGDNV)
+    real(rt)         cdtdy
 
     integer i, j, n, nqp, ipassive
 
-    double precision rhoinv
-    double precision rrnew, rr
-    double precision compn, compu
-    double precision rrrx, rrlx
-    double precision rurx, rulx
-    double precision rvrx, rvlx
-    double precision rwrx, rwlx
-    double precision ekenrx, ekenlx
-    double precision rerx, relx
-    double precision rrnewrx, rrnewlx
-    double precision runewrx, runewlx
-    double precision rvnewrx, rvnewlx
-    double precision rwnewrx, rwnewlx
-    double precision renewrx, renewlx
-    double precision pnewrx, pnewlx
-    double precision rhoekenrx, rhoekenlx
-    double precision pggp, pggm, ugp, ugm, gegp, gegm, dup, pav, du, dge, uav, geav
-    double precision :: gamc
+    real(rt)         rhoinv
+    real(rt)         rrnew, rr
+    real(rt)         compn, compu
+    real(rt)         rrrx, rrlx
+    real(rt)         rurx, rulx
+    real(rt)         rvrx, rvlx
+    real(rt)         rwrx, rwlx
+    real(rt)         ekenrx, ekenlx
+    real(rt)         rerx, relx
+    real(rt)         rrnewrx, rrnewlx
+    real(rt)         runewrx, runewlx
+    real(rt)         rvnewrx, rvnewlx
+    real(rt)         rwnewrx, rwnewlx
+    real(rt)         renewrx, renewlx
+    real(rt)         pnewrx, pnewlx
+    real(rt)         rhoekenrx, rhoekenlx
+    real(rt)         pggp, pggm, ugp, ugm, gegp, gegm, dup, pav, du, dge, uav, geav
+    real(rt)         :: gamc
 
 #ifdef RADIATION
-    double precision :: dre, dmom
-    double precision, dimension(0:ngroups-1) :: lambda, ergp, ergm, err, erl, ernewr, ernewl, &
+    real(rt)         :: dre, dmom
+    real(rt)        , dimension(0:ngroups-1) :: lambda, ergp, ergm, err, erl, ernewr, ernewl, &
          lamge, luge, der
-    double precision eddf, f1, ugc
+    real(rt)         eddf, f1, ugc
     integer :: g
 #endif
 
@@ -1213,6 +1218,7 @@ contains
                      qy, qy_lo, qy_hi, &
                      cdtdy, ilo, ihi, jlo, jhi, kc, km, k3d)
 
+    use bl_fort_module, only : rt => c_real
     integer :: qd_lo(3),qd_hi(3)
     integer :: qa_lo(3),qa_hi(3)
     integer :: fy_lo(3),fy_hi(3)
@@ -1220,46 +1226,46 @@ contains
     integer ilo,ihi,jlo,jhi,kc,km,k3d
 
 #ifdef RADIATION
-    double precision rfy(fy_lo(1):fy_hi(1),fy_lo(2):fy_hi(2),fy_lo(3):fy_hi(3),0:ngroups-1)
+    real(rt)         rfy(fy_lo(1):fy_hi(1),fy_lo(2):fy_hi(2),fy_lo(3):fy_hi(3),0:ngroups-1)
 #endif
 
-    double precision  qzm(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),NQ)
-    double precision  qzp(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),NQ)
-    double precision qzmo(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),NQ)
-    double precision qzpo(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),NQ)
+    real(rt)          qzm(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),NQ)
+    real(rt)          qzp(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),NQ)
+    real(rt)         qzmo(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),NQ)
+    real(rt)         qzpo(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),NQ)
 
-    double precision qaux(qa_lo(1):qa_hi(1),qa_lo(2):qa_hi(2),qa_lo(3):qa_hi(3),NQAUX)
+    real(rt)         qaux(qa_lo(1):qa_hi(1),qa_lo(2):qa_hi(2),qa_lo(3):qa_hi(3),NQAUX)
 
-    double precision fy(fy_lo(1):fy_hi(1),fy_lo(2):fy_hi(2),fy_lo(3):fy_hi(3),NVAR)
-    double precision qy(qy_lo(1):qy_hi(1),qy_lo(2):qy_hi(2),qy_lo(3):qy_hi(3),NGDNV)
-    double precision cdtdy
+    real(rt)         fy(fy_lo(1):fy_hi(1),fy_lo(2):fy_hi(2),fy_lo(3):fy_hi(3),NVAR)
+    real(rt)         qy(qy_lo(1):qy_hi(1),qy_lo(2):qy_hi(2),qy_lo(3):qy_hi(3),NGDNV)
+    real(rt)         cdtdy
 
     integer i, j, n, nqp, ipassive
 
-    double precision rhoinv
-    double precision rrnew, rr
-    double precision compn, compu
-    double precision rrrz, rrlz
-    double precision rurz, rulz
-    double precision rvrz, rvlz
-    double precision rwrz, rwlz
-    double precision ekenrz, ekenlz
-    double precision rerz, relz
-    double precision rrnewrz, rrnewlz
-    double precision runewrz, runewlz
-    double precision rvnewrz, rvnewlz
-    double precision rwnewrz, rwnewlz
-    double precision renewrz, renewlz
-    double precision pnewrz, pnewlz
-    double precision rhoekenrz, rhoekenlz
-    double precision pggp, pggm, ugp, ugm, gegp, gegm, dup, pav, du, dge, uav, geav
-    double precision :: gamc
+    real(rt)         rhoinv
+    real(rt)         rrnew, rr
+    real(rt)         compn, compu
+    real(rt)         rrrz, rrlz
+    real(rt)         rurz, rulz
+    real(rt)         rvrz, rvlz
+    real(rt)         rwrz, rwlz
+    real(rt)         ekenrz, ekenlz
+    real(rt)         rerz, relz
+    real(rt)         rrnewrz, rrnewlz
+    real(rt)         runewrz, runewlz
+    real(rt)         rvnewrz, rvnewlz
+    real(rt)         rwnewrz, rwnewlz
+    real(rt)         renewrz, renewlz
+    real(rt)         pnewrz, pnewlz
+    real(rt)         rhoekenrz, rhoekenlz
+    real(rt)         pggp, pggm, ugp, ugm, gegp, gegm, dup, pav, du, dge, uav, geav
+    real(rt)         :: gamc
 
 #ifdef RADIATION
-    double precision :: dre, dmom
-    double precision, dimension(0:ngroups-1) :: lambda, ergp, ergm, err, erl, ernewr, ernewl, &
+    real(rt)         :: dre, dmom
+    real(rt)        , dimension(0:ngroups-1) :: lambda, ergp, ergm, err, erl, ernewr, ernewl, &
          lamge, luge, der
-    double precision eddf, f1, ugc
+    real(rt)         eddf, f1, ugc
     integer :: g
 #endif
 
@@ -1611,6 +1617,7 @@ contains
                     qz,qz_lo,qz_hi, &
                     cdtdz,ilo,ihi,jlo,jhi,km,kc,k3d)
 
+    use bl_fort_module, only : rt => c_real
     integer :: qd_lo(3),qd_hi(3)
     integer :: qa_lo(3),qa_hi(3)
     integer :: fz_lo(3),fz_hi(3)
@@ -1618,49 +1625,49 @@ contains
     integer ilo,ihi,jlo,jhi,km,kc,k3d
 
 #ifdef RADIATION
-    double precision rfz(fz_lo(1):fz_hi(1),fz_lo(2):fz_hi(2),fz_lo(3):fz_hi(3),0:ngroups-1)
+    real(rt)         rfz(fz_lo(1):fz_hi(1),fz_lo(2):fz_hi(2),fz_lo(3):fz_hi(3),0:ngroups-1)
 #endif
 
-    double precision  qxm(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),NQ)
-    double precision  qxp(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),NQ)
-    double precision  qym(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),NQ)
-    double precision  qyp(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),NQ)
-    double precision qxmo(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),NQ)
-    double precision qxpo(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),NQ)
-    double precision qymo(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),NQ)
-    double precision qypo(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),NQ)
+    real(rt)          qxm(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),NQ)
+    real(rt)          qxp(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),NQ)
+    real(rt)          qym(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),NQ)
+    real(rt)          qyp(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),NQ)
+    real(rt)         qxmo(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),NQ)
+    real(rt)         qxpo(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),NQ)
+    real(rt)         qymo(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),NQ)
+    real(rt)         qypo(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),NQ)
 
-    double precision qaux(qa_lo(1):qa_hi(1),qa_lo(2):qa_hi(2),qa_lo(3):qa_hi(3),NQAUX)
+    real(rt)         qaux(qa_lo(1):qa_hi(1),qa_lo(2):qa_hi(2),qa_lo(3):qa_hi(3),NQAUX)
 
-    double precision fz(fz_lo(1):fz_hi(1),fz_lo(2):fz_hi(2),fz_lo(3):fz_hi(3),NVAR)
-    double precision qz(qz_lo(1):qz_hi(1),qz_lo(2):qz_hi(2),qz_lo(3):qz_hi(3),NGDNV)
-    double precision cdtdz
+    real(rt)         fz(fz_lo(1):fz_hi(1),fz_lo(2):fz_hi(2),fz_lo(3):fz_hi(3),NVAR)
+    real(rt)         qz(qz_lo(1):qz_hi(1),qz_lo(2):qz_hi(2),qz_lo(3):qz_hi(3),NGDNV)
+    real(rt)         cdtdz
 
     integer n, nqp, i, j, ipassive
 
-    double precision rrnew, rr
-    double precision compn, compu
-    double precision rrrx, rrry, rrlx, rrly
-    double precision rurx, rury, rulx, ruly
-    double precision rvrx, rvry, rvlx, rvly
-    double precision rwrx, rwry, rwlx, rwly
-    double precision ekenrx, ekenry, ekenlx, ekenly
-    double precision rerx, rery, relx, rely
-    double precision rrnewrx, rrnewry, rrnewlx, rrnewly
-    double precision runewrx, runewry, runewlx, runewly
-    double precision rvnewrx, rvnewry, rvnewlx, rvnewly
-    double precision rwnewrx, rwnewry, rwnewlx, rwnewly
-    double precision renewrx, renewry, renewlx, renewly
-    double precision pnewrx, pnewry, pnewlx, pnewly
-    double precision rhoekenrx, rhoekenry, rhoekenlx, rhoekenly
-    double precision pggp, pggm, ugp, ugm, gegp, gegm, dup, pav, du, dge, uav, geav
-    double precision :: gamc
+    real(rt)         rrnew, rr
+    real(rt)         compn, compu
+    real(rt)         rrrx, rrry, rrlx, rrly
+    real(rt)         rurx, rury, rulx, ruly
+    real(rt)         rvrx, rvry, rvlx, rvly
+    real(rt)         rwrx, rwry, rwlx, rwly
+    real(rt)         ekenrx, ekenry, ekenlx, ekenly
+    real(rt)         rerx, rery, relx, rely
+    real(rt)         rrnewrx, rrnewry, rrnewlx, rrnewly
+    real(rt)         runewrx, runewry, runewlx, runewly
+    real(rt)         rvnewrx, rvnewry, rvnewlx, rvnewly
+    real(rt)         rwnewrx, rwnewry, rwnewlx, rwnewly
+    real(rt)         renewrx, renewry, renewlx, renewly
+    real(rt)         pnewrx, pnewry, pnewlx, pnewly
+    real(rt)         rhoekenrx, rhoekenry, rhoekenlx, rhoekenly
+    real(rt)         pggp, pggm, ugp, ugm, gegp, gegm, dup, pav, du, dge, uav, geav
+    real(rt)         :: gamc
 
 #ifdef RADIATION
-    double precision :: dmz, dre
-    double precision, dimension(0:ngroups-1) :: der, lambda, luge, lamge, &
+    real(rt)         :: dmz, dre
+    real(rt)        , dimension(0:ngroups-1) :: der, lambda, luge, lamge, &
          ergp, errx, ernewrx, erry, ernewry, ergm, erlx, ernewlx, erly, ernewly
-    double precision eddf, f1
+    real(rt)         eddf, f1
     integer :: g
 #endif
 
@@ -2164,6 +2171,7 @@ contains
                      srcQ,src_lo,src_hi, &
                      hdt,cdtdx,cdtdy,ilo,ihi,jlo,jhi,kc,km,k3d)
 
+    use bl_fort_module, only : rt => c_real
     integer :: qd_lo(3),qd_hi(3)
     integer :: qa_lo(3),qa_hi(3)
     integer :: fx_lo(3),fx_hi(3)
@@ -2174,44 +2182,44 @@ contains
     integer ilo,ihi,jlo,jhi,km,kc,k3d
 
 #ifdef RADIATION
-    double precision rfxy(fx_lo(1):fx_hi(1),fx_lo(2):fx_hi(2),fx_lo(3):fx_hi(3),0:ngroups-1)
-    double precision rfyx(fy_lo(1):fy_hi(1),fy_lo(2):fy_hi(2),fy_lo(3):fy_hi(3),0:ngroups-1)
+    real(rt)         rfxy(fx_lo(1):fx_hi(1),fx_lo(2):fx_hi(2),fx_lo(3):fx_hi(3),0:ngroups-1)
+    real(rt)         rfyx(fy_lo(1):fy_hi(1),fy_lo(2):fy_hi(2),fy_lo(3):fy_hi(3),0:ngroups-1)
 #endif
 
-    double precision  qm(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),NQ)
-    double precision qmo(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),NQ)
-    double precision  qp(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),NQ)
-    double precision qpo(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),NQ)
+    real(rt)          qm(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),NQ)
+    real(rt)         qmo(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),NQ)
+    real(rt)          qp(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),NQ)
+    real(rt)         qpo(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),NQ)
 
-    double precision qaux(qa_lo(1):qa_hi(1),qa_lo(2):qa_hi(2),qa_lo(3):qa_hi(3),NQAUX)
+    real(rt)         qaux(qa_lo(1):qa_hi(1),qa_lo(2):qa_hi(2),qa_lo(3):qa_hi(3),NQAUX)
 
-    double precision fxy(fx_lo(1):fx_hi(1),fx_lo(2):fx_hi(2),fx_lo(3):fx_hi(3),NVAR)
-    double precision fyx(fy_lo(1):fy_hi(1),fy_lo(2):fy_hi(2),fy_lo(3):fy_hi(3),NVAR)
-    double precision  qx(qx_lo(1):qx_hi(1),qx_lo(2):qx_hi(2),qx_lo(3):qx_hi(3),NGDNV)
-    double precision  qy(qy_lo(1):qy_hi(1),qy_lo(2):qy_hi(2),qy_lo(3):qy_hi(3),NGDNV)
-    double precision srcQ(src_lo(1):src_hi(1),src_lo(2):src_hi(2),src_lo(3):src_hi(3),QVAR)
-    double precision hdt,cdtdx,cdtdy
+    real(rt)         fxy(fx_lo(1):fx_hi(1),fx_lo(2):fx_hi(2),fx_lo(3):fx_hi(3),NVAR)
+    real(rt)         fyx(fy_lo(1):fy_hi(1),fy_lo(2):fy_hi(2),fy_lo(3):fy_hi(3),NVAR)
+    real(rt)          qx(qx_lo(1):qx_hi(1),qx_lo(2):qx_hi(2),qx_lo(3):qx_hi(3),NGDNV)
+    real(rt)          qy(qy_lo(1):qy_hi(1),qy_lo(2):qy_hi(2),qy_lo(3):qy_hi(3),NGDNV)
+    real(rt)         srcQ(src_lo(1):src_hi(1),src_lo(2):src_hi(2),src_lo(3):src_hi(3),QVAR)
+    real(rt)         hdt,cdtdx,cdtdy
 
     integer i, j, n, nqp, ipassive
 
-    double precision rrr, rur, rvr, rwr, rer, ekenr, rhoekenr
-    double precision rrl, rul, rvl, rwl, rel, ekenl, rhoekenl
-    double precision rrnewr, runewr, rvnewr, rwnewr, renewr
-    double precision rrnewl, runewl, rvnewl, rwnewl, renewl
-    double precision pnewr, pnewl
-    double precision pggxp, pggxm, ugxp, ugxm, gegxp, gegxm, duxp, pxav, dux, pxnew, gexnew
-    double precision pggyp, pggym, ugyp, ugym, gegyp, gegym, duyp, pyav, duy, pynew, geynew
-    double precision uxav, gexav, dgex, uyav, geyav, dgey
-    double precision pggxpm, pggxmm, ugxpm, ugxmm, gegxpm, gegxmm, duxpm, pxavm, duxm, pxnewm, gexnewm
-    double precision pggypm, pggymm, ugypm, ugymm, gegypm, gegymm, duypm, pyavm, duym, pynewm, geynewm
-    double precision uxavm, gexavm, dgexm, uyavm, geyavm, dgeym
-    double precision compr, compl, compnr, compnl
+    real(rt)         rrr, rur, rvr, rwr, rer, ekenr, rhoekenr
+    real(rt)         rrl, rul, rvl, rwl, rel, ekenl, rhoekenl
+    real(rt)         rrnewr, runewr, rvnewr, rwnewr, renewr
+    real(rt)         rrnewl, runewl, rvnewl, rwnewl, renewl
+    real(rt)         pnewr, pnewl
+    real(rt)         pggxp, pggxm, ugxp, ugxm, gegxp, gegxm, duxp, pxav, dux, pxnew, gexnew
+    real(rt)         pggyp, pggym, ugyp, ugym, gegyp, gegym, duyp, pyav, duy, pynew, geynew
+    real(rt)         uxav, gexav, dgex, uyav, geyav, dgey
+    real(rt)         pggxpm, pggxmm, ugxpm, ugxmm, gegxpm, gegxmm, duxpm, pxavm, duxm, pxnewm, gexnewm
+    real(rt)         pggypm, pggymm, ugypm, ugymm, gegypm, gegymm, duypm, pyavm, duym, pynewm, geynewm
+    real(rt)         uxavm, gexavm, dgexm, uyavm, geyavm, dgeym
+    real(rt)         compr, compl, compnr, compnl
 
 #ifdef RADIATION
-    double precision :: dmx, dmy, dre
-    double precision, dimension(0:ngroups-1) :: der, lamc, lamm, lugex, lugey, lgex, lgey, &
+    real(rt)         :: dmx, dmy, dre
+    real(rt)        , dimension(0:ngroups-1) :: der, lamc, lamm, lugex, lugey, lgex, lgey, &
          err, ernewr, erl, ernewl, ergxp, ergyp, ergxm, ergym, ergxpm, ergypm, ergxmm, ergymm
-    double precision eddf, f1
+    real(rt)         eddf, f1
     integer :: g
 #endif
 
@@ -2645,6 +2653,7 @@ contains
                      srcQ,src_lo,src_hi, &
                      hdt,cdtdx,cdtdz,ilo,ihi,jlo,jhi,km,kc,k3d)
 
+    use bl_fort_module, only : rt => c_real
     integer :: qd_lo(3),qd_hi(3)
     integer :: qa_lo(3),qa_hi(3)
     integer :: fx_lo(3),fx_hi(3)
@@ -2655,41 +2664,41 @@ contains
     integer ilo,ihi,jlo,jhi,km,kc,k3d
 
 #ifdef RADIATION
-    double precision rfxz(fx_lo(1):fx_hi(1),fx_lo(2):fx_hi(2),fx_lo(3):fx_hi(3),0:ngroups-1)
-    double precision rfzx(fz_lo(1):fz_hi(1),fz_lo(2):fz_hi(2),fz_lo(3):fz_hi(3),0:ngroups-1)
+    real(rt)         rfxz(fx_lo(1):fx_hi(1),fx_lo(2):fx_hi(2),fx_lo(3):fx_hi(3),0:ngroups-1)
+    real(rt)         rfzx(fz_lo(1):fz_hi(1),fz_lo(2):fz_hi(2),fz_lo(3):fz_hi(3),0:ngroups-1)
 #endif
 
-    double precision  qm(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),NQ)
-    double precision  qp(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),NQ)
-    double precision qmo(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),NQ)
-    double precision qpo(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),NQ)
+    real(rt)          qm(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),NQ)
+    real(rt)          qp(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),NQ)
+    real(rt)         qmo(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),NQ)
+    real(rt)         qpo(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),NQ)
 
-    double precision qaux(qa_lo(1):qa_hi(1),qa_lo(2):qa_hi(2),qa_lo(3):qa_hi(3),NQAUX)
+    real(rt)         qaux(qa_lo(1):qa_hi(1),qa_lo(2):qa_hi(2),qa_lo(3):qa_hi(3),NQAUX)
 
-    double precision fxz(fx_lo(1):fx_hi(1),fx_lo(2):fx_hi(2),fx_lo(3):fx_hi(3),NVAR)
-    double precision fzx(fz_lo(1):fz_hi(1),fz_lo(2):fz_hi(2),fz_lo(3):fz_hi(3),NVAR)
-    double precision  qx(qx_lo(1):qx_hi(1),qx_lo(2):qx_hi(2),qx_lo(3):qx_hi(3),NGDNV)
-    double precision  qz(qz_lo(1):qz_hi(1),qz_lo(2):qz_hi(2),qz_lo(3):qz_hi(3),NGDNV)
-    double precision srcQ(src_lo(1):src_hi(1),src_lo(2):src_hi(2),src_lo(3):src_hi(3),QVAR)
-    double precision hdt,cdtdx,cdtdz
+    real(rt)         fxz(fx_lo(1):fx_hi(1),fx_lo(2):fx_hi(2),fx_lo(3):fx_hi(3),NVAR)
+    real(rt)         fzx(fz_lo(1):fz_hi(1),fz_lo(2):fz_hi(2),fz_lo(3):fz_hi(3),NVAR)
+    real(rt)          qx(qx_lo(1):qx_hi(1),qx_lo(2):qx_hi(2),qx_lo(3):qx_hi(3),NGDNV)
+    real(rt)          qz(qz_lo(1):qz_hi(1),qz_lo(2):qz_hi(2),qz_lo(3):qz_hi(3),NGDNV)
+    real(rt)         srcQ(src_lo(1):src_hi(1),src_lo(2):src_hi(2),src_lo(3):src_hi(3),QVAR)
+    real(rt)         hdt,cdtdx,cdtdz
 
     integer i, j, n, nqp, ipassive
 
-    double precision rrr, rur, rvr, rwr, rer, ekenr, rhoekenr
-    double precision rrl, rul, rvl, rwl, rel, ekenl, rhoekenl
-    double precision rrnewr, runewr, rvnewr, rwnewr, renewr
-    double precision rrnewl, runewl, rvnewl, rwnewl, renewl
-    double precision pnewr, pnewl
-    double precision pggxp, pggxm, ugxp, ugxm, gegxp, gegxm, duxp, pxav, dux, pxnew, gexnew
-    double precision pggzp, pggzm, ugzp, ugzm, gegzp, gegzm, duzp, pzav, duz, pznew, geznew
-    double precision uxav, gexav, dgex, uzav, gezav, dgez
-    double precision compr, compl, compnr, compnl, drr, dcompn
+    real(rt)         rrr, rur, rvr, rwr, rer, ekenr, rhoekenr
+    real(rt)         rrl, rul, rvl, rwl, rel, ekenl, rhoekenl
+    real(rt)         rrnewr, runewr, rvnewr, rwnewr, renewr
+    real(rt)         rrnewl, runewl, rvnewl, rwnewl, renewl
+    real(rt)         pnewr, pnewl
+    real(rt)         pggxp, pggxm, ugxp, ugxm, gegxp, gegxm, duxp, pxav, dux, pxnew, gexnew
+    real(rt)         pggzp, pggzm, ugzp, ugzm, gegzp, gegzm, duzp, pzav, duz, pznew, geznew
+    real(rt)         uxav, gexav, dgex, uzav, gezav, dgez
+    real(rt)         compr, compl, compnr, compnl, drr, dcompn
 
 #ifdef RADIATION
-    double precision :: dmx, dmz, dre
-    double precision, dimension(0:ngroups-1) :: der, lambda, lugex, lugez, lgex, lgez, &
+    real(rt)         :: dmx, dmz, dre
+    real(rt)        , dimension(0:ngroups-1) :: der, lambda, lugex, lugez, lgex, lgez, &
          err, ernewr, erl, ernewl, ergzp, ergxp, ergzm,  ergxm
-    double precision eddf, f1
+    real(rt)         eddf, f1
     integer :: g
 #endif
 
@@ -3061,6 +3070,7 @@ contains
                      srcQ,src_lo,src_hi, &
                      hdt,cdtdy,cdtdz,ilo,ihi,jlo,jhi,km,kc,k3d)
 
+    use bl_fort_module, only : rt => c_real
     integer :: qd_lo(3),qd_hi(3)
     integer :: qa_lo(3),qa_hi(3)
     integer :: fy_lo(3),fy_hi(3)
@@ -3071,42 +3081,42 @@ contains
     integer ilo,ihi,jlo,jhi,km,kc,k3d
 
 #ifdef RADIATION
-    double precision rfyz(fy_lo(1):fy_hi(1),fy_lo(2):fy_hi(2),fy_lo(3):fy_hi(3),0:ngroups-1)
-    double precision rfzy(fz_lo(1):fz_hi(1),fz_lo(2):fz_hi(2),fz_lo(3):fz_hi(3),0:ngroups-1)
+    real(rt)         rfyz(fy_lo(1):fy_hi(1),fy_lo(2):fy_hi(2),fy_lo(3):fy_hi(3),0:ngroups-1)
+    real(rt)         rfzy(fz_lo(1):fz_hi(1),fz_lo(2):fz_hi(2),fz_lo(3):fz_hi(3),0:ngroups-1)
 #endif
 
-    double precision qm(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),NQ)
-    double precision qp(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),NQ)
-    double precision qmo(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),NQ)
-    double precision qpo(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),NQ)
+    real(rt)         qm(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),NQ)
+    real(rt)         qp(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),NQ)
+    real(rt)         qmo(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),NQ)
+    real(rt)         qpo(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),NQ)
 
-    double precision qaux(qa_lo(1):qa_hi(1),qa_lo(2):qa_hi(2),qa_lo(3):qa_hi(3),NQAUX)
+    real(rt)         qaux(qa_lo(1):qa_hi(1),qa_lo(2):qa_hi(2),qa_lo(3):qa_hi(3),NQAUX)
 
-    double precision fyz(fy_lo(1):fy_hi(1),fy_lo(2):fy_hi(2),fy_lo(3):fy_hi(3),NVAR)
-    double precision fzy(fz_lo(1):fz_hi(1),fz_lo(2):fz_hi(2),fz_lo(3):fz_hi(3),NVAR)
-    double precision  qy(qy_lo(1):qy_hi(1),qy_lo(2):qy_hi(2),qy_lo(3):qy_hi(3),NGDNV)
-    double precision  qz(qz_lo(1):qz_hi(1),qz_lo(2):qz_hi(2),qz_lo(3):qz_hi(3),NGDNV)
-    double precision srcQ(src_lo(1):src_hi(1),src_lo(2):src_hi(2),src_lo(3):src_hi(3),QVAR)
-    double precision hdt,cdtdy,cdtdz
+    real(rt)         fyz(fy_lo(1):fy_hi(1),fy_lo(2):fy_hi(2),fy_lo(3):fy_hi(3),NVAR)
+    real(rt)         fzy(fz_lo(1):fz_hi(1),fz_lo(2):fz_hi(2),fz_lo(3):fz_hi(3),NVAR)
+    real(rt)          qy(qy_lo(1):qy_hi(1),qy_lo(2):qy_hi(2),qy_lo(3):qy_hi(3),NGDNV)
+    real(rt)          qz(qz_lo(1):qz_hi(1),qz_lo(2):qz_hi(2),qz_lo(3):qz_hi(3),NGDNV)
+    real(rt)         srcQ(src_lo(1):src_hi(1),src_lo(2):src_hi(2),src_lo(3):src_hi(3),QVAR)
+    real(rt)         hdt,cdtdy,cdtdz
 
     integer i, j, n, nqp, ipassive
 
-    double precision rrr, rur, rvr, rwr, rer, ekenr, rhoekenr
-    double precision rrl, rul, rvl, rwl, rel, ekenl, rhoekenl
-    double precision rrnewr, runewr, rvnewr, rwnewr, renewr
-    double precision rrnewl, runewl, rvnewl, rwnewl, renewl
-    double precision pnewr, pnewl
-    double precision pggyp, pggym, ugyp, ugym, gegyp, gegym, duyp, pyav, duy, pynew, geynew
-    double precision pggzp, pggzm, ugzp, ugzm, gegzp, gegzm, duzp, pzav, duz, pznew, geznew
-    double precision uyav, geyav, dgey, uzav, gezav, dgez
-    double precision compr, compl, compnr, compnl
-    double precision drr, dcompn
+    real(rt)         rrr, rur, rvr, rwr, rer, ekenr, rhoekenr
+    real(rt)         rrl, rul, rvl, rwl, rel, ekenl, rhoekenl
+    real(rt)         rrnewr, runewr, rvnewr, rwnewr, renewr
+    real(rt)         rrnewl, runewl, rvnewl, rwnewl, renewl
+    real(rt)         pnewr, pnewl
+    real(rt)         pggyp, pggym, ugyp, ugym, gegyp, gegym, duyp, pyav, duy, pynew, geynew
+    real(rt)         pggzp, pggzm, ugzp, ugzm, gegzp, gegzm, duzp, pzav, duz, pznew, geznew
+    real(rt)         uyav, geyav, dgey, uzav, gezav, dgez
+    real(rt)         compr, compl, compnr, compnl
+    real(rt)         drr, dcompn
 
 #ifdef RADIATION
-    double precision :: dmy, dmz, dre
-    double precision, dimension(0:ngroups-1) :: der, lambda, lugey, lugez, lgey, lgez, &
+    real(rt)         :: dmy, dmz, dre
+    real(rt)        , dimension(0:ngroups-1) :: der, lambda, lugey, lugez, lgey, lgez, &
          err, ernewr, erl, ernewl, ergzp, ergyp, ergzm, ergym
-    double precision eddf, f1
+    real(rt)         eddf, f1
     integer :: g
 #endif
 

--- a/Source/Src_nd/Castro_nd.F90
+++ b/Source/Src_nd/Castro_nd.F90
@@ -23,6 +23,7 @@ subroutine ca_extern_init(name,namlen) bind(C, name="ca_extern_init")
   ! initialize the external runtime parameters in
   ! extern_probin_module
 
+  use bl_fort_module, only : rt => c_real
   integer :: namlen
   integer :: name(namlen)
 
@@ -38,6 +39,7 @@ subroutine get_num_spec(nspec_out) bind(C, name="get_num_spec")
 
   use network, only : nspec
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(out) :: nspec_out
@@ -54,6 +56,7 @@ subroutine get_num_aux(naux_out) bind(C, name="get_num_aux")
 
   use network, only : naux
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(out) :: naux_out
@@ -71,6 +74,7 @@ subroutine get_spec_names(spec_names,ispec,len) &
 
   use network, only : nspec, short_spec_names
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in   ) :: ispec
@@ -96,10 +100,11 @@ subroutine get_spec_az(ispec,A,Z) bind(C, name="get_spec_az")
 
   use network, only : nspec, aion, zion
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer         , intent(in   ) :: ispec
-  double precision, intent(inout) :: A, Z
+  real(rt)        , intent(inout) :: A, Z
 
   ! C++ is 0-based indexing, so increment
   A = aion(ispec+1)
@@ -116,6 +121,7 @@ subroutine get_aux_names(aux_names,iaux,len) &
 
   use network, only : naux, short_aux_names
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in   ) :: iaux
@@ -141,6 +147,7 @@ subroutine get_qvar(qvar_in) bind(C, name="get_qvar")
 
   use meth_params_module, only: QVAR
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(inout) :: qvar_in
@@ -157,6 +164,7 @@ subroutine get_nqaux(nqaux_in) bind(C, name="get_nqaux")
 
   use meth_params_module, only: NQAUX
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(inout) :: nqaux_in
@@ -174,10 +182,11 @@ subroutine set_amr_info(level_in, iteration_in, ncycle_in, time_in, dt_in) &
 
   use amrinfo_module, only: amr_level, amr_iteration, amr_ncycle, amr_time, amr_dt
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: level_in, iteration_in, ncycle_in
-  double precision, intent(in) :: time_in, dt_in
+  real(rt)        , intent(in) :: time_in, dt_in
 
   if (level_in .ge. 0) then
      amr_level = level_in
@@ -211,6 +220,7 @@ subroutine get_method_params(nGrowHyp) bind(C, name="get_method_params")
 
   use meth_params_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(out) :: ngrowHyp
@@ -228,6 +238,7 @@ subroutine allocate_outflow_data(np,nc) &
 
   use meth_params_module, only: outflow_data_old, outflow_data_new, outflow_data_allocated
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: np,nc
@@ -251,10 +262,11 @@ subroutine set_old_outflow_data(radial,time,np,nc) &
 
   use meth_params_module, only: outflow_data_old, outflow_data_old_time
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
-  double precision, intent(in) :: radial(nc,np)
-  double precision, intent(in) :: time
+  real(rt)        , intent(in) :: radial(nc,np)
+  real(rt)        , intent(in) :: time
   integer         , intent(in) :: np,nc
 
   ! Do this so the routine has the right size
@@ -277,10 +289,11 @@ subroutine set_new_outflow_data(radial,time,np,nc) &
 
   use meth_params_module, only: outflow_data_new, outflow_data_new_time
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
-  double precision, intent(in) :: radial(nc,np)
-  double precision, intent(in) :: time
+  real(rt)        , intent(in) :: radial(nc,np)
+  real(rt)        , intent(in) :: time
   integer         , intent(in) :: np,nc
 
   ! Do this so the routine has the right size
@@ -301,6 +314,7 @@ subroutine swap_outflow_data() bind(C, name="swap_outflow_data")
   use meth_params_module, only: outflow_data_new, outflow_data_new_time, &
        outflow_data_old, outflow_data_old_time
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer                       :: np,nc
@@ -321,9 +335,9 @@ subroutine swap_outflow_data() bind(C, name="swap_outflow_data")
 
   outflow_data_old(1:nc,1:np) = outflow_data_new(1:nc,1:np)
 
-  if (outflow_data_new_time .ge. 0.d0) &
+  if (outflow_data_new_time .ge. 0.e0_rt) &
        outflow_data_old_time = outflow_data_new_time
-  outflow_data_new_time = -1.d0
+  outflow_data_new_time = -1.e0_rt
 
 end subroutine swap_outflow_data
 
@@ -349,6 +363,7 @@ subroutine set_method_params(dm,Density,Xmom,Eden,Eint,Temp, &
   use rad_params_module, only : ngroups
 #endif
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: dm
@@ -360,7 +375,7 @@ subroutine set_method_params(dm,Density,Xmom,Eden,Eint,Temp, &
 #endif
   integer, intent(in) :: gravity_type_len
   integer, intent(in) :: gravity_type_in(gravity_type_len)
-  double precision, intent(in) :: diffuse_cutoff_density_in
+  real(rt)        , intent(in) :: diffuse_cutoff_density_in
   integer :: iadv, ispec
 
   integer :: QLAST
@@ -571,26 +586,26 @@ subroutine set_method_params(dm,Density,Xmom,Eden,Eint,Temp, &
   ! safety checks
   !---------------------------------------------------------------------
 
-  if (small_dens <= 0.d0) then
+  if (small_dens <= 0.e0_rt) then
      if (ioproc == 1) then
-        call bl_warning("Warning:: small_dens has not been set, defaulting to 1.d-200.")
+        call bl_warning("Warning:: small_dens has not been set, defaulting to 1.e-200_rt.")
      endif
-     small_dens = 1.d-200
+     small_dens = 1.e-200_rt
   endif
 
-  if (small_temp <= 0.d0) then
+  if (small_temp <= 0.e0_rt) then
      if (ioproc == 1) then
-        call bl_warning("Warning:: small_temp has not been set, defaulting to 1.d-200.")
+        call bl_warning("Warning:: small_temp has not been set, defaulting to 1.e-200_rt.")
      endif
-     small_temp = 1.d-200
+     small_temp = 1.e-200_rt
   endif
 
-  if (small_pres <= 0.d0) then
-     small_pres = 1.d-200
+  if (small_pres <= 0.e0_rt) then
+     small_pres = 1.e-200_rt
   endif
 
-  if (small_ener <= 0.d0) then
-     small_ener = 1.d-200
+  if (small_ener <= 0.e0_rt) then
+     small_ener = 1.e-200_rt
   endif
 
   ! Note that the EOS may modify our choices because of its
@@ -623,6 +638,7 @@ subroutine init_godunov_indices() bind(C, name="init_godunov_indices")
   use meth_params_module, only : GDRHO, GDU, GDV, GDW, GDPRES, GDGAME, NGDNV, &
        QU, QV, QW
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   NGDNV = 6
@@ -659,13 +675,14 @@ subroutine set_problem_params(dm,physbc_lo_in,physbc_hi_in,&
   use meth_params_module, only: rot_axis
 #endif
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer, intent(in) :: dm
   integer, intent(in) :: physbc_lo_in(dm),physbc_hi_in(dm)
   integer, intent(in) :: Interior_in, Inflow_in, Outflow_in, Symmetry_in, SlipWall_in, NoSlipWall_in
   integer, intent(in) :: coord_type_in
-  double precision, intent(in) :: problo_in(dm), probhi_in(dm), center_in(dm)
+  real(rt)        , intent(in) :: problo_in(dm), probhi_in(dm), center_in(dm)
 
   dim = dm
 
@@ -716,10 +733,11 @@ subroutine set_grid_info(max_level_in, dx_level_in, domlo_in, domhi_in, ref_rati
 
   use prob_params_module, only: max_level, dx_level, domlo_level, domhi_level, n_error_buf, ref_ratio, blocking_factor
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer,          intent(in) :: max_level_in
-  double precision, intent(in) :: dx_level_in(3*(max_level_in+1))
+  real(rt)        , intent(in) :: dx_level_in(3*(max_level_in+1))
   integer,          intent(in) :: domlo_in(3*(max_level_in+1)), domhi_in(3*(max_level_in+1))
   integer,          intent(in) :: ref_ratio_in(3*(max_level_in+1))
   integer,          intent(in) :: n_error_buf_in(0:max_level_in)
@@ -779,7 +797,8 @@ end subroutine set_grid_info
 
 subroutine ca_set_special_tagging_flag(dummy,flag) &
      bind(C, name="ca_set_special_tagging_flag")
-  double precision :: dummy
+  use bl_fort_module, only : rt => c_real
+  real(rt)         :: dummy
   integer          :: flag
 end subroutine ca_set_special_tagging_flag
 
@@ -794,6 +813,7 @@ subroutine get_tagging_params(name, namlen) &
 
   ! Initialize the tagging parameters
 
+  use bl_fort_module, only : rt => c_real
   integer :: namlen
   integer :: name(namlen)
 
@@ -811,33 +831,33 @@ subroutine get_tagging_params(name, namlen) &
        raderr,     radgrad,   max_raderr_lev,   max_radgrad_lev
 
   ! Set namelist defaults
-  denerr = 1.d20
-  dengrad = 1.d20
+  denerr = 1.e20_rt
+  dengrad = 1.e20_rt
   max_denerr_lev = 10
   max_dengrad_lev = 10
 
-  enterr = 1.d20
-  entgrad = 1.d20
+  enterr = 1.e20_rt
+  entgrad = 1.e20_rt
   max_enterr_lev = -1
   max_entgrad_lev = -1
 
-  presserr = 1.d20
-  pressgrad = 1.d20
+  presserr = 1.e20_rt
+  pressgrad = 1.e20_rt
   max_presserr_lev = -1
   max_pressgrad_lev = -1
 
-  velerr  = 1.d20
-  velgrad = 1.d20
+  velerr  = 1.e20_rt
+  velgrad = 1.e20_rt
   max_velerr_lev = -1
   max_velgrad_lev = -1
 
-  temperr  = 1.d20
-  tempgrad = 1.d20
+  temperr  = 1.e20_rt
+  tempgrad = 1.e20_rt
   max_temperr_lev = -1
   max_tempgrad_lev = -1
 
-  raderr  = 1.d20
-  radgrad = 1.d20
+  raderr  = 1.e20_rt
+  radgrad = 1.e20_rt
   max_raderr_lev = -1
   max_radgrad_lev = -1
 
@@ -879,6 +899,7 @@ subroutine get_sponge_params(name, namlen) bind(C, name="get_sponge_params")
 
   ! Initialize the sponge parameters
 
+  use bl_fort_module, only : rt => c_real
   integer :: namlen
   integer :: name(namlen)
 
@@ -895,16 +916,16 @@ subroutine get_sponge_params(name, namlen) bind(C, name="get_sponge_params")
 
   ! Set namelist defaults
 
-  sponge_lower_factor = 0.d0
-  sponge_upper_factor = 1.d0
+  sponge_lower_factor = 0.e0_rt
+  sponge_upper_factor = 1.e0_rt
 
-  sponge_lower_radius = -1.d0
-  sponge_upper_radius = -1.d0
+  sponge_lower_radius = -1.e0_rt
+  sponge_upper_radius = -1.e0_rt
 
-  sponge_lower_density = -1.d0
-  sponge_upper_density = -1.d0
+  sponge_lower_density = -1.e0_rt
+  sponge_upper_density = -1.e0_rt
 
-  sponge_timescale    = -1.d0
+  sponge_timescale    = -1.e0_rt
 
   ! create the filename
   if (namlen > maxlen) then
@@ -933,11 +954,11 @@ subroutine get_sponge_params(name, namlen) bind(C, name="get_sponge_params")
 
   ! Sanity check
 
-  if (sponge_lower_factor < 0.d0 .or. sponge_lower_factor > 1.d0) then
+  if (sponge_lower_factor < 0.e0_rt .or. sponge_lower_factor > 1.e0_rt) then
      call bl_error('ERROR: sponge_lower_factor cannot be outside of [0, 1].')
   endif
 
-  if (sponge_upper_factor < 0.d0 .or. sponge_upper_factor > 1.d0) then
+  if (sponge_upper_factor < 0.e0_rt .or. sponge_upper_factor > 1.e0_rt) then
      call bl_error('ERROR: sponge_upper_factor cannot be outside of [0, 1].')
   endif
 
@@ -953,9 +974,10 @@ subroutine set_pointmass(pointmass_in) bind(C, name='set_pointmass')
 
   use meth_params_module, only: point_mass
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
-  double precision, intent(in) :: pointmass_in
+  real(rt)        , intent(in) :: pointmass_in
 
   point_mass = pointmass_in
 

--- a/Source/Src_nd/Castro_util.F90
+++ b/Source/Src_nd/Castro_util.F90
@@ -1,5 +1,6 @@
 module castro_util_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
 contains
@@ -15,11 +16,12 @@ contains
     use bl_constants_module, only: ZERO, HALF
 
     ! Input arguments
+    use bl_fort_module, only : rt => c_real
     integer :: i, j, k
     logical, optional :: ccx, ccy, ccz
 
     ! Local variables
-    double precision :: position(3), dx(3), offset(3)
+    real(rt)         :: position(3), dx(3), offset(3)
     integer :: idx(3)
     logical :: cc(3)
     integer :: domlo(3), domhi(3)
@@ -83,15 +85,16 @@ contains
     use meth_params_module, only : NVAR, URHO, UMX, UMY, UMZ, UEDEN, UEINT
     use bl_constants_module
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer          :: lo(3), hi(3)
     integer          :: s_lo(3), s_hi(3)
-    double precision :: state(s_lo(1):s_hi(1),s_lo(2):s_hi(2),s_lo(3):s_hi(3),NVAR)
+    real(rt)         :: state(s_lo(1):s_hi(1),s_lo(2):s_hi(2),s_lo(3):s_hi(3),NVAR)
 
     ! Local variables
     integer          :: i,j,k
-    double precision :: u, v, w, rhoInv
+    real(rt)         :: u, v, w, rhoInv
 
     !
     ! Enforces (rho E) = (rho e) + 1/2 rho (u^2 + v^2 + w^2)
@@ -126,15 +129,16 @@ contains
          dual_energy_eta2, dual_energy_update_E_from_e
     use bl_constants_module
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer          :: lo(3), hi(3), verbose
     integer          :: u_lo(3), u_hi(3)
-    double precision :: u(u_lo(1):u_hi(1),u_lo(2):u_hi(2),u_lo(3):u_hi(3),NVAR)
+    real(rt)         :: u(u_lo(1):u_hi(1),u_lo(2):u_hi(2),u_lo(3):u_hi(3),NVAR)
 
     ! Local variables
     integer          :: i,j,k
-    double precision :: Up, Vp, Wp, ke, rho_eint, eden, small_e, eint_new, rhoInv
+    real(rt)         :: Up, Vp, Wp, ke, rho_eint, eden, small_e, eint_new, rhoInv
 
     type (eos_t) :: eos_state
 
@@ -331,14 +335,15 @@ contains
          UFS, UFX, allow_negative_energy, dual_energy_update_E_from_e
     use bl_constants_module
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer         , intent(in   ) :: lo(3),hi(3)
     integer         , intent(in   ) :: s_lo(3),s_hi(3)
-    double precision, intent(inout) :: state(s_lo(1):s_hi(1),s_lo(2):s_hi(2),s_lo(3):s_hi(3),NVAR)
+    real(rt)        , intent(inout) :: state(s_lo(1):s_hi(1),s_lo(2):s_hi(2),s_lo(3):s_hi(3),NVAR)
 
     integer          :: i,j,k
-    double precision :: rhoInv
+    real(rt)         :: rhoInv
 
     type (eos_t) :: eos_state
 
@@ -407,15 +412,16 @@ contains
     use meth_params_module, only : NVAR, URHO, UFS
     use bl_constants_module
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer          :: lo(3), hi(3)
     integer          :: state_lo(3), state_hi(3)
-    double precision :: state(state_lo(1):state_hi(1),state_lo(2):state_hi(2),state_lo(3):state_hi(3),NVAR)
+    real(rt)         :: state(state_lo(1):state_hi(1),state_lo(2):state_hi(2),state_lo(3):state_hi(3),NVAR)
 
     ! Local variables
     integer          :: i, j, k
-    double precision :: spec_sum
+    real(rt)         :: spec_sum
 
     do k = lo(3), hi(3)
        do j = lo(2), hi(2)
@@ -423,7 +429,7 @@ contains
 
              spec_sum = sum(state(i,j,k,UFS:UFS+nspec-1))
 
-             if (abs(state(i,j,k,URHO)-spec_sum) .gt. 1.d-8 * state(i,j,k,URHO)) then
+             if (abs(state(i,j,k,URHO)-spec_sum) .gt. 1.e-8_rt * state(i,j,k,URHO)) then
 
                 print *,'Sum of (rho X)_i vs rho at (i,j,k): ',i,j,k,spec_sum,state(i,j,k,URHO)
                 call bl_error("Error:: Failed check of initial species summing to 1")
@@ -445,15 +451,16 @@ contains
     use bl_constants_module, only: ONE
     use extern_probin_module, only: small_x
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer          :: lo(3), hi(3)
     integer          :: u_lo(3), u_hi(3)
-    double precision :: u(u_lo(1):u_hi(1),u_lo(2):u_hi(2),u_lo(3):u_hi(3),NVAR)
+    real(rt)         :: u(u_lo(1):u_hi(1),u_lo(2):u_hi(2),u_lo(3):u_hi(3),NVAR)
 
     ! Local variables
     integer          :: i, j, k
-    double precision :: xn(nspec)
+    real(rt)         :: xn(nspec)
 
     do k = lo(3), hi(3)
        do j = lo(2), hi(2)
@@ -483,7 +490,8 @@ contains
     use amrinfo_module, only: amr_level
     use prob_params_module, only: dx_level, dim
     
-    double precision :: loc(3)
+    use bl_fort_module, only : rt => c_real
+    real(rt)         :: loc(3)
 
     integer :: index(3)
 
@@ -507,14 +515,15 @@ contains
     use bl_constants_module, only: ZERO, ONE, TWO, M_PI, FOUR
     use prob_params_module, only: dim, coord_type, dx_level
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer, intent(in) :: i, j, k, dir
 
-    double precision :: area
+    real(rt)         :: area
 
     logical :: cc(3) = .true.
-    double precision :: dx(3), loc(3)
+    real(rt)         :: dx(3), loc(3)
 
     ! Force edge-centering along the direction of interest
 
@@ -636,13 +645,14 @@ contains
     use bl_constants_module, only: ZERO, HALF, FOUR3RD, TWO, M_PI
     use prob_params_module, only: dim, coord_type, dx_level
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer, intent(in) :: i, j, k
 
-    double precision :: volume
+    real(rt)         :: volume
 
-    double precision :: dx(3), loc_l(3), loc_r(3)
+    real(rt)         :: dx(3), loc_l(3), loc_r(3)
 
     dx = dx_level(:,amr_level)
 
@@ -712,9 +722,10 @@ contains
 
     use prob_params_module, only : center
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
-    double precision, intent(inout) :: center_out(3)
+    real(rt)        , intent(inout) :: center_out(3)
 
     center_out = center
 
@@ -726,9 +737,10 @@ contains
 
     use prob_params_module, only : center
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
-    double precision :: center_in(3)
+    real(rt)         :: center_in(3)
 
     center = center_in
 
@@ -742,12 +754,13 @@ contains
     use bl_constants_module
     use prob_params_module, only: dg, dim
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
-    double precision :: data(-1:1,-1*dg(2):1*dg(2),-1*dg(3):1*dg(3))
-    double precision :: new_center(3)
-    double precision :: dx(3),problo(3)
-    double precision :: a,b,x,y,z,cen
+    real(rt)         :: data(-1:1,-1*dg(2):1*dg(2),-1*dg(3):1*dg(3))
+    real(rt)         :: new_center(3)
+    real(rt)         :: dx(3),problo(3)
+    real(rt)         :: a,b,x,y,z,cen
     integer          :: icen(3)
     integer          :: i,j,k
 
@@ -814,24 +827,25 @@ contains
     use prob_params_module, only : center, dim
     use bl_constants_module
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer          :: lo(3),hi(3),nc
-    double precision :: dx(3),dr,problo(3)
+    real(rt)         :: dx(3),dr,problo(3)
 
     integer          :: numpts_1d
-    double precision :: radial_state(nc,0:numpts_1d-1)
-    double precision :: radial_vol(0:numpts_1d-1)
+    real(rt)         :: radial_state(nc,0:numpts_1d-1)
+    real(rt)         :: radial_vol(0:numpts_1d-1)
 
     integer          :: s_lo(3), s_hi(3)
-    double precision :: state(s_lo(1):s_hi(1),s_lo(2):s_hi(2),s_lo(3):s_hi(3),nc)
+    real(rt)         :: state(s_lo(1):s_hi(1),s_lo(2):s_hi(2),s_lo(3):s_hi(3),nc)
 
     integer          :: v_lo(3), v_hi(3)
-    double precision :: vol(v_lo(1):v_hi(1),v_lo(2):v_hi(2),v_lo(3):v_hi(3))
+    real(rt)         :: vol(v_lo(1):v_hi(1),v_lo(2):v_hi(2),v_lo(3):v_hi(3))
 
     integer          :: i,j,k,n,index
-    double precision :: x,y,z,r
-    double precision :: x_mom,y_mom,z_mom,radial_mom
+    real(rt)         :: x,y,z,r
+    real(rt)         :: x_mom,y_mom,z_mom,radial_mom
 
     if (dim .eq. 1) call bl_error("Error: cannot do ca_compute_avgstate in 1D.")
 
@@ -880,10 +894,11 @@ contains
 
   function linear_to_angular_momentum(loc, mom) result(ang_mom)
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
-    double precision :: loc(3), mom(3)
-    double precision :: ang_mom(3)
+    real(rt)         :: loc(3), mom(3)
+    real(rt)         :: ang_mom(3)
 
     ang_mom(1) = loc(2) * mom(3) - loc(3) * mom(2)
     ang_mom(2) = loc(3) * mom(1) - loc(1) * mom(3)

--- a/Source/Src_nd/Derive_nd.f90
+++ b/Source/Src_nd/Derive_nd.f90
@@ -1,5 +1,6 @@
 module derive_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   public
@@ -17,6 +18,7 @@ contains
     ! The incoming   "dat" vector contains (rho,T,(rho X)_1)
     ! The outgoing "state" vector contains (rho,T,X_1)
     !
+    use bl_fort_module, only : rt => c_real
     implicit none 
 
     integer          :: lo(3), hi(3)
@@ -24,9 +26,9 @@ contains
     integer          :: d_lo(3), d_hi(3), nc
     integer          :: domlo(3), domhi(3)
     integer          :: bc(3,2,nc)
-    double precision :: delta(3), xlo(3), time, dt
-    double precision :: state(s_lo(1):s_hi(1),s_lo(2):s_hi(2),s_lo(3):s_hi(3),nv)
-    double precision :: dat(d_lo(1):d_hi(1),d_lo(2):d_hi(2),d_lo(3):d_hi(3),nc)
+    real(rt)         :: delta(3), xlo(3), time, dt
+    real(rt)         :: state(s_lo(1):s_hi(1),s_lo(2):s_hi(2),s_lo(3):s_hi(3),nv)
+    real(rt)         :: dat(d_lo(1):d_hi(1),d_lo(2):d_hi(2),d_lo(3):d_hi(3),nc)
     integer          :: level, grid_no
 
     integer          :: i, j, k
@@ -66,6 +68,7 @@ contains
     !
     ! This routine will derive the velocity from the momentum.
     !
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer          :: lo(3), hi(3)
@@ -73,9 +76,9 @@ contains
     integer          :: d_lo(3), d_hi(3), nc
     integer          :: domlo(3), domhi(3)
     integer          :: bc(3,2,nc)
-    double precision :: delta(3), xlo(3), time, dt
-    double precision :: vel(v_lo(1):v_hi(1),v_lo(2):v_hi(2),v_lo(3):v_hi(3),nv)
-    double precision :: dat(d_lo(1):d_hi(1),d_lo(2):d_hi(2),d_lo(3):d_hi(3),nc)
+    real(rt)         :: delta(3), xlo(3), time, dt
+    real(rt)         :: vel(v_lo(1):v_hi(1),v_lo(2):v_hi(2),v_lo(3):v_hi(3),nv)
+    real(rt)         :: dat(d_lo(1):d_hi(1),d_lo(2):d_hi(2),d_lo(3):d_hi(3),nc)
     integer          :: level, grid_no
 
     integer          :: i, j, k
@@ -102,6 +105,7 @@ contains
     use meth_params_module, only : URHO, UEINT, UTEMP, UFS, UFX
     use bl_constants_module
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer          :: lo(3), hi(3)
@@ -109,13 +113,13 @@ contains
     integer          :: d_lo(3), d_hi(3), nc
     integer          :: domlo(3), domhi(3)
     integer          :: bc(3,2,nc)
-    double precision :: delta(3), xlo(3), time, dt
-    double precision :: vel(v_lo(1):v_hi(1),v_lo(2):v_hi(2),v_lo(3):v_hi(3),nv)
-    double precision :: dat(d_lo(1):d_hi(1),d_lo(2):d_hi(2),d_lo(3):d_hi(3),nc)
+    real(rt)         :: delta(3), xlo(3), time, dt
+    real(rt)         :: vel(v_lo(1):v_hi(1),v_lo(2):v_hi(2),v_lo(3):v_hi(3),nv)
+    real(rt)         :: dat(d_lo(1):d_hi(1),d_lo(2):d_hi(2),d_lo(3):d_hi(3),nc)
     integer          :: level, grid_no
 
     integer          :: i, j, k
-    double precision :: rhoInv
+    real(rt)         :: rhoInv
 
     type (eos_t) :: eos_state
 
@@ -151,6 +155,7 @@ contains
     use meth_params_module, only : URHO, UEINT, UTEMP, UFS, UFX
     use bl_constants_module
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer          :: lo(3), hi(3)
@@ -158,13 +163,13 @@ contains
     integer          :: d_lo(3), d_hi(3), nc
     integer          :: domlo(3), domhi(3)
     integer          :: bc(3,2,nc)
-    double precision :: delta(3), xlo(3), time, dt
-    double precision :: vel(v_lo(1):v_hi(1),v_lo(2):v_hi(2),v_lo(3):v_hi(3),nv)
-    double precision :: dat(d_lo(1):d_hi(1),d_lo(2):d_hi(2),d_lo(3):d_hi(3),nc)
+    real(rt)         :: delta(3), xlo(3), time, dt
+    real(rt)         :: vel(v_lo(1):v_hi(1),v_lo(2):v_hi(2),v_lo(3):v_hi(3),nv)
+    real(rt)         :: dat(d_lo(1):d_hi(1),d_lo(2):d_hi(2),d_lo(3):d_hi(3),nc)
     integer          :: level, grid_no
 
     integer          :: i, j, k
-    double precision :: rhoInv
+    real(rt)         :: rhoInv
 
     type (eos_t) :: eos_state
 
@@ -197,6 +202,7 @@ contains
     !
     ! This routine will derive magnitude of velocity.
     !
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer          :: lo(3), hi(3)
@@ -204,18 +210,18 @@ contains
     integer          :: d_lo(3), d_hi(3), nc
     integer          :: domlo(3), domhi(3)
     integer          :: bc(3,2,nc)
-    double precision :: delta(3), xlo(3), time, dt
-    double precision :: magvel(v_lo(1):v_hi(1),v_lo(2):v_hi(2),v_lo(3):v_hi(3),nv)
-    double precision ::    dat(d_lo(1):d_hi(1),d_lo(2):d_hi(2),d_lo(3):d_hi(3),nc)
+    real(rt)         :: delta(3), xlo(3), time, dt
+    real(rt)         :: magvel(v_lo(1):v_hi(1),v_lo(2):v_hi(2),v_lo(3):v_hi(3),nv)
+    real(rt)         ::    dat(d_lo(1):d_hi(1),d_lo(2):d_hi(2),d_lo(3):d_hi(3),nc)
     integer          :: level, grid_no
 
     integer          :: i, j, k
-    double precision :: dat1inv
+    real(rt)         :: dat1inv
 
     do k = lo(3), hi(3)
        do j = lo(2), hi(2)
           do i = lo(1), hi(1)
-             dat1inv = 1.d0/dat(i,j,k,1)
+             dat1inv = 1.e0_rt/dat(i,j,k,1)
              magvel(i,j,k,1) = sqrt( (dat(i,j,k,2) * dat1inv)**2 + &
                   (dat(i,j,k,3) * dat1inv)**2 + &
                   (dat(i,j,k,4) * dat1inv)**2 )
@@ -234,6 +240,7 @@ contains
     !
     ! This routine will derive magnitude of the gravity vector.
     !
+    use bl_fort_module, only : rt => c_real
     implicit none 
 
     integer          :: lo(3), hi(3)
@@ -241,9 +248,9 @@ contains
     integer          :: d_lo(3), d_hi(3), nc
     integer          :: domlo(3), domhi(3)
     integer          :: bc(3,2,nc)
-    double precision :: delta(3), xlo(3), time, dt
-    double precision :: maggrav(g_lo(1):g_hi(1),g_lo(2):g_hi(2),g_lo(3):g_hi(3),ng)
-    double precision ::     dat(d_lo(1):d_hi(1),d_lo(2):d_hi(2),d_lo(3):d_hi(3),nc)
+    real(rt)         :: delta(3), xlo(3), time, dt
+    real(rt)         :: maggrav(g_lo(1):g_hi(1),g_lo(2):g_hi(2),g_lo(3):g_hi(3),ng)
+    real(rt)         ::     dat(d_lo(1):d_hi(1),d_lo(2):d_hi(2),d_lo(3):d_hi(3),nc)
     integer          :: level, grid_no
 
     integer          :: i, j, k
@@ -272,6 +279,7 @@ contains
     use bl_constants_module
     use prob_params_module, only: center
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer          :: lo(3), hi(3)
@@ -279,13 +287,13 @@ contains
     integer          :: d_lo(3), d_hi(3), nc
     integer          :: domlo(3), domhi(3)
     integer          :: bc(3,2,nc)
-    double precision :: delta(3), xlo(3), time, dt
-    double precision :: radvel(v_lo(1):v_hi(1),v_lo(2):v_hi(2),v_lo(3):v_hi(3),nv)
-    double precision ::    dat(d_lo(1):d_hi(1),d_lo(2):d_hi(2),d_lo(3):d_hi(3),nc)
+    real(rt)         :: delta(3), xlo(3), time, dt
+    real(rt)         :: radvel(v_lo(1):v_hi(1),v_lo(2):v_hi(2),v_lo(3):v_hi(3),nv)
+    real(rt)         ::    dat(d_lo(1):d_hi(1),d_lo(2):d_hi(2),d_lo(3):d_hi(3),nc)
     integer          :: level, grid_no
 
     integer          :: i, j, k
-    double precision :: x, y, z, r
+    real(rt)         :: x, y, z, r
 
     do k = lo(3), hi(3)
        z = xlo(3) + (dble(k-lo(3))+HALF) * delta(3) - center(3)
@@ -312,6 +320,7 @@ contains
     !
     ! This routine will derive magnitude of momentum.
     !
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer          :: lo(3), hi(3)
@@ -319,9 +328,9 @@ contains
     integer          :: d_lo(3), d_hi(3), nc
     integer          :: domlo(3), domhi(3)
     integer          :: bc(3,2,nc)
-    double precision :: delta(3), xlo(3), time, dt
-    double precision :: magmom(m_lo(1):m_hi(1),m_lo(2):m_hi(2),m_lo(3):m_hi(3),nv)
-    double precision ::    dat(d_lo(1):d_hi(1),d_lo(2):d_hi(2),d_lo(3):d_hi(3),nc)
+    real(rt)         :: delta(3), xlo(3), time, dt
+    real(rt)         :: magmom(m_lo(1):m_hi(1),m_lo(2):m_hi(2),m_lo(3):m_hi(3),nv)
+    real(rt)         ::    dat(d_lo(1):d_hi(1),d_lo(2):d_hi(2),d_lo(3):d_hi(3),nc)
     integer          :: level, grid_no
 
     integer          :: i, j, k
@@ -347,18 +356,19 @@ contains
     use bl_constants_module, only: HALF
     use math_module, only: cross_product
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer          :: L_lo(3), L_hi(3), ncomp_L ! == 1
     integer          :: u_lo(3), u_hi(3), ncomp_u ! == 4
     integer          :: lo(3), hi(3), domlo(3), domhi(3)
-    double precision :: L(L_lo(1):L_hi(1),L_lo(2):L_hi(2),L_lo(3):L_hi(3),ncomp_L)
-    double precision :: u(u_lo(1):u_hi(1),u_lo(2):u_hi(2),u_lo(3):u_hi(3),ncomp_u)
-    double precision :: dx(3), xlo(3), time, dt
+    real(rt)         :: L(L_lo(1):L_hi(1),L_lo(2):L_hi(2),L_lo(3):L_hi(3),ncomp_L)
+    real(rt)         :: u(u_lo(1):u_hi(1),u_lo(2):u_hi(2),u_lo(3):u_hi(3),ncomp_u)
+    real(rt)         :: dx(3), xlo(3), time, dt
     integer          :: bc(3,2,ncomp_u), level, grid_no
 
     integer          :: i, j, k
-    double precision :: loc(3), mom(3), ang_mom(3), rho
+    real(rt)         :: loc(3), mom(3), ang_mom(3), rho
 
     do k = lo(3), hi(3)
        loc(3) = xlo(3) + (dble(k - lo(3)) + HALF) * dx(3)
@@ -390,18 +400,19 @@ contains
     use bl_constants_module, only: HALF
     use math_module, only: cross_product
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer          :: L_lo(3), L_hi(3), ncomp_L ! == 1
     integer          :: u_lo(3), u_hi(3), ncomp_u ! == 4
     integer          :: lo(3), hi(3), domlo(3), domhi(3)
-    double precision :: L(L_lo(1):L_hi(1),L_lo(2):L_hi(2),L_lo(3):L_hi(3),ncomp_L)
-    double precision :: u(u_lo(1):u_hi(1),u_lo(2):u_hi(2),u_lo(3):u_hi(3),ncomp_u)
-    double precision :: dx(3), xlo(3), time, dt
+    real(rt)         :: L(L_lo(1):L_hi(1),L_lo(2):L_hi(2),L_lo(3):L_hi(3),ncomp_L)
+    real(rt)         :: u(u_lo(1):u_hi(1),u_lo(2):u_hi(2),u_lo(3):u_hi(3),ncomp_u)
+    real(rt)         :: dx(3), xlo(3), time, dt
     integer          :: bc(3,2,ncomp_u), level, grid_no
 
     integer          :: i, j, k
-    double precision :: loc(3), mom(3), ang_mom(3), rho
+    real(rt)         :: loc(3), mom(3), ang_mom(3), rho
 
     do k = lo(3), hi(3)
        loc(3) = xlo(3) + (dble(k - lo(3)) + HALF) * dx(3)
@@ -433,18 +444,19 @@ contains
     use bl_constants_module, only: HALF
     use math_module, only: cross_product
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer          :: L_lo(3), L_hi(3), ncomp_L ! == 1
     integer          :: u_lo(3), u_hi(3), ncomp_u ! == 4
     integer          :: lo(3), hi(3), domlo(3), domhi(3)
-    double precision :: L(L_lo(1):L_hi(1),L_lo(2):L_hi(2),L_lo(3):L_hi(3),ncomp_L)
-    double precision :: u(u_lo(1):u_hi(1),u_lo(2):u_hi(2),u_lo(3):u_hi(3),ncomp_u)
-    double precision :: dx(3), xlo(3), time, dt
+    real(rt)         :: L(L_lo(1):L_hi(1),L_lo(2):L_hi(2),L_lo(3):L_hi(3),ncomp_L)
+    real(rt)         :: u(u_lo(1):u_hi(1),u_lo(2):u_hi(2),u_lo(3):u_hi(3),ncomp_u)
+    real(rt)         :: dx(3), xlo(3), time, dt
     integer          :: bc(3,2,ncomp_u), level, grid_no
 
     integer          :: i, j, k
-    double precision :: loc(3), mom(3), ang_mom(3), rho
+    real(rt)         :: loc(3), mom(3), ang_mom(3), rho
 
     do k = lo(3), hi(3)
        loc(3) = xlo(3) + (dble(k - lo(3)) + HALF) * dx(3)
@@ -477,18 +489,19 @@ contains
     use meth_params_module, only: URHO, UEINT, UTEMP, UFS, UFX
     use bl_constants_module
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer          :: lo(3), hi(3)
     integer          :: p_lo(3), p_hi(3), ncomp_p
     integer          :: u_lo(3), u_hi(3), ncomp_u
     integer          :: domlo(3), domhi(3)
-    double precision :: p(p_lo(1):p_hi(1),p_lo(2):p_hi(2),p_lo(3):p_hi(3),ncomp_p)
-    double precision :: u(u_lo(1):u_hi(1),u_lo(2):u_hi(2),u_lo(3):u_hi(3),ncomp_u)
-    double precision :: dx(3), xlo(3), time, dt
+    real(rt)         :: p(p_lo(1):p_hi(1),p_lo(2):p_hi(2),p_lo(3):p_hi(3),ncomp_p)
+    real(rt)         :: u(u_lo(1):u_hi(1),u_lo(2):u_hi(2),u_lo(3):u_hi(3),ncomp_u)
+    real(rt)         :: dx(3), xlo(3), time, dt
     integer          :: bc(3,2,ncomp_u), level, grid_no
 
-    double precision :: rhoInv
+    real(rt)         :: rhoInv
     integer          :: i, j, k
 
     type (eos_t) :: eos_state
@@ -523,18 +536,19 @@ contains
     use bl_constants_module
     use meth_params_module, only: URHO, UMX, UMY, UMZ, UEDEN 
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer          :: lo(3), hi(3)
     integer          :: e_lo(3), e_hi(3), ncomp_e
     integer          :: u_lo(3), u_hi(3), ncomp_u
     integer          :: domlo(3), domhi(3)
-    double precision :: e(e_lo(1):e_hi(1),e_lo(2):e_hi(2),e_lo(3):e_hi(3),ncomp_e)
-    double precision :: u(u_lo(1):u_hi(1),u_lo(2):u_hi(2),u_lo(3):u_hi(3),ncomp_u)
-    double precision :: dx(3), xlo(3), time, dt
+    real(rt)         :: e(e_lo(1):e_hi(1),e_lo(2):e_hi(2),e_lo(3):e_hi(3),ncomp_e)
+    real(rt)         :: u(u_lo(1):u_hi(1),u_lo(2):u_hi(2),u_lo(3):u_hi(3),ncomp_u)
+    real(rt)         :: dx(3), xlo(3), time, dt
     integer          :: bc(3,2,ncomp_u), level, grid_no
 
-    double precision :: rhoInv, ux, uy, uz
+    real(rt)         :: rhoInv, ux, uy, uz
     integer          :: i, j, k
     !
     ! Compute internal energy from (rho E).
@@ -562,15 +576,16 @@ contains
 
     use meth_params_module, only: URHO, UEINT
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer          :: lo(3), hi(3)
     integer          :: e_lo(3), e_hi(3), ncomp_e
     integer          :: u_lo(3), u_hi(3), ncomp_u
     integer          :: domlo(3), domhi(3)
-    double precision :: e(e_lo(1):e_hi(1),e_lo(2):e_hi(2),e_lo(3):e_hi(3),ncomp_e)
-    double precision :: u(u_lo(1):u_hi(1),u_lo(2):u_hi(2),u_lo(3):u_hi(3),ncomp_u)
-    double precision :: dx(3), xlo(3), time, dt
+    real(rt)         :: e(e_lo(1):e_hi(1),e_lo(2):e_hi(2),e_lo(3):e_hi(3),ncomp_e)
+    real(rt)         :: u(u_lo(1):u_hi(1),u_lo(2):u_hi(2),u_lo(3):u_hi(3),ncomp_u)
+    real(rt)         :: dx(3), xlo(3), time, dt
     integer          :: bc(3,2,ncomp_u), level, grid_no
 
     integer          :: i, j, k
@@ -599,18 +614,19 @@ contains
     use meth_params_module, only: URHO, UEINT, UTEMP, UFS, UFX
     use bl_constants_module
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer          :: lo(3), hi(3)
     integer          :: c_lo(3), c_hi(3), ncomp_c
     integer          :: u_lo(3), u_hi(3), ncomp_u
     integer          :: domlo(3), domhi(3)
-    double precision :: c(c_lo(1):c_hi(1),c_lo(2):c_hi(2),c_lo(3):c_hi(3),ncomp_c)
-    double precision :: u(u_lo(1):u_hi(1),u_lo(2):u_hi(2),u_lo(3):u_hi(3),ncomp_u)
-    double precision :: dx(3), xlo(3), time, dt
+    real(rt)         :: c(c_lo(1):c_hi(1),c_lo(2):c_hi(2),c_lo(3):c_hi(3),ncomp_c)
+    real(rt)         :: u(u_lo(1):u_hi(1),u_lo(2):u_hi(2),u_lo(3):u_hi(3),ncomp_u)
+    real(rt)         :: dx(3), xlo(3), time, dt
     integer          :: bc(3,2,ncomp_u), level, grid_no
 
-    double precision :: rhoInv
+    real(rt)         :: rhoInv
     integer          :: i, j, k
 
     type (eos_t) :: eos_state
@@ -647,18 +663,19 @@ contains
     use meth_params_module, only: URHO, UMX, UMZ, UEINT, UTEMP, UFS, UFX
     use bl_constants_module
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer          :: lo(3), hi(3)
     integer          :: m_lo(3), m_hi(3), ncomp_mach
     integer          :: u_lo(3), u_hi(3), ncomp_u
     integer          :: domlo(3), domhi(3)
-    double precision :: mach(m_lo(1):m_hi(1),m_lo(2):m_hi(2),m_lo(3):m_hi(3),ncomp_mach)
-    double precision ::    u(u_lo(1):u_hi(1),u_lo(2):u_hi(2),u_lo(3):u_hi(3),ncomp_u   )
-    double precision :: dx(3), xlo(3), time, dt
+    real(rt)         :: mach(m_lo(1):m_hi(1),m_lo(2):m_hi(2),m_lo(3):m_hi(3),ncomp_mach)
+    real(rt)         ::    u(u_lo(1):u_hi(1),u_lo(2):u_hi(2),u_lo(3):u_hi(3),ncomp_u   )
+    real(rt)         :: dx(3), xlo(3), time, dt
     integer          :: bc(3,2,ncomp_u), level, grid_no
 
-    double precision :: rhoInv
+    real(rt)         :: rhoInv
     integer          :: i, j, k
 
     type (eos_t) :: eos_state
@@ -695,18 +712,19 @@ contains
     use meth_params_module, only: URHO, UEINT, UTEMP, UFS, UFX
     use bl_constants_module
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer          :: lo(3), hi(3)
     integer          :: s_lo(3), s_hi(3), ncomp_s
     integer          :: u_lo(3), u_hi(3), ncomp_u
     integer          :: domlo(3), domhi(3)
-    double precision :: s(s_lo(1):s_hi(1),s_lo(2):s_hi(2),s_lo(3):s_hi(3),ncomp_s)
-    double precision :: u(u_lo(1):u_hi(1),u_lo(2):u_hi(2),u_lo(3):u_hi(3),ncomp_u)
-    double precision :: dx(3), xlo(3), time, dt
+    real(rt)         :: s(s_lo(1):s_hi(1),s_lo(2):s_hi(2),s_lo(3):s_hi(3),ncomp_s)
+    real(rt)         :: u(u_lo(1):u_hi(1),u_lo(2):u_hi(2),u_lo(3):u_hi(3),ncomp_u)
+    real(rt)         :: dx(3), xlo(3), time, dt
     integer          :: bc(3,2,ncomp_u), level, grid_no
 
-    double precision :: rhoInv
+    real(rt)         :: rhoInv
     integer          :: i, j, k
 
     type (eos_t) :: eos_state
@@ -744,19 +762,20 @@ contains
     use prob_params_module, only: dim
     use eos_module, only: eos_t, eos_input_re, eos
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer          :: lo(3), hi(3)
     integer          :: t_lo(3), t_hi(3), ncomp_t
     integer          :: u_lo(3), u_hi(3), ncomp_u
     integer          :: domlo(3), domhi(3)
-    double precision :: t(t_lo(1):t_hi(1),t_lo(2):t_hi(2),t_lo(3):t_hi(3),ncomp_t)
-    double precision :: u(u_lo(1):u_hi(1),u_lo(2):u_hi(2),u_lo(3):u_hi(3),ncomp_u) ! NVAR, enuc
-    double precision :: dx(3), xlo(3), time, dt
+    real(rt)         :: t(t_lo(1):t_hi(1),t_lo(2):t_hi(2),t_lo(3):t_hi(3),ncomp_t)
+    real(rt)         :: u(u_lo(1):u_hi(1),u_lo(2):u_hi(2),u_lo(3):u_hi(3),ncomp_u) ! NVAR, enuc
+    real(rt)         :: dx(3), xlo(3), time, dt
     integer          :: bc(3,2,ncomp_u), level, grid_no
 
     integer          :: i, j, k
-    double precision :: rhoInv, eint, enuc, t_s, t_e
+    real(rt)         :: rhoInv, eint, enuc, t_s, t_e
 
     type (eos_t)     :: eos_state
 
@@ -766,7 +785,7 @@ contains
 
              enuc = abs(u(i,j,k,ncomp_u))
 
-             if (enuc > 1.d-100) then
+             if (enuc > 1.e-100_rt) then
 
                 rhoInv = ONE / u(i,j,k,URHO)
 
@@ -809,6 +828,7 @@ contains
     !
     ! This routine derives the mass fractions of the species.
     !
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer          :: lo(3), hi(3)
@@ -816,9 +836,9 @@ contains
     integer          :: d_lo(3), d_hi(3), nc
     integer          :: domlo(3), domhi(3)
     integer          :: bc(3,2,nc)
-    double precision :: delta(3), xlo(3), time, dt
-    double precision :: spec(s_lo(1):s_hi(1),s_lo(2):s_hi(2),s_lo(3):s_hi(3),nv)
-    double precision ::  dat(d_lo(1):d_hi(1),d_lo(2):d_hi(2),d_lo(3):d_hi(3),nc)
+    real(rt)         :: delta(3), xlo(3), time, dt
+    real(rt)         :: spec(s_lo(1):s_hi(1),s_lo(2):s_hi(2),s_lo(3):s_hi(3),nv)
+    real(rt)         ::  dat(d_lo(1):d_hi(1),d_lo(2):d_hi(2),d_lo(3):d_hi(3),nc)
     integer          :: level, grid_no
 
     integer          :: i, j, k
@@ -841,6 +861,7 @@ contains
                           xlo,time,dt,bc,level,grid_no) &
                           bind(C, name="ca_derlogden")
     
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer          :: lo(3), hi(3)
@@ -848,9 +869,9 @@ contains
     integer          :: d_lo(3), d_hi(3), nc
     integer          :: domlo(3), domhi(3), level, grid_no
     integer          :: bc(3,2,nc)
-    double precision :: delta(3), xlo(3), time, dt
-    double precision :: logden(l_lo(1):l_hi(1),l_lo(2):l_hi(2),l_lo(3):l_hi(3),nd)
-    double precision ::    dat(d_lo(1):d_hi(1),d_lo(2):d_hi(2),d_lo(3):d_hi(3),nc)
+    real(rt)         :: delta(3), xlo(3), time, dt
+    real(rt)         :: logden(l_lo(1):l_hi(1),l_lo(2):l_hi(2),l_lo(3):l_hi(3),nd)
+    real(rt)         ::    dat(d_lo(1):d_hi(1),d_lo(2):d_hi(2),d_lo(3):d_hi(3),nc)
 
     integer          :: i, j, k
 
@@ -878,6 +899,7 @@ contains
     use bl_constants_module
     use prob_params_module, only: dg
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer          :: lo(3), hi(3)
@@ -885,13 +907,13 @@ contains
     integer          :: d_lo(3), d_hi(3), nc
     integer          :: domlo(3), domhi(3), level, grid_no
     integer          :: bc(3,2,nc)
-    double precision :: delta(3), xlo(3), time, dt
-    double precision :: vort(v_lo(1):v_hi(1),v_lo(2):v_hi(2),v_lo(3):v_hi(3),nv)
-    double precision ::  dat(d_lo(1):d_hi(1),d_lo(2):d_hi(2),d_lo(3):d_hi(3),nc)
+    real(rt)         :: delta(3), xlo(3), time, dt
+    real(rt)         :: vort(v_lo(1):v_hi(1),v_lo(2):v_hi(2),v_lo(3):v_hi(3),nv)
+    real(rt)         ::  dat(d_lo(1):d_hi(1),d_lo(2):d_hi(2),d_lo(3):d_hi(3),nc)
 
     integer          :: i, j, k
-    double precision :: uy, uz, vx, vz, wx, wy, v1, v2, v3
-    double precision :: ldat(lo(1)-1:hi(1)+1,lo(2)-1:hi(2)+1,lo(3)-1:hi(3)+1,2:4)
+    real(rt)         :: uy, uz, vx, vz, wx, wy, v1, v2, v3
+    real(rt)         :: ldat(lo(1)-1:hi(1)+1,lo(2)-1:hi(2)+1,lo(3)-1:hi(3)+1,2:4)
 
     ldat = ZERO
 
@@ -959,6 +981,7 @@ contains
     use bl_constants_module
     use prob_params_module, only: dg
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer          :: lo(3), hi(3)
@@ -966,13 +989,13 @@ contains
     integer          :: d_lo(3), d_hi(3), nc
     integer          :: domlo(3), domhi(3)
     integer          :: bc(3,2,nc)
-    double precision :: delta(3), xlo(3), time, dt
-    double precision :: divu(u_lo(1):u_hi(1),u_lo(2):u_hi(2),u_lo(3):u_hi(3),nd)
-    double precision ::  dat(d_lo(1):d_hi(1),d_lo(2):d_hi(2),d_lo(3):d_hi(3),nc)
+    real(rt)         :: delta(3), xlo(3), time, dt
+    real(rt)         :: divu(u_lo(1):u_hi(1),u_lo(2):u_hi(2),u_lo(3):u_hi(3),nd)
+    real(rt)         ::  dat(d_lo(1):d_hi(1),d_lo(2):d_hi(2),d_lo(3):d_hi(3),nc)
     integer          :: level, grid_no
 
     integer          :: i, j, k
-    double precision :: ulo, uhi, vlo, vhi, wlo, whi
+    real(rt)         :: ulo, uhi, vlo, vhi, wlo, whi
 
     do k = lo(3), hi(3)
        do j = lo(2), hi(2)
@@ -1009,6 +1032,7 @@ contains
 
     use bl_constants_module
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer          :: lo(3), hi(3)
@@ -1016,9 +1040,9 @@ contains
     integer          :: d_lo(3), d_hi(3), nc
     integer          :: domlo(3), domhi(3)
     integer          :: bc(3,2,nc)
-    double precision :: delta(3), xlo(3), time, dt
-    double precision :: kineng(k_lo(1):k_hi(1),k_lo(2):k_hi(2),k_lo(3):k_hi(3),nk)
-    double precision ::    dat(d_lo(1):d_hi(1),d_lo(2):d_hi(2),d_lo(3):d_hi(3),nc)
+    real(rt)         :: delta(3), xlo(3), time, dt
+    real(rt)         :: kineng(k_lo(1):k_hi(1),k_lo(2):k_hi(2),k_lo(3):k_hi(3),nk)
+    real(rt)         ::    dat(d_lo(1):d_hi(1),d_lo(2):d_hi(2),d_lo(3):d_hi(3),nc)
     integer          :: level, grid_no
 
     integer          :: i, j, k
@@ -1045,6 +1069,7 @@ contains
     !
     ! This routine is used by particle_count.  Yes it does nothing.
     !
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer          :: lo(3), hi(3)
@@ -1052,9 +1077,9 @@ contains
     integer          :: d_lo(3), d_hi(3), nc
     integer          :: domlo(3), domhi(3)
     integer          :: bc(3,2,nc)
-    double precision :: delta(3), xlo(3), time, dt
-    double precision :: kineng(k_lo(1):k_hi(1),k_lo(2):k_hi(2),k_lo(3):k_hi(3),nk)
-    double precision ::    dat(d_lo(1):d_hi(1),d_lo(2):d_hi(2),d_lo(3):d_hi(3),nc)
+    real(rt)         :: delta(3), xlo(3), time, dt
+    real(rt)         :: kineng(k_lo(1):k_hi(1),k_lo(2):k_hi(2),k_lo(3):k_hi(3),nk)
+    real(rt)         ::    dat(d_lo(1):d_hi(1),d_lo(2):d_hi(2),d_lo(3):d_hi(3),nc)
     integer          :: level, grid_no
 
   end subroutine ca_dernull

--- a/Source/Src_nd/Diffusion_nd.f90
+++ b/Source/Src_nd/Diffusion_nd.f90
@@ -1,5 +1,6 @@
 module diffusion_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   public
@@ -14,11 +15,12 @@ contains
 
     use prob_params_module, only: dg
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer :: lo(3), hi(3)
     integer :: t_lo(3), t_hi(3)
-    double precision :: tdif(t_lo(1):t_hi(1),t_lo(2):t_hi(2),t_lo(3):t_hi(3))
+    real(rt)         :: tdif(t_lo(1):t_hi(1),t_lo(2):t_hi(2),t_lo(3):t_hi(3))
 
     ! Local variables
 
@@ -210,22 +212,23 @@ contains
     use conductivity_module
     use eos_type_module
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer         , intent(in   ) :: lo(3), hi(3)
     integer         , intent(in   ) :: s_lo(3), s_hi(3)
     integer         , intent(in   ) :: cx_lo(3), cx_hi(3), cy_lo(3), cy_hi(3), cz_lo(3), cz_hi(3)
-    real (kind=dp_t), intent(in   ) :: state(s_lo(1):s_hi(1),s_lo(2):s_hi(2),s_lo(3):s_hi(3),NVAR)
-    real (kind=dp_t), intent(inout) :: coefx(cx_lo(1):cx_hi(1),cx_lo(2):cx_hi(2),cx_lo(3):cx_hi(3))
-    real (kind=dp_t), intent(inout) :: coefy(cy_lo(1):cy_hi(1),cy_lo(2):cy_hi(2),cy_lo(3):cy_hi(3))
-    real (kind=dp_t), intent(inout) :: coefz(cz_lo(1):cz_hi(1),cz_lo(2):cz_hi(2),cz_lo(3):cz_hi(3))
+    real(rt)        , intent(in   ) :: state(s_lo(1):s_hi(1),s_lo(2):s_hi(2),s_lo(3):s_hi(3),NVAR)
+    real(rt)        , intent(inout) :: coefx(cx_lo(1):cx_hi(1),cx_lo(2):cx_hi(2),cx_lo(3):cx_hi(3))
+    real(rt)        , intent(inout) :: coefy(cy_lo(1):cy_hi(1),cy_lo(2):cy_hi(2),cy_lo(3):cy_hi(3))
+    real(rt)        , intent(inout) :: coefz(cz_lo(1):cz_hi(1),cz_lo(2):cz_hi(2),cz_lo(3):cz_hi(3))
 
     ! local variables
     integer          :: i, j, k
-    double precision :: coef_cc(lo(1)-1:hi(1)+1,lo(2)-1:hi(2)+1,lo(3)-1:hi(3)+1)
+    real(rt)         :: coef_cc(lo(1)-1:hi(1)+1,lo(2)-1:hi(2)+1,lo(3)-1:hi(3)+1)
 
     type (eos_t) :: eos_state
-    double precision :: coeff
+    real(rt)         :: coeff
 
     ! fill the cell-centered diffusion coefficient
 
@@ -255,7 +258,7 @@ contains
     do k = lo(3),hi(3)
        do j = lo(2),hi(2)
           do i = lo(1),hi(1)+1*dg(1)
-             coefx(i,j,k) = 0.5d0 * (coef_cc(i,j,k) + coef_cc(i-1*dg(1),j,k))
+             coefx(i,j,k) = 0.5e0_rt * (coef_cc(i,j,k) + coef_cc(i-1*dg(1),j,k))
           end do
        end do
     enddo
@@ -263,7 +266,7 @@ contains
     do k = lo(3),hi(3)
        do j = lo(2),hi(2)+1*dg(2)
           do i = lo(1),hi(1)
-             coefy(i,j,k) = 0.5d0 * (coef_cc(i,j,k) + coef_cc(i,j-1*dg(2),k))
+             coefy(i,j,k) = 0.5e0_rt * (coef_cc(i,j,k) + coef_cc(i,j-1*dg(2),k))
           end do
        end do
     enddo
@@ -271,7 +274,7 @@ contains
     do k = lo(3),hi(3)+1*dg(3)
        do j = lo(2),hi(2)
           do i = lo(1),hi(1)
-             coefz(i,j,k) = 0.5d0 * (coef_cc(i,j,k) + coef_cc(i,j,k-1*dg(3)))
+             coefz(i,j,k) = 0.5e0_rt * (coef_cc(i,j,k) + coef_cc(i,j,k-1*dg(3)))
           end do
        end do
     enddo
@@ -296,22 +299,23 @@ contains
     use conductivity_module
     use eos_type_module
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer         , intent(in   ) :: lo(3), hi(3)
     integer         , intent(in   ) :: s_lo(3), s_hi(3)
     integer         , intent(in   ) :: cx_lo(3), cx_hi(3), cy_lo(3), cy_hi(3), cz_lo(3), cz_hi(3)
-    real (kind=dp_t), intent(in   ) :: state(s_lo(1):s_hi(1),s_lo(2):s_hi(2),s_lo(3):s_hi(3),NVAR)
-    real (kind=dp_t), intent(inout) :: coefx(cx_lo(1):cx_hi(1),cx_lo(2):cx_hi(2),cx_lo(3):cx_hi(3))
-    real (kind=dp_t), intent(inout) :: coefy(cy_lo(1):cy_hi(1),cy_lo(2):cy_hi(2),cy_lo(3):cy_hi(3))
-    real (kind=dp_t), intent(inout) :: coefz(cz_lo(1):cz_hi(1),cz_lo(2):cz_hi(2),cz_lo(3):cz_hi(3))
+    real(rt)        , intent(in   ) :: state(s_lo(1):s_hi(1),s_lo(2):s_hi(2),s_lo(3):s_hi(3),NVAR)
+    real(rt)        , intent(inout) :: coefx(cx_lo(1):cx_hi(1),cx_lo(2):cx_hi(2),cx_lo(3):cx_hi(3))
+    real(rt)        , intent(inout) :: coefy(cy_lo(1):cy_hi(1),cy_lo(2):cy_hi(2),cy_lo(3):cy_hi(3))
+    real(rt)        , intent(inout) :: coefz(cz_lo(1):cz_hi(1),cz_lo(2):cz_hi(2),cz_lo(3):cz_hi(3))
 
     ! local variables
     integer          :: i, j, k
-    double precision :: coef_cc(lo(1)-1:hi(1)+1,lo(2)-1:hi(2)+1,lo(3)-1:hi(3)+1)
+    real(rt)         :: coef_cc(lo(1)-1:hi(1)+1,lo(2)-1:hi(2)+1,lo(3)-1:hi(3)+1)
 
     type (eos_t) :: eos_state
-    double precision :: cond
+    real(rt)         :: cond
 
     ! fill the cell-centered conductivity
 
@@ -348,7 +352,7 @@ contains
     do k = lo(3),hi(3)
        do j = lo(2),hi(2)
           do i = lo(1),hi(1)+1*dg(1)
-             coefx(i,j,k) = 0.5d0 * (coef_cc(i,j,k) + coef_cc(i-1*dg(1),j,k))
+             coefx(i,j,k) = 0.5e0_rt * (coef_cc(i,j,k) + coef_cc(i-1*dg(1),j,k))
           end do
        end do
     enddo
@@ -356,7 +360,7 @@ contains
     do k = lo(3),hi(3)
        do j = lo(2),hi(2)+1*dg(2)
           do i = lo(1),hi(1)
-             coefy(i,j,k) = 0.5d0 * (coef_cc(i,j,k) + coef_cc(i,j-1*dg(2),k))
+             coefy(i,j,k) = 0.5e0_rt * (coef_cc(i,j,k) + coef_cc(i,j-1*dg(2),k))
           end do
        end do
     enddo
@@ -364,7 +368,7 @@ contains
     do k = lo(3),hi(3)+1*dg(3)
        do j = lo(2),hi(2)
           do i = lo(1),hi(1)
-             coefz(i,j,k) = 0.5d0 * (coef_cc(i,j,k) + coef_cc(i,j,k-1*dg(3)))
+             coefz(i,j,k) = 0.5e0_rt * (coef_cc(i,j,k) + coef_cc(i,j,k-1*dg(3)))
           end do
        end do
     enddo
@@ -389,22 +393,23 @@ contains
     use conductivity_module
     use eos_type_module
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer         , intent(in   ) :: lo(3), hi(3)
     integer         , intent(in   ) :: s_lo(3), s_hi(3)
     integer         , intent(in   ) :: cx_lo(3), cx_hi(3), cy_lo(3), cy_hi(3), cz_lo(3), cz_hi(3)
-    real (kind=dp_t), intent(in   ) :: state(s_lo(1):s_hi(1),s_lo(2):s_hi(2),s_lo(3):s_hi(3),NVAR)
-    real (kind=dp_t), intent(inout) :: coefx(cx_lo(1):cx_hi(1),cx_lo(2):cx_hi(2),cx_lo(3):cx_hi(3))
-    real (kind=dp_t), intent(inout) :: coefy(cy_lo(1):cy_hi(1),cy_lo(2):cy_hi(2),cy_lo(3):cy_hi(3))
-    real (kind=dp_t), intent(inout) :: coefz(cz_lo(1):cz_hi(1),cz_lo(2):cz_hi(2),cz_lo(3):cz_hi(3))
+    real(rt)        , intent(in   ) :: state(s_lo(1):s_hi(1),s_lo(2):s_hi(2),s_lo(3):s_hi(3),NVAR)
+    real(rt)        , intent(inout) :: coefx(cx_lo(1):cx_hi(1),cx_lo(2):cx_hi(2),cx_lo(3):cx_hi(3))
+    real(rt)        , intent(inout) :: coefy(cy_lo(1):cy_hi(1),cy_lo(2):cy_hi(2),cy_lo(3):cy_hi(3))
+    real(rt)        , intent(inout) :: coefz(cz_lo(1):cz_hi(1),cz_lo(2):cz_hi(2),cz_lo(3):cz_hi(3))
 
     ! local variables
     integer          :: i, j, k
-    double precision :: coef_cc(lo(1)-1:hi(1)+1,lo(2)-1:hi(2)+1,lo(3)-1:hi(3)+1)
+    real(rt)         :: coef_cc(lo(1)-1:hi(1)+1,lo(2)-1:hi(2)+1,lo(3)-1:hi(3)+1)
 
     type (eos_t) :: eos_state
-    double precision :: cond
+    real(rt)         :: cond
 
     ! fill the cell-centered conductivity
 
@@ -435,7 +440,7 @@ contains
     do k = lo(3),hi(3)
        do j = lo(2),hi(2)
           do i = lo(1),hi(1)+1*dg(1)
-             coefx(i,j,k) = 0.5d0 * (coef_cc(i,j,k) + coef_cc(i-1*dg(1),j,k))
+             coefx(i,j,k) = 0.5e0_rt * (coef_cc(i,j,k) + coef_cc(i-1*dg(1),j,k))
           end do
        end do
     enddo
@@ -443,7 +448,7 @@ contains
     do k = lo(3),hi(3)
        do j = lo(2),hi(2)+1*dg(2)
           do i = lo(1),hi(1)
-             coefy(i,j,k) = 0.5d0 * (coef_cc(i,j,k) + coef_cc(i,j-1*dg(2),k))
+             coefy(i,j,k) = 0.5e0_rt * (coef_cc(i,j,k) + coef_cc(i,j-1*dg(2),k))
           end do
        end do
     enddo
@@ -451,7 +456,7 @@ contains
     do k = lo(3),hi(3)+1*dg(3)
        do j = lo(2),hi(2)
           do i = lo(1),hi(1)
-             coefz(i,j,k) = 0.5d0 * (coef_cc(i,j,k) + coef_cc(i,j,k-1*dg(3)))
+             coefz(i,j,k) = 0.5e0_rt * (coef_cc(i,j,k) + coef_cc(i,j,k-1*dg(3)))
           end do
        end do
     enddo
@@ -475,22 +480,23 @@ contains
     use viscosity_module
     use eos_type_module
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer         , intent(in   ) :: lo(3), hi(3)
     integer         , intent(in   ) :: s_lo(3), s_hi(3)
     integer         , intent(in   ) :: cx_lo(3), cx_hi(3), cy_lo(3), cy_hi(3), cz_lo(3), cz_hi(3)
-    real (kind=dp_t), intent(in   ) :: state(s_lo(1):s_hi(1),s_lo(2):s_hi(2),s_lo(3):s_hi(3),NVAR)
-    real (kind=dp_t), intent(inout) :: coefx(cx_lo(1):cx_hi(1),cx_lo(2):cx_hi(2),cx_lo(3):cx_hi(3))
-    real (kind=dp_t), intent(inout) :: coefy(cy_lo(1):cy_hi(1),cy_lo(2):cy_hi(2),cy_lo(3):cy_hi(3))
-    real (kind=dp_t), intent(inout) :: coefz(cz_lo(1):cz_hi(1),cz_lo(2):cz_hi(2),cz_lo(3):cz_hi(3))
+    real(rt)        , intent(in   ) :: state(s_lo(1):s_hi(1),s_lo(2):s_hi(2),s_lo(3):s_hi(3),NVAR)
+    real(rt)        , intent(inout) :: coefx(cx_lo(1):cx_hi(1),cx_lo(2):cx_hi(2),cx_lo(3):cx_hi(3))
+    real(rt)        , intent(inout) :: coefy(cy_lo(1):cy_hi(1),cy_lo(2):cy_hi(2),cy_lo(3):cy_hi(3))
+    real(rt)        , intent(inout) :: coefz(cz_lo(1):cz_hi(1),cz_lo(2):cz_hi(2),cz_lo(3):cz_hi(3))
 
     ! local variables
     integer          :: i, j, k
-    double precision :: coef_cc(lo(1)-1:hi(1)+1,lo(2)-1:hi(2)+1,lo(3)-1:hi(3)+1)
+    real(rt)         :: coef_cc(lo(1)-1:hi(1)+1,lo(2)-1:hi(2)+1,lo(3)-1:hi(3)+1)
 
     type (eos_t) :: eos_state
-    double precision :: coeff
+    real(rt)         :: coeff
 
     ! fill the cell-centered viscous coefficient
 
@@ -507,7 +513,7 @@ contains
              else
                 coeff = ZERO
              endif
-             coef_cc(i,j,k) = 2.d0 * coeff
+             coef_cc(i,j,k) = 2.e0_rt * coeff
           enddo
        enddo
     enddo
@@ -516,7 +522,7 @@ contains
     do k = lo(3),hi(3)
        do j = lo(2),hi(2)
           do i = lo(1),hi(1)+1*dg(1)
-             coefx(i,j,k) = 0.5d0 * (coef_cc(i,j,k) + coef_cc(i-1*dg(1),j,k))
+             coefx(i,j,k) = 0.5e0_rt * (coef_cc(i,j,k) + coef_cc(i-1*dg(1),j,k))
           end do
        end do
     enddo
@@ -524,7 +530,7 @@ contains
     do k = lo(3),hi(3)
        do j = lo(2),hi(2)+1*dg(2)
           do i = lo(1),hi(1)
-             coefy(i,j,k) = 0.5d0 * (coef_cc(i,j,k) + coef_cc(i,j-1*dg(2),k))
+             coefy(i,j,k) = 0.5e0_rt * (coef_cc(i,j,k) + coef_cc(i,j-1*dg(2),k))
           end do
        end do
     enddo
@@ -532,7 +538,7 @@ contains
     do k = lo(3),hi(3)+1*dg(3)
        do j = lo(2),hi(2)
           do i = lo(1),hi(1)
-             coefz(i,j,k) = 0.5d0 * (coef_cc(i,j,k) + coef_cc(i,j,k-1*dg(3)))
+             coefz(i,j,k) = 0.5e0_rt * (coef_cc(i,j,k) + coef_cc(i,j,k-1*dg(3)))
           end do
        end do
     enddo
@@ -554,25 +560,26 @@ contains
     use viscosity_module
     use eos_type_module
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer         , intent(in   ) :: lo(3), hi(3)
     integer         , intent(in   ) :: s_lo(3), s_hi(3)
     integer         , intent(in   ) :: cx_lo(3), cx_hi(3), cy_lo(3), cy_hi(3), cz_lo(3), cz_hi(3)
-    real (kind=dp_t), intent(in   ) :: state(s_lo(1):s_hi(1),s_lo(2):s_hi(2),s_lo(3):s_hi(3),NVAR)
-    real (kind=dp_t), intent(inout) :: coefx(cx_lo(1):cx_hi(1),cx_lo(2):cx_hi(2),cx_lo(3):cx_hi(3))
-    real (kind=dp_t), intent(inout) :: coefy(cy_lo(1):cy_hi(1),cy_lo(2):cy_hi(2),cy_lo(3):cy_hi(3))
-    real (kind=dp_t), intent(inout) :: coefz(cz_lo(1):cz_hi(1),cz_lo(2):cz_hi(2),cz_lo(3):cz_hi(3))
+    real(rt)        , intent(in   ) :: state(s_lo(1):s_hi(1),s_lo(2):s_hi(2),s_lo(3):s_hi(3),NVAR)
+    real(rt)        , intent(inout) :: coefx(cx_lo(1):cx_hi(1),cx_lo(2):cx_hi(2),cx_lo(3):cx_hi(3))
+    real(rt)        , intent(inout) :: coefy(cy_lo(1):cy_hi(1),cy_lo(2):cy_hi(2),cy_lo(3):cy_hi(3))
+    real(rt)        , intent(inout) :: coefz(cz_lo(1):cz_hi(1),cz_lo(2):cz_hi(2),cz_lo(3):cz_hi(3))
 
     ! local variables
     integer          :: i, j, k
-    double precision :: coef_cc(lo(1)-1:hi(1)+1,lo(2)-1:hi(2)+1,lo(3)-1:hi(3)+1)
+    real(rt)         :: coef_cc(lo(1)-1:hi(1)+1,lo(2)-1:hi(2)+1,lo(3)-1:hi(3)+1)
 
     type (eos_t) :: eos_state
-    double precision :: bulk_visc, mu, twothirds
+    real(rt)         :: bulk_visc, mu, twothirds
 
-    bulk_visc = 0.d0
-    twothirds = 2.d0 / 3.d0
+    bulk_visc = 0.e0_rt
+    twothirds = 2.e0_rt / 3.e0_rt
 
     ! fill the cell-centered viscous coefficient
 
@@ -601,7 +608,7 @@ contains
     do k = lo(3),hi(3)
        do j = lo(2),hi(2)
           do i = lo(1),hi(1)+1*dg(1)
-             coefx(i,j,k) = 0.5d0 * (coef_cc(i,j,k) + coef_cc(i-1*dg(1),j,k))
+             coefx(i,j,k) = 0.5e0_rt * (coef_cc(i,j,k) + coef_cc(i-1*dg(1),j,k))
           end do
        end do
     enddo
@@ -609,7 +616,7 @@ contains
     do k = lo(3),hi(3)
        do j = lo(2),hi(2)+1*dg(2)
           do i = lo(1),hi(1)
-             coefy(i,j,k) = 0.5d0 * (coef_cc(i,j,k) + coef_cc(i,j-1*dg(2),k))
+             coefy(i,j,k) = 0.5e0_rt * (coef_cc(i,j,k) + coef_cc(i,j-1*dg(2),k))
           end do
        end do
     enddo
@@ -617,7 +624,7 @@ contains
     do k = lo(3),hi(3)+1*dg(3)
        do j = lo(2),hi(2)
           do i = lo(1),hi(1)
-             coefz(i,j,k) = 0.5d0 * (coef_cc(i,j,k) + coef_cc(i,j,k-1*dg(3)))
+             coefz(i,j,k) = 0.5e0_rt * (coef_cc(i,j,k) + coef_cc(i,j,k-1*dg(3)))
           end do
        end do
     enddo
@@ -636,31 +643,32 @@ contains
     use viscosity_module
     use eos_type_module
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer         , intent(in   ) ::   lo(3),   hi(3)
     integer         , intent(in   ) :: d_lo(3), d_hi(3)
     integer         , intent(in   ) :: s_lo(3), s_hi(3)
-    real (kind=dp_t), intent(  out) :: div_tau_u(d_lo(1):d_hi(1),d_lo(2):d_hi(2),d_lo(3):d_hi(3))
-    real (kind=dp_t), intent(in   ) :: state    (s_lo(1):s_hi(1),s_lo(2):s_hi(2),s_lo(3):s_hi(3),NVAR)
-    real (kind=dp_t), intent(in   ) :: dx(3)
+    real(rt)        , intent(  out) :: div_tau_u(d_lo(1):d_hi(1),d_lo(2):d_hi(2),d_lo(3):d_hi(3))
+    real(rt)        , intent(in   ) :: state    (s_lo(1):s_hi(1),s_lo(2):s_hi(2),s_lo(3):s_hi(3),NVAR)
+    real(rt)        , intent(in   ) :: dx(3)
     integer         , intent(in   ) :: coord_type
 
     ! local variables
-    real (kind=dp_t) :: twothirds
+    real(rt)         :: twothirds
     type (eos_t)     :: eos_state
 
     ! These are cell-centered
-    real (kind=dp_t) :: rm,rc,rp,vm,vc,vp,mu_temp
-    real (kind=dp_t), allocatable :: mu(:), kappa(:)
+    real(rt)         :: rm,rc,rp,vm,vc,vp,mu_temp
+    real(rt)        , allocatable :: mu(:), kappa(:)
 
     ! These are edge-centered
-    real (kind=dp_t) :: mu_em, kap_em, tau1m, tau2m, x_em, v_em
-    real (kind=dp_t) :: mu_ep, kap_ep, tau1p, tau2p, x_ep, v_ep
+    real(rt)         :: mu_em, kap_em, tau1m, tau2m, x_em, v_em
+    real(rt)         :: mu_ep, kap_ep, tau1p, tau2p, x_ep, v_ep
 
     integer          :: i, j, k, imin
 
-    twothirds = 2.d0 / 3.d0
+    twothirds = 2.e0_rt / 3.e0_rt
 
     allocate(   mu(lo(1)-2:hi(1)+2))
     allocate(kappa(lo(1)-2:hi(1)+2))
@@ -681,7 +689,7 @@ contains
        call viscous_coeff(eos_state, mu_temp)
        mu(i) = mu_temp
 
-       kappa(i) = 0.d0
+       kappa(i) = 0.e0_rt
     end do
 
     imin = max(lo(1)-1,0)
@@ -691,9 +699,9 @@ contains
        do i = imin,hi(1)+1
 
           ! These are cell-centered
-          rm = (dble(i)-0.5d0) * dx(1)
-          rc = (dble(i)+0.5d0) * dx(1)
-          rp = (dble(i)+1.5d0) * dx(1)
+          rm = (dble(i)-0.5e0_rt) * dx(1)
+          rc = (dble(i)+0.5e0_rt) * dx(1)
+          rp = (dble(i)+1.5e0_rt) * dx(1)
 
           ! These are cell-centered
           vp = state(i+1,j,k,UMX)/state(i+1,j,k,URHO)
@@ -701,16 +709,16 @@ contains
           vm = state(i-1,j,k,UMX)/state(i-1,j,k,URHO)
 
           ! These are edge-centered
-          mu_em = (mu(i-1)+mu(i)) * 0.5d0
-          mu_ep = (mu(i+1)+mu(i)) * 0.5d0
+          mu_em = (mu(i-1)+mu(i)) * 0.5e0_rt
+          mu_ep = (mu(i+1)+mu(i)) * 0.5e0_rt
 
           ! These are edge-centered
-          kap_em = (kappa(i-1)+kappa(i)) * 0.5d0
-          kap_ep = (kappa(i+1)+kappa(i)) * 0.5d0
+          kap_em = (kappa(i-1)+kappa(i)) * 0.5e0_rt
+          kap_ep = (kappa(i+1)+kappa(i)) * 0.5e0_rt
 
           ! These are edge-centered
-          tau1p = 2.d0 * mu_ep * (vp - vc) /dx(1)
-          tau1m = 2.d0 * mu_em * (vc - vm) /dx(1)
+          tau1p = 2.e0_rt * mu_ep * (vp - vc) /dx(1)
+          tau1m = 2.e0_rt * mu_em * (vc - vm) /dx(1)
 
           ! These are edge-centered
           tau2p = (kap_ep - twothirds*mu_ep) * (rp**2*vp - rc**2* vc) /dx(1)
@@ -721,8 +729,8 @@ contains
           x_em = dble(i  )*dx(1)
 
           ! These are edge-centered
-          v_ep = (vc + vp) * 0.5d0
-          v_em = (vc + vm) * 0.5d0
+          v_ep = (vc + vp) * 0.5e0_rt
+          v_em = (vc + vm) * 0.5e0_rt
 
           div_tau_u(i,j,k) = ( (x_ep**2*tau1p*v_ep) - (x_em**2*tau1m*v_em) &
                +(tau2p*v_ep)-(tau2m*v_em) ) / (rc**2 * dx(1))

--- a/Source/Src_nd/Enthalpy_nd.f90
+++ b/Source/Src_nd/Enthalpy_nd.f90
@@ -1,5 +1,6 @@
 module enthalpy_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   public
@@ -19,13 +20,14 @@ contains
     use conductivity_module
     use eos_type_module
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer         , intent(in   ) :: lo(3), hi(3)
     integer         , intent(in   ) :: s_lo(3), s_hi(3)
     integer         , intent(in   ) :: e_lo(3), e_hi(3)
-    real (kind=dp_t), intent(in   ) :: state(s_lo(1):s_hi(1),s_lo(2):s_hi(2),s_lo(3):s_hi(3),NVAR)
-    real (kind=dp_t), intent(inout) ::  enth(e_lo(1):e_hi(1),e_lo(2):e_hi(2),e_lo(3):e_hi(3))
+    real(rt)        , intent(in   ) :: state(s_lo(1):s_hi(1),s_lo(2):s_hi(2),s_lo(3):s_hi(3),NVAR)
+    real(rt)        , intent(inout) ::  enth(e_lo(1):e_hi(1),e_lo(2):e_hi(2),e_lo(3):e_hi(3))
 
     ! local variables
     integer          :: i, j, k

--- a/Source/Src_nd/Gravity_nd.f90
+++ b/Source/Src_nd/Gravity_nd.f90
@@ -1,19 +1,20 @@
 module gravity_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   public
 
   ! Data for the multipole gravity
 
-  double precision, save :: volumeFactor, parityFactor
-  double precision, save :: edgeTolerance = 1.0d-2
-  double precision, save :: rmax
+  real(rt)        , save :: volumeFactor, parityFactor
+  real(rt)        , save :: edgeTolerance = 1.0e-2_rt
+  real(rt)        , save :: rmax
   logical,          save :: doSymmetricAddLo(3), doSymmetricAddHi(3), doSymmetricAdd
   logical,          save :: doReflectionLo(3), doReflectionHi(3)
   integer,          save :: lnum_max
-  double precision, allocatable, save :: factArray(:,:)
-  double precision, allocatable, save :: parity_q0(:), parity_qC_qS(:,:)
+  real(rt)        , allocatable, save :: factArray(:,:)
+  real(rt)        , allocatable, save :: parity_q0(:), parity_qC_qS(:,:)
 
 contains
   
@@ -27,7 +28,8 @@ contains
 
     use fundamental_constants_module, only: Gconst
 
-    double precision :: Gconst_out
+    use bl_fort_module, only : rt => c_real
+    real(rt)         :: Gconst_out
 
     Gconst_out = Gconst
 
@@ -51,29 +53,30 @@ contains
     use fundamental_constants_module, only : Gconst
     use bl_constants_module
 
+    use bl_fort_module, only : rt => c_real
     implicit none
     integer          :: numpts_1d
-    double precision :: mass(0:numpts_1d-1)
-    double precision ::  den(0:numpts_1d-1)
-    double precision :: grav(0:numpts_1d-1)
-    double precision :: max_radius,dr
+    real(rt)         :: mass(0:numpts_1d-1)
+    real(rt)         ::  den(0:numpts_1d-1)
+    real(rt)         :: grav(0:numpts_1d-1)
+    real(rt)         :: max_radius,dr
 
     integer          :: i
-    double precision :: rc,rlo,rhi,halfdr
-    double precision :: mass_encl
-    double precision :: vol_inner_shell, vol_outer_shell
-    double precision :: vol_lower_shell, vol_upper_shell
-    double precision :: vol_total_im1, vol_total_i
+    real(rt)         :: rc,rlo,rhi,halfdr
+    real(rt)         :: mass_encl
+    real(rt)         :: vol_inner_shell, vol_outer_shell
+    real(rt)         :: vol_lower_shell, vol_upper_shell
+    real(rt)         :: vol_total_im1, vol_total_i
 
-    double precision, parameter ::  fourthirdspi = 4.d0 * M_PI / 3.d0
+    real(rt)        , parameter ::  fourthirdspi = 4.e0_rt * M_PI / 3.e0_rt
 
-    halfdr = 0.5d0 * dr
+    halfdr = 0.5e0_rt * dr
 
-    mass_encl = 0.d0
+    mass_encl = 0.e0_rt
     do i = 0,numpts_1d-1
        rlo = (dble(i)      ) * dr
-       rc  = (dble(i)+0.5d0) * dr
-       rhi = (dble(i)+1.0d0) * dr
+       rc  = (dble(i)+0.5e0_rt) * dr
+       rhi = (dble(i)+1.0e0_rt) * dr
 
        if (i.eq.0) then
 
@@ -159,19 +162,20 @@ contains
 
     use fundamental_constants_module, only : Gconst
 
+    use bl_fort_module, only : rt => c_real
     implicit none
     integer          :: numpts_1d
-    double precision :: mass(0:numpts_1d-1)
-    double precision :: grav(0:numpts_1d-1)
-    double precision :: phi(0:numpts_1d-1)
-    double precision :: dr
-    double precision :: gravBC, phiBC
+    real(rt)         :: mass(0:numpts_1d-1)
+    real(rt)         :: grav(0:numpts_1d-1)
+    real(rt)         :: phi(0:numpts_1d-1)
+    real(rt)         :: dr
+    real(rt)         :: gravBC, phiBC
 
     integer          :: i
-    double precision :: mass_encl,rhi
+    real(rt)         :: mass_encl,rhi
 
-    mass_encl = 0.d0
-    grav(0)   = 0.d0
+    mass_encl = 0.e0_rt
+    grav(0)   = 0.e0_rt
     do i = 1,numpts_1d-1
        rhi = dble(i) * dr
        mass_encl = mass_encl + mass(i-1)
@@ -205,32 +209,33 @@ contains
     use fundamental_constants_module, only : Gconst, c_light
     use bl_constants_module
 
+    use bl_fort_module, only : rt => c_real
     implicit none
     integer          :: numpts_1d
-    double precision ::  rho(0:numpts_1d-1)
-    double precision :: mass(0:numpts_1d-1)
-    double precision :: pres(0:numpts_1d-1)
-    double precision :: grav(0:numpts_1d-1)
-    double precision :: dr
+    real(rt)         ::  rho(0:numpts_1d-1)
+    real(rt)         :: mass(0:numpts_1d-1)
+    real(rt)         :: pres(0:numpts_1d-1)
+    real(rt)         :: grav(0:numpts_1d-1)
+    real(rt)         :: dr
 
     integer          :: i
-    double precision :: mass_encl,rc,rlo,rhi,halfdr
-    double precision :: ga, gb, gc, P,R
-    double precision :: vol_inner_shell, vol_outer_shell
-    double precision :: vol_lower_shell, vol_upper_shell
-    double precision :: vol_total_im1, vol_total_i
+    real(rt)         :: mass_encl,rc,rlo,rhi,halfdr
+    real(rt)         :: ga, gb, gc, P,R
+    real(rt)         :: vol_inner_shell, vol_outer_shell
+    real(rt)         :: vol_lower_shell, vol_upper_shell
+    real(rt)         :: vol_total_im1, vol_total_i
 
-    double precision, parameter ::  fourpi       = 4.d0 * M_PI
-    double precision, parameter ::  fourthirdspi = 4.d0 * M_PI / 3.d0
-    double precision, parameter ::  sqvc         = c_light**2
+    real(rt)        , parameter ::  fourpi       = 4.e0_rt * M_PI
+    real(rt)        , parameter ::  fourthirdspi = 4.e0_rt * M_PI / 3.e0_rt
+    real(rt)        , parameter ::  sqvc         = c_light**2
 
-    halfdr = 0.5d0 * dr
+    halfdr = 0.5e0_rt * dr
 
-    mass_encl = 0.d0
+    mass_encl = 0.e0_rt
     do i = 0,numpts_1d-1
        rlo = (dble(i)      ) * dr
-       rc  = (dble(i)+0.5d0) * dr
-       rhi = (dble(i)+1.0d0) * dr
+       rc  = (dble(i)+0.5e0_rt) * dr
+       rhi = (dble(i)+1.0e0_rt) * dr
 
        if (i.eq.0) then
 
@@ -265,12 +270,12 @@ contains
 
        !!       Tolman-Oppenheimer-Volkoff(TOV) case
 
-       if (rho(i) .gt. 0.d0) then
+       if (rho(i) .gt. 0.e0_rt) then
           P =  pres(i)
           R =  rho(i)
-          ga = (1.d0 + P/(R*sqvc))
-          gb = (1.d0 + fourpi * rc**3 * P / (mass_encl*sqvc))
-          gc = 1.d0 / (1.d0 - 2.d0 * Gconst * mass_encl / (rc*sqvc))
+          ga = (1.e0_rt + P/(R*sqvc))
+          gb = (1.e0_rt + fourpi * rc**3 * P / (mass_encl*sqvc))
+          gc = 1.e0_rt / (1.e0_rt - 2.e0_rt * Gconst * mass_encl / (rc*sqvc))
 
           print *, i, grav(i), ga, gb, gc
 
@@ -294,6 +299,7 @@ contains
     use bl_constants_module
     use prob_params_module, only: coord_type, Symmetry, problo, probhi, center, dim
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer :: lnum, lo_bc(3), hi_bc(3)
@@ -400,12 +406,12 @@ contains
     enddo
 
     ! Now let's take care of a safety issue. The multipole calculation involves taking powers of r^l,
-    ! which can overflow the double precision exponent limit if lnum is very large. Therefore,
+    ! which can overflow the real(rt)         exponent limit if lnum is very large. Therefore,
     ! we will normalize all distances to the maximum possible physical distance from the center,
     ! which is the diagonal from the center to the edge of the box. Then r^l will always be
     ! less than or equal to one. For large enough lnum, this may still result in roundoff
     ! errors that don't make your answer any more precise, but at least it avoids
-    ! possible NaN issues from having numbers that are too large for double precision.
+    ! possible NaN issues from having numbers that are too large for real(rt)        .
     ! We will put the rmax factor back in at the end of ca_put_multipole_phi.
 
     rmax = HALF * maxval(probhi(1:dim) - problo(1:dim)) * sqrt(dble(dim))
@@ -424,24 +430,25 @@ contains
     use fundamental_constants_module, only: Gconst
     use bl_constants_module
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer          :: lo(3), hi(3)
     integer          :: domlo(3), domhi(3)
-    double precision :: dx(3)
+    real(rt)         :: dx(3)
 
     integer          :: lnum, npts, boundary_only
-    double precision :: qL0(0:lnum,0:npts-1), qLC(0:lnum,0:lnum,0:npts-1), qLS(0:lnum,0:lnum,0:npts-1)
-    double precision :: qU0(0:lnum,0:npts-1), qUC(0:lnum,0:lnum,0:npts-1), qUS(0:lnum,0:lnum,0:npts-1)
+    real(rt)         :: qL0(0:lnum,0:npts-1), qLC(0:lnum,0:lnum,0:npts-1), qLS(0:lnum,0:lnum,0:npts-1)
+    real(rt)         :: qU0(0:lnum,0:npts-1), qUC(0:lnum,0:lnum,0:npts-1), qUS(0:lnum,0:lnum,0:npts-1)
 
     integer          :: p_lo(3), p_hi(3)
-    double precision :: phi(p_lo(1):p_hi(1),p_lo(2):p_hi(2),p_lo(3):p_hi(3))
+    real(rt)         :: phi(p_lo(1):p_hi(1),p_lo(2):p_hi(2),p_lo(3):p_hi(3))
 
     integer          :: i, j, k
     integer          :: l, m, n, nlo
-    double precision :: x, y, z, r, cosTheta, phiAngle
-    double precision :: legPolyArr(0:lnum), assocLegPolyArr(0:lnum,0:lnum)
-    double precision :: r_L, r_U
+    real(rt)         :: x, y, z, r, cosTheta, phiAngle
+    real(rt)         :: legPolyArr(0:lnum), assocLegPolyArr(0:lnum,0:lnum)
+    real(rt)         :: r_L, r_U
 
     ! If we're using this to construct boundary values, then only use
     ! the outermost bin.
@@ -502,7 +509,7 @@ contains
 
                 r = sqrt( x**2 + y**2 + z**2 )
 
-                if ( r < 1.0d-12 ) then
+                if ( r < 1.0e-12_rt ) then
                    phi(i,j,k) = ZERO
                    cycle
                 endif
@@ -573,25 +580,26 @@ contains
     use prob_params_module, only: problo, center, probhi, dim, coord_type
     use bl_constants_module
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer          :: lo(3),hi(3)
     integer          :: domlo(3),domhi(3)
-    double precision :: dx(3)
+    real(rt)         :: dx(3)
     integer          :: boundary_only, npts, lnum
 
-    double precision :: qL0(0:lnum,0:npts-1), qLC(0:lnum,0:lnum,0:npts-1), qLS(0:lnum,0:lnum,0:npts-1)
-    double precision :: qU0(0:lnum,0:npts-1), qUC(0:lnum,0:lnum,0:npts-1), qUS(0:lnum,0:lnum,0:npts-1)
+    real(rt)         :: qL0(0:lnum,0:npts-1), qLC(0:lnum,0:lnum,0:npts-1), qLS(0:lnum,0:lnum,0:npts-1)
+    real(rt)         :: qU0(0:lnum,0:npts-1), qUC(0:lnum,0:lnum,0:npts-1), qUS(0:lnum,0:lnum,0:npts-1)
 
     integer          :: r_lo(3), r_hi(3)
     integer          :: v_lo(3), v_hi(3)
-    double precision :: rho(r_lo(1):r_hi(1),r_lo(2):r_hi(2),r_lo(3):r_hi(3))
-    double precision :: vol(v_lo(1):v_hi(1),v_lo(2):v_hi(2),v_lo(3):v_hi(3))
+    real(rt)         :: rho(r_lo(1):r_hi(1),r_lo(2):r_hi(2),r_lo(3):r_hi(3))
+    real(rt)         :: vol(v_lo(1):v_hi(1),v_lo(2):v_hi(2),v_lo(3):v_hi(3))
 
     integer          :: i, j, k
     integer          :: nlo, index
 
-    double precision :: x, y, z, r, drInv, cosTheta, phiAngle
+    real(rt)         :: x, y, z, r, drInv, cosTheta, phiAngle
 
     ! If we're using this to construct boundary values, then only fill
     ! the outermost bin.
@@ -663,10 +671,11 @@ contains
 
     use bl_constants_module
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer :: n, i
-    double precision :: factorial
+    real(rt)         :: factorial
 
     factorial = ONE
 
@@ -682,12 +691,13 @@ contains
 
     use bl_constants_module
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer :: lnum
     integer :: l, m, n
-    double precision :: x
-    double precision :: legPolyArr(0:lnum), assocLegPolyArr(0:lnum,0:lnum)
+    real(rt)         :: x
+    real(rt)         :: legPolyArr(0:lnum), assocLegPolyArr(0:lnum,0:lnum)
 
     legPolyArr(:)        = ZERO
     assocLegPolyArr(:,:) = ZERO
@@ -771,23 +781,24 @@ contains
     use prob_params_module, only: center
     use bl_constants_module
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer,          intent(in) :: lnum, npts, nlo, index
-    double precision, intent(in) :: x, y, z
-    double precision, intent(in) :: problo(3), probhi(3)
-    double precision, intent(in) :: rho, vol
+    real(rt)        , intent(in) :: x, y, z
+    real(rt)        , intent(in) :: problo(3), probhi(3)
+    real(rt)        , intent(in) :: rho, vol
 
     logical,          intent(in) :: doSymmetricAddLo(3), doSymmetricAddHi(3)
 
-    double precision, intent(inout) :: qL0(0:lnum,0:npts-1)
-    double precision, intent(inout) :: qLC(0:lnum,0:lnum,0:npts-1), qLS(0:lnum,0:lnum,0:npts-1)
+    real(rt)        , intent(inout) :: qL0(0:lnum,0:npts-1)
+    real(rt)        , intent(inout) :: qLC(0:lnum,0:lnum,0:npts-1), qLS(0:lnum,0:lnum,0:npts-1)
 
-    double precision, intent(inout) :: qU0(0:lnum,0:npts-1)
-    double precision, intent(inout) :: qUC(0:lnum,0:lnum,0:npts-1), qUS(0:lnum,0:lnum,0:npts-1)
+    real(rt)        , intent(inout) :: qU0(0:lnum,0:npts-1)
+    real(rt)        , intent(inout) :: qUC(0:lnum,0:lnum,0:npts-1), qUS(0:lnum,0:lnum,0:npts-1)
 
-    double precision :: cosTheta, phiAngle, r
-    double precision :: xLo, yLo, zLo, xHi, yHi, zHi
+    real(rt)         :: cosTheta, phiAngle, r
+    real(rt)         :: xLo, yLo, zLo, xHi, yHi, zHi
 
     xLo = ( TWO * (problo(1) - center(1)) ) / rmax - x
     xHi = ( TWO * (probhi(1) - center(1)) ) / rmax - x
@@ -878,23 +889,24 @@ contains
 
     use bl_constants_module, only: ONE
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer,          intent(in)    :: lnum, npts, nlo, index
-    double precision, intent(in)    :: cosTheta, phiAngle, r, rho, vol
+    real(rt)        , intent(in)    :: cosTheta, phiAngle, r, rho, vol
 
-    double precision, intent(inout) :: qL0(0:lnum,0:npts-1), qLC(0:lnum,0:lnum,0:npts-1), qLS(0:lnum,0:lnum,0:npts-1)
-    double precision, intent(inout) :: qU0(0:lnum,0:npts-1), qUC(0:lnum,0:lnum,0:npts-1), qUS(0:lnum,0:lnum,0:npts-1)
+    real(rt)        , intent(inout) :: qL0(0:lnum,0:npts-1), qLC(0:lnum,0:lnum,0:npts-1), qLS(0:lnum,0:lnum,0:npts-1)
+    real(rt)        , intent(inout) :: qU0(0:lnum,0:npts-1), qUC(0:lnum,0:lnum,0:npts-1), qUS(0:lnum,0:lnum,0:npts-1)
 
     logical, optional, intent(in)   :: do_parity
 
     integer :: l, m, n
 
-    double precision :: legPolyArr(0:lnum), assocLegPolyArr(0:lnum,0:lnum)
+    real(rt)         :: legPolyArr(0:lnum), assocLegPolyArr(0:lnum,0:lnum)
 
-    double precision :: rho_r_L, rho_r_U
+    real(rt)         :: rho_r_L, rho_r_U
 
-    double precision :: p0(0:lnum), pCS(0:lnum,0:lnum)
+    real(rt)         :: p0(0:lnum), pCS(0:lnum,0:lnum)
 
     call fill_legendre_arrays(legPolyArr, assocLegPolyArr, cosTheta, lnum)
 

--- a/Source/Src_nd/Prob_nd.F90
+++ b/Source/Src_nd/Prob_nd.F90
@@ -1,10 +1,11 @@
 subroutine PROBINIT (init,name,namlen,problo,probhi)
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer          :: init, namlen
   integer          :: name(namlen)
-  double precision :: problo(3), probhi(3)
+  real(rt)         :: problo(3), probhi(3)
 
 end subroutine PROBINIT
 
@@ -36,13 +37,14 @@ subroutine ca_initdata(level,time,lo,hi,nvar, &
 
   use bl_error_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer :: level, nvar
   integer :: lo(3), hi(3)
   integer :: state_lo(3), state_hi(3)
-  double precision :: xlo(3), xhi(3), time, dx(3)
-  double precision :: state(state_lo(1):state_hi(1), &
+  real(rt)         :: xlo(3), xhi(3), time, dx(3)
+  real(rt)         :: state(state_lo(1):state_hi(1), &
                             state_lo(2):state_hi(2), &
                             state_lo(3):state_hi(3),nvar)
 

--- a/Source/Src_nd/Problem.f90
+++ b/Source/Src_nd/Problem.f90
@@ -4,6 +4,7 @@ subroutine problem_checkpoint(int_dir_name, len) bind(C, name="problem_checkpoin
 
   ! called by the IO processor during checkpoint
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer :: len
@@ -26,6 +27,7 @@ subroutine problem_restart(int_dir_name, len) bind(C, name="problem_restart")
 
   ! called by ALL processors during restart 
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer :: len

--- a/Source/Src_nd/React_nd.F90
+++ b/Source/Src_nd/React_nd.F90
@@ -1,5 +1,6 @@
 module reactions_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   public
@@ -33,6 +34,7 @@ contains
     use burn_type_module
     use bl_constants_module
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer          :: lo(3), hi(3)
@@ -40,14 +42,14 @@ contains
     integer          :: r_lo(3), r_hi(3)
     integer          :: w_lo(3), w_hi(3)
     integer          :: m_lo(3), m_hi(3)
-    double precision :: state(s_lo(1):s_hi(1),s_lo(2):s_hi(2),s_lo(3):s_hi(3),NVAR)
-    double precision :: reactions(r_lo(1):r_hi(1),r_lo(2):r_hi(2),r_lo(3):r_hi(3),nspec+2)
-    double precision :: weights(w_lo(1):w_hi(1),w_lo(2):w_hi(2),w_lo(3):w_hi(3))
+    real(rt)         :: state(s_lo(1):s_hi(1),s_lo(2):s_hi(2),s_lo(3):s_hi(3),NVAR)
+    real(rt)         :: reactions(r_lo(1):r_hi(1),r_lo(2):r_hi(2),r_lo(3):r_hi(3),nspec+2)
+    real(rt)         :: weights(w_lo(1):w_hi(1),w_lo(2):w_hi(2),w_lo(3):w_hi(3))
     integer          :: mask(m_lo(1):m_hi(1),m_lo(2):m_hi(2),m_lo(3):m_hi(3))
-    double precision :: time, dt_react
+    real(rt)         :: time, dt_react
 
     integer          :: i, j, k, n
-    double precision :: rhoInv, rho_e_K, delta_e, delta_rho_e, dx_min
+    real(rt)         :: rhoInv, rho_e_K, delta_e, delta_rho_e, dx_min
 
     type (burn_t) :: burn_state_in, burn_state_out
     type (eos_t) :: eos_state_in, eos_state_out
@@ -224,6 +226,7 @@ contains
     use bl_constants_module, only : ZERO, HALF, ONE
     use sdc_type_module, only : sdc_t, SRHO, SMX, SMZ, SEDEN, SEINT, SFS
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer          :: lo(3), hi(3)
@@ -232,15 +235,15 @@ contains
     integer          :: as_lo(3), as_hi(3)
     integer          :: r_lo(3), r_hi(3)
     integer          :: m_lo(3), m_hi(3)
-    double precision :: uold(uo_lo(1):uo_hi(1),uo_lo(2):uo_hi(2),uo_lo(3):uo_hi(3),NVAR)
-    double precision :: unew(un_lo(1):un_hi(1),un_lo(2):un_hi(2),un_lo(3):un_hi(3),NVAR)
-    double precision :: asrc(as_lo(1):as_hi(1),as_lo(2):as_hi(2),as_lo(3):as_hi(3),NVAR)
-    double precision :: reactions(r_lo(1):r_hi(1),r_lo(2):r_hi(2),r_lo(3):r_hi(3),nspec+2)
+    real(rt)         :: uold(uo_lo(1):uo_hi(1),uo_lo(2):uo_hi(2),uo_lo(3):uo_hi(3),NVAR)
+    real(rt)         :: unew(un_lo(1):un_hi(1),un_lo(2):un_hi(2),un_lo(3):un_hi(3),NVAR)
+    real(rt)         :: asrc(as_lo(1):as_hi(1),as_lo(2):as_hi(2),as_lo(3):as_hi(3),NVAR)
+    real(rt)         :: reactions(r_lo(1):r_hi(1),r_lo(2):r_hi(2),r_lo(3):r_hi(3),nspec+2)
     integer          :: mask(m_lo(1):m_hi(1),m_lo(2):m_hi(2),m_lo(3):m_hi(3))
-    double precision :: time, dt_react
+    real(rt)         :: time, dt_react
 
     integer          :: i, j, k, n
-    double precision :: rhooInv, rhonInv, rho_e_K, delta_e, delta_rho_e
+    real(rt)         :: rhooInv, rhonInv, rho_e_K, delta_e, delta_rho_e
 
     type (sdc_t) :: burn_state_in, burn_state_out
 

--- a/Source/Src_nd/Rotation_frequency.F90
+++ b/Source/Src_nd/Rotation_frequency.F90
@@ -1,5 +1,6 @@
 module rotation_frequency_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   private
@@ -14,12 +15,13 @@ contains
     use meth_params_module, only: rot_period, rot_period_dot, rot_axis
     use bl_constants_module, only: ZERO, TWO, M_PI
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
-    double precision :: time
-    double precision :: omega(3)
+    real(rt)         :: time
+    real(rt)         :: omega(3)
 
-    double precision :: curr_period
+    real(rt)         :: curr_period
 
     ! If rot_period is less than zero, that means rotation is disabled, and so we should effectively
     ! shut off the source term by setting omega = 0. Note that by default rot_axis == 3 for Cartesian
@@ -57,12 +59,13 @@ contains
     use meth_params_module, only: rot_period, rot_period_dot, rot_axis
     use bl_constants_module, only: ZERO, TWO, M_PI
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
-    double precision :: time
-    double precision :: domegadt(3)
+    real(rt)         :: time
+    real(rt)         :: domegadt(3)
 
-    double precision :: curr_period, curr_omega(3)
+    real(rt)         :: curr_period, curr_omega(3)
 
     domegadt = ZERO
 

--- a/Source/Src_nd/Rotation_nd.f90
+++ b/Source/Src_nd/Rotation_nd.f90
@@ -5,6 +5,7 @@ module rotation_module
   use meth_params_module, only: rotation_include_centrifugal, rotation_include_coriolis, &
                                 rotation_include_domegadt
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   private
@@ -21,14 +22,15 @@ contains
     use prob_params_module, only: center
     use castro_util_module, only: position
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer, intent(in) :: idx(3)
-    double precision, intent(in   ) :: time
-    double precision, intent(inout) :: v(3)
+    real(rt)        , intent(in   ) :: time
+    real(rt)        , intent(inout) :: v(3)
     integer, intent(in), optional :: idir
 
-    double precision :: loc(3), omega(3)
+    real(rt)         :: loc(3), omega(3)
 
     if (present(idir)) then
        if (idir .eq. 1) then
@@ -63,12 +65,13 @@ contains
     use bl_constants_module, only: ZERO, TWO
     use meth_params_module, only: state_in_rotating_frame
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
-    double precision :: r(3), v(3), time
-    double precision :: Sr(3)
+    real(rt)         :: r(3), v(3), time
+    real(rt)         :: Sr(3)
 
-    double precision :: omega(3), domega_dt(3), omegacrossr(3), omegacrossv(3)
+    real(rt)         :: omega(3), domega_dt(3), omegacrossr(3), omegacrossv(3)
 
     logical, optional :: centrifugal, coriolis, domegadt
     logical :: c1, c2, c3
@@ -174,12 +177,13 @@ contains
     use bl_constants_module, only: ZERO, HALF
     use meth_params_module, only: state_in_rotating_frame, rotation_include_centrifugal
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
-    double precision :: r(3), time
-    double precision :: phi
+    real(rt)         :: r(3), time
+    real(rt)         :: phi
 
-    double precision :: omega(3), omegacrossr(3)
+    real(rt)         :: omega(3), omegacrossr(3)
 
     if (state_in_rotating_frame .eq. 1) then
 
@@ -211,16 +215,17 @@ contains
     use prob_params_module, only: problo, center
     use bl_constants_module, only: HALF
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer         , intent(in   ) :: lo(3), hi(3)
     integer         , intent(in   ) :: phi_lo(3), phi_hi(3)
 
-    double precision, intent(inout) :: phi(phi_lo(1):phi_hi(1),phi_lo(2):phi_hi(2),phi_lo(3):phi_hi(3))
-    double precision, intent(in   ) :: dx(3), time
+    real(rt)        , intent(inout) :: phi(phi_lo(1):phi_hi(1),phi_lo(2):phi_hi(2),phi_lo(3):phi_hi(3))
+    real(rt)        , intent(in   ) :: dx(3), time
 
     integer          :: i, j, k
-    double precision :: r(3)
+    real(rt)         :: r(3)
 
     do k = lo(3), hi(3)
        r(3) = problo(3) + dx(3)*(dble(k)+HALF) - center(3)
@@ -248,18 +253,19 @@ contains
     use prob_params_module, only: problo, center
     use bl_constants_module, only: HALF
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer         , intent(in   ) :: lo(3), hi(3)
     integer         , intent(in   ) :: rot_lo(3), rot_hi(3)
     integer         , intent(in   ) :: state_lo(3), state_hi(3)
 
-    double precision, intent(inout) :: rot(rot_lo(1):rot_hi(1),rot_lo(2):rot_hi(2),rot_lo(3):rot_hi(3),3)
-    double precision, intent(in   ) :: state(state_lo(1):state_hi(1),state_lo(2):state_hi(2),state_lo(3):state_hi(3),NVAR)
-    double precision, intent(in   ) :: dx(3), time
+    real(rt)        , intent(inout) :: rot(rot_lo(1):rot_hi(1),rot_lo(2):rot_hi(2),rot_lo(3):rot_hi(3),3)
+    real(rt)        , intent(in   ) :: state(state_lo(1):state_hi(1),state_lo(2):state_hi(2),state_lo(3):state_hi(3),NVAR)
+    real(rt)        , intent(in   ) :: dx(3), time
 
     integer          :: i, j, k
-    double precision :: r(3)
+    real(rt)         :: r(3)
 
     do k = lo(3), hi(3)
        r(3) = problo(3) + dx(3)*(dble(k)+HALF) - center(3)

--- a/Source/Src_nd/Tagging_nd.f90
+++ b/Source/Src_nd/Tagging_nd.f90
@@ -1,13 +1,14 @@
 module tagging_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
-  double precision, save ::    denerr,   dengrad
-  double precision, save ::    enterr,   entgrad
-  double precision, save ::    velerr,   velgrad
-  double precision, save ::   temperr,  tempgrad
-  double precision, save ::  presserr, pressgrad
-  double precision, save ::    raderr,   radgrad
+  real(rt)        , save ::    denerr,   dengrad
+  real(rt)        , save ::    enterr,   entgrad
+  real(rt)        , save ::    velerr,   velgrad
+  real(rt)        , save ::   temperr,  tempgrad
+  real(rt)        , save ::  presserr, pressgrad
+  real(rt)        , save ::    raderr,   radgrad
   integer         , save ::  max_denerr_lev,   max_dengrad_lev
   integer         , save ::  max_enterr_lev,   max_entgrad_lev
   integer         , save ::  max_velerr_lev,   max_velgrad_lev
@@ -53,6 +54,7 @@ contains
 
     use prob_params_module, only: dg, dim
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer          :: set, clear, nd, level
@@ -60,18 +62,18 @@ contains
     integer          :: varlo(3), varhi(3)
     integer          :: lo(3), hi(3), domlo(3), domhi(3)
     integer          :: tag(taglo(1):taghi(1),taglo(2):taghi(2),taglo(3):taghi(3))
-    double precision :: var(varlo(1):varhi(1),varlo(2):varhi(2),varlo(3):varhi(3))
-    double precision :: delta(3), xlo(3), problo(3), time
+    real(rt)         :: var(varlo(1):varhi(1),varlo(2):varhi(2),varlo(3):varhi(3))
+    real(rt)         :: delta(3), xlo(3), problo(3), time
 
     integer          :: i, j, k
-    double precision ::  delu(lo(1)-1:hi(1)+1,lo(2)-1:hi(2)+1,lo(3)-1:hi(3)+1,3)
-    double precision :: delua(lo(1)-1:hi(1)+1,lo(2)-1:hi(2)+1,lo(3)-1:hi(3)+1,3)
-    double precision :: delu2(9), delu3(9), delu4(9)
-    double precision :: num, denom, error
+    real(rt)         ::  delu(lo(1)-1:hi(1)+1,lo(2)-1:hi(2)+1,lo(3)-1:hi(3)+1,3)
+    real(rt)         :: delua(lo(1)-1:hi(1)+1,lo(2)-1:hi(2)+1,lo(3)-1:hi(3)+1,3)
+    real(rt)         :: delu2(9), delu3(9), delu4(9)
+    real(rt)         :: num, denom, error
 
     ! This value is  taken from FLASH
-    double precision, parameter :: ctore=0.8
-    double precision, parameter :: epsil=0.02
+    real(rt)        , parameter :: ctore=0.8
+    real(rt)        , parameter :: epsil=0.02
 
     ! adapted from ref_marking.f90 in FLASH2.5
 
@@ -164,7 +166,7 @@ contains
              ! compute the error
              num   = sum(delu2**2)
 
-             denom = sum((delu3 + (epsil*delu4+1.d-99))**2)
+             denom = sum((delu3 + (epsil*delu4+1.e-99_rt))**2)
 
              error = sqrt(num/denom)
 
@@ -189,6 +191,7 @@ contains
 
     use prob_params_module, only: dg
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer          :: set, clear, nd, level
@@ -196,10 +199,10 @@ contains
     integer          :: denlo(3), denhi(3)
     integer          :: lo(3), hi(3), domlo(3), domhi(3)
     integer          :: tag(taglo(1):taghi(1),taglo(2):taghi(2),taglo(3):taghi(3))
-    double precision :: den(denlo(1):denhi(1),denlo(2):denhi(2),denlo(3):denhi(3),nd)
-    double precision :: delta(3), xlo(3), problo(3), time
+    real(rt)         :: den(denlo(1):denhi(1),denlo(2):denhi(2),denlo(3):denhi(3),nd)
+    real(rt)         :: delta(3), xlo(3), problo(3), time
 
-    double precision :: ax, ay, az
+    real(rt)         :: ax, ay, az
     integer          :: i, j, k
 
     !     Tag on regions of high density
@@ -249,6 +252,7 @@ contains
 
     use prob_params_module, only: dg
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer          :: set, clear, np, level
@@ -256,10 +260,10 @@ contains
     integer          :: templo(3), temphi(3)
     integer          :: lo(3), hi(3), domlo(3), domhi(3)
     integer          :: tag(taglo(1):taghi(1),taglo(2):taghi(2),taglo(3):taghi(3))
-    double precision :: temp(templo(1):temphi(1),templo(2):temphi(2),templo(3):temphi(3),np)
-    double precision :: delta(3), xlo(3), problo(3), time
+    real(rt)         :: temp(templo(1):temphi(1),templo(2):temphi(2),templo(3):temphi(3),np)
+    real(rt)         :: delta(3), xlo(3), problo(3), time
 
-    double precision :: ax, ay, az
+    real(rt)         :: ax, ay, az
     integer          :: i, j, k
 
     !     Tag on regions of high temperature
@@ -309,6 +313,7 @@ contains
 
     use prob_params_module, only: dg
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer          :: set, clear, np, level
@@ -316,10 +321,10 @@ contains
     integer          :: presslo(3), presshi(3)
     integer          :: lo(3), hi(3), domlo(3), domhi(3)
     integer          :: tag(taglo(1):taghi(1),taglo(2):taghi(2),taglo(3):taghi(3))
-    double precision :: press(presslo(1):presshi(1),presslo(2):presshi(2),presslo(3):presshi(3),np)
-    double precision :: delta(3), xlo(3), problo(3), time
+    real(rt)         :: press(presslo(1):presshi(1),presslo(2):presshi(2),presslo(3):presshi(3),np)
+    real(rt)         :: delta(3), xlo(3), problo(3), time
 
-    double precision :: ax, ay, az
+    real(rt)         :: ax, ay, az
     integer          :: i, j, k
 
     !     Tag on regions of high pressure
@@ -369,6 +374,7 @@ contains
 
     use prob_params_module, only: dg
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer          :: set, clear, nv, level
@@ -376,10 +382,10 @@ contains
     integer          :: vello(3), velhi(3)
     integer          :: lo(3), hi(3), domlo(3), domhi(3)
     integer          :: tag(taglo(1):taghi(1),taglo(2):taghi(2),taglo(3):taghi(3))
-    double precision :: vel(vello(1):velhi(1),vello(2):velhi(2),vello(3):velhi(3),nv)
-    double precision :: delta(3), xlo(3), problo(3), time
+    real(rt)         :: vel(vello(1):velhi(1),vello(2):velhi(2),vello(3):velhi(3),nv)
+    real(rt)         :: delta(3), xlo(3), problo(3), time
 
-    double precision :: ax, ay, az
+    real(rt)         :: ax, ay, az
     integer          :: i, j, k
 
     !     Tag on regions of high velocity
@@ -429,6 +435,7 @@ contains
 
     use prob_params_module, only: dg
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer          :: set, clear, nr, level
@@ -436,10 +443,10 @@ contains
     integer          :: radlo(3), radhi(3)
     integer          :: lo(3), hi(3), domlo(3), domhi(3)
     integer          :: tag(taglo(1):taghi(1),taglo(2):taghi(2),taglo(3):taghi(3))
-    double precision :: rad(radlo(1):radhi(1),radlo(2):radhi(2),radlo(3):radhi(3),nr)
-    double precision :: delta(3), xlo(3), problo(3), time
+    real(rt)         :: rad(radlo(1):radhi(1),radlo(2):radhi(2),radlo(3):radhi(3),nr)
+    real(rt)         :: delta(3), xlo(3), problo(3), time
 
-    double precision :: ax, ay, az
+    real(rt)         :: ax, ay, az
     integer          :: i, j, k
 
     !     Tag on regions of high radiation
@@ -489,6 +496,7 @@ contains
 
     use prob_params_module, only: dg
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer          :: set, clear, nr, level
@@ -496,10 +504,10 @@ contains
     integer          :: entlo(3), enthi(3)
     integer          :: lo(3), hi(3), domlo(3), domhi(3)
     integer          :: tag(taglo(1):taghi(1),taglo(2):taghi(2),taglo(3):taghi(3))
-    double precision :: ent(entlo(1):enthi(1),entlo(2):enthi(2),entlo(3):enthi(3),nr)
-    double precision :: delta(3), xlo(3), problo(3), time
+    real(rt)         :: ent(entlo(1):enthi(1),entlo(2):enthi(2),entlo(3):enthi(3),nr)
+    real(rt)         :: delta(3), xlo(3), problo(3), time
 
-    double precision :: ax, ay, az
+    real(rt)         :: ax, ay, az
     integer          :: i, j, k
 
     !     Tag on regions of high radiation
@@ -552,6 +560,7 @@ contains
 
     use meth_params_module, only: dxnuc
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer          :: set, clear, nr, level
@@ -559,14 +568,14 @@ contains
     integer          :: tlo(3), thi(3)
     integer          :: lo(3), hi(3), domlo(3), domhi(3)
     integer          :: tag(taglo(1):taghi(1),taglo(2):taghi(2),taglo(3):taghi(3))
-    double precision :: t(tlo(1):thi(1),tlo(2):thi(2),tlo(3):thi(3),nr) ! t_sound / t_e
-    double precision :: delta(3), xlo(3), problo(3), time
+    real(rt)         :: t(tlo(1):thi(1),tlo(2):thi(2),tlo(3):thi(3),nr) ! t_sound / t_e
+    real(rt)         :: delta(3), xlo(3), problo(3), time
 
     integer          :: i, j, k
 
     ! Disable if we're not utilizing this tagging
 
-    if (dxnuc > 1.d199) return
+    if (dxnuc > 1.e199_rt) return
 
     do k = lo(3), hi(3)
        do j = lo(2), hi(2)

--- a/Source/Src_nd/advection_util_nd.F90
+++ b/Source/Src_nd/advection_util_nd.F90
@@ -1,5 +1,6 @@
 module advection_util_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   private
@@ -20,6 +21,7 @@ contains
     use meth_params_module, only : NVAR, URHO, UEINT, UEDEN, small_dens, density_reset_method
     use bl_constants_module, only : ZERO
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer, intent(in) :: lo(3), hi(3), verbose
@@ -27,21 +29,21 @@ contains
     integer, intent(in) :: uout_lo(3), uout_hi(3)
     integer, intent(in) ::  vol_lo(3),  vol_hi(3)
 
-    double precision, intent(in) ::  uin( uin_lo(1): uin_hi(1), uin_lo(2): uin_hi(2), uin_lo(3): uin_hi(3),NVAR)
-    double precision, intent(inout) :: uout(uout_lo(1):uout_hi(1),uout_lo(2):uout_hi(2),uout_lo(3):uout_hi(3),NVAR)
-    double precision, intent(in) ::  vol( vol_lo(1): vol_hi(1), vol_lo(2): vol_hi(2), vol_lo(3): vol_hi(3))
-    double precision, intent(inout) :: mass_added, eint_added, eden_added, frac_change
+    real(rt)        , intent(in) ::  uin( uin_lo(1): uin_hi(1), uin_lo(2): uin_hi(2), uin_lo(3): uin_hi(3),NVAR)
+    real(rt)        , intent(inout) :: uout(uout_lo(1):uout_hi(1),uout_lo(2):uout_hi(2),uout_lo(3):uout_hi(3),NVAR)
+    real(rt)        , intent(in) ::  vol( vol_lo(1): vol_hi(1), vol_lo(2): vol_hi(2), vol_lo(3): vol_hi(3))
+    real(rt)        , intent(inout) :: mass_added, eint_added, eden_added, frac_change
 
     ! Local variables
     integer          :: i,ii,j,jj,k,kk
     integer          :: i_set, j_set, k_set
-    double precision :: max_dens
-    double precision :: unew(NVAR)
+    real(rt)         :: max_dens
+    real(rt)         :: unew(NVAR)
     integer          :: num_positive_zones
 
-    double precision :: initial_mass, final_mass
-    double precision :: initial_eint, final_eint
-    double precision :: initial_eden, final_eden
+    real(rt)         :: initial_mass, final_mass
+    real(rt)         :: initial_eint, final_eint
+    real(rt)         :: initial_eden, final_eden
 
     logical :: have_reset
 
@@ -213,16 +215,17 @@ contains
     use meth_params_module, only: UMR, UMP
 #endif
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
-    double precision :: old_state(NVAR), new_state(NVAR)
+    real(rt)         :: old_state(NVAR), new_state(NVAR)
     integer          :: idx(3), lo(3), hi(3), verbose
 
     integer          :: n, ipassive
     type (eos_t)     :: eos_state
 
 #ifdef HYBRID_MOMENTUM
-    double precision :: loc(3)
+    real(rt)         :: loc(3)
 #endif
 
     ! If no neighboring zones are above small_dens, our only recourse
@@ -279,9 +282,10 @@ contains
     use bl_constants_module, only: ZERO
     use meth_params_module, only: NVAR, URHO
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
-    double precision :: old_state(NVAR), new_state(NVAR), input_state(NVAR)
+    real(rt)         :: old_state(NVAR), new_state(NVAR), input_state(NVAR)
     integer          :: idx(3), lo(3), hi(3), verbose
 
     if (verbose .gt. 0) then
@@ -317,17 +321,18 @@ contains
     use meth_params_module, only: QVAR, QRHO, QU, QV, QW, QC, NQAUX
     use prob_params_module, only: dim
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer :: lo(3), hi(3)
     integer :: q_lo(3), q_hi(3), qa_lo(3), qa_hi(3)
 
-    double precision :: q(q_lo(1):q_hi(1),q_lo(2):q_hi(2),q_lo(3):q_hi(3),QVAR)
-    double precision :: qaux(qa_lo(1):qa_hi(1),qa_lo(2):qa_hi(2),qa_lo(3):qa_hi(3),NQAUX)
-    double precision :: dt, dx(3), courno
+    real(rt)         :: q(q_lo(1):q_hi(1),q_lo(2):q_hi(2),q_lo(3):q_hi(3),QVAR)
+    real(rt)         :: qaux(qa_lo(1):qa_hi(1),qa_lo(2):qa_hi(2),qa_lo(3):qa_hi(3),NQAUX)
+    real(rt)         :: dt, dx(3), courno
 
-    double precision :: courx, coury, courz, courmx, courmy, courmz
-    double precision :: dtdx, dtdy, dtdz
+    real(rt)         :: courx, coury, courz, courmx, courmy, courmz
+    real(rt)         :: dtdx, dtdy, dtdz
     integer          :: i, j, k
 
     ! Compute running max of Courant number over grids
@@ -435,6 +440,7 @@ contains
     use rad_util_module, only : compute_ptot_ctot
 #endif
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer, intent(in) :: lo(3), hi(3)
@@ -446,26 +452,26 @@ contains
     integer, intent(in) :: q_lo(3), q_hi(3)
     integer, intent(in) :: qa_lo(3), qa_hi(3)
 
-    double precision, intent(in   ) :: uin(uin_lo(1):uin_hi(1),uin_lo(2):uin_hi(2),uin_lo(3):uin_hi(3),NVAR)
+    real(rt)        , intent(in   ) :: uin(uin_lo(1):uin_hi(1),uin_lo(2):uin_hi(2),uin_lo(3):uin_hi(3),NVAR)
 #ifdef RADIATION
-    double precision, intent(in   ) :: Erin(Erin_lo(1):Erin_hi(1),Erin_lo(2):Erin_hi(2),Erin_lo(3):Erin_hi(3),0:ngroups-1)
-    double precision, intent(in   ) :: lam(lam_lo(1):lam_hi(1),lam_lo(2):lam_hi(2),lam_lo(3):lam_hi(3),0:ngroups-1)
+    real(rt)        , intent(in   ) :: Erin(Erin_lo(1):Erin_hi(1),Erin_lo(2):Erin_hi(2),Erin_lo(3):Erin_hi(3),0:ngroups-1)
+    real(rt)        , intent(in   ) :: lam(lam_lo(1):lam_hi(1),lam_lo(2):lam_hi(2),lam_lo(3):lam_hi(3),0:ngroups-1)
 #endif
 
-    double precision, intent(inout) :: q(q_lo(1):q_hi(1),q_lo(2):q_hi(2),q_lo(3):q_hi(3),NQ)
-    double precision, intent(inout) :: qaux(qa_lo(1):qa_hi(1),qa_lo(2):qa_hi(2),qa_lo(3):qa_hi(3),NQAUX)
+    real(rt)        , intent(inout) :: q(q_lo(1):q_hi(1),q_lo(2):q_hi(2),q_lo(3):q_hi(3),NQ)
+    real(rt)        , intent(inout) :: qaux(qa_lo(1):qa_hi(1),qa_lo(2):qa_hi(2),qa_lo(3):qa_hi(3),NQAUX)
 
-    double precision, parameter :: small = 1.d-8
+    real(rt)        , parameter :: small = 1.e-8_rt
 
     integer          :: i, j, k, g
     integer          :: n, iq, ipassive
-    double precision :: kineng, rhoinv
-    double precision :: vel(3)
+    real(rt)         :: kineng, rhoinv
+    real(rt)         :: vel(3)
 
     type (eos_t) :: eos_state
 
 #ifdef RADIATION
-    double precision :: ptot, ctot, gamc_tot
+    real(rt)         :: ptot, ctot, gamc_tot
 #endif
 
     do k = lo(3), hi(3)
@@ -610,6 +616,7 @@ contains
     use bl_constants_module, only: ZERO, HALF, ONE
     use castro_util_module, only: position
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer, intent(in) :: lo(3), hi(3)
@@ -618,14 +625,14 @@ contains
     integer, intent(in) :: src_lo(3), src_hi(3)
     integer, intent(in) :: srQ_lo(3), srQ_hi(3)
 
-    double precision, intent(in   ) :: q(q_lo(1):q_hi(1),q_lo(2):q_hi(2),q_lo(3):q_hi(3),NQ)
-    double precision, intent(in   ) :: qaux(qa_lo(1):qa_hi(1),qa_lo(2):qa_hi(2),qa_lo(3):qa_hi(3),NQAUX)
-    double precision, intent(in   ) :: src(src_lo(1):src_hi(1),src_lo(2):src_hi(2),src_lo(3):src_hi(3),NVAR)
-    double precision, intent(inout) :: srcQ(srQ_lo(1):srQ_hi(1),srQ_lo(2):srQ_hi(2),srQ_lo(3):srQ_hi(3),QVAR)
+    real(rt)        , intent(in   ) :: q(q_lo(1):q_hi(1),q_lo(2):q_hi(2),q_lo(3):q_hi(3),NQ)
+    real(rt)        , intent(in   ) :: qaux(qa_lo(1):qa_hi(1),qa_lo(2):qa_hi(2),qa_lo(3):qa_hi(3),NQAUX)
+    real(rt)        , intent(in   ) :: src(src_lo(1):src_hi(1),src_lo(2):src_hi(2),src_lo(3):src_hi(3),NVAR)
+    real(rt)        , intent(inout) :: srcQ(srQ_lo(1):srQ_hi(1),srQ_lo(2):srQ_hi(2),srQ_lo(3):srQ_hi(3),QVAR)
 
     integer          :: i, j, k
     integer          :: n, iq, ipassive
-    double precision :: rhoinv
+    real(rt)         :: rhoinv
 
     srcQ(lo(1):hi(1),lo(2):hi(2),lo(3):hi(3),:) = ZERO
 
@@ -682,16 +689,17 @@ contains
     use meth_params_module, only: NGDNV, GDRHO, GDU, GDW, GDPRES, QRHO, QW
 #endif
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer :: dir, idx(3)
-    double precision :: u(NVAR), q(QVAR), flux(NVAR)
+    real(rt)         :: u(NVAR), q(QVAR), flux(NVAR)
     logical, optional :: include_pressure
 
-    double precision :: v_adv
+    real(rt)         :: v_adv
     integer :: ipassive, n
 #ifdef HYBRID_MOMENTUM
-    double precision :: qgdnv(NGDNV)
+    real(rt)         :: qgdnv(NGDNV)
     logical :: cell_centered
 #endif
 
@@ -771,6 +779,7 @@ contains
     use eos_type_module, only: eos_input_rt, eos_t
     use eos_module, only: eos
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer, intent(in) :: u_lo(3), u_hi(3)
@@ -788,35 +797,35 @@ contains
     integer, intent(in) :: area3_lo(3), area3_hi(3)
 #endif
 
-    double precision, intent(in   ) :: dt, dx(3)
+    real(rt)        , intent(in   ) :: dt, dx(3)
 
-    double precision, intent(in   ) :: u(u_lo(1):u_hi(1),u_lo(2):u_hi(2),u_lo(3):u_hi(3),NVAR)
-    double precision, intent(in   ) :: q(q_lo(1):q_hi(1),q_lo(2):q_hi(2),q_lo(3):q_hi(3),QVAR)
-    double precision, intent(in   ) :: vol(vol_lo(1):vol_hi(1),vol_lo(2):vol_hi(2),vol_lo(3):vol_hi(3))
-    double precision, intent(inout) :: flux1(flux1_lo(1):flux1_hi(1),flux1_lo(2):flux1_hi(2),flux1_lo(3):flux1_hi(3),NVAR)
-    double precision, intent(in   ) :: area1(area1_lo(1):area1_hi(1),area1_lo(2):area1_hi(2),area1_lo(3):area1_hi(3))
+    real(rt)        , intent(in   ) :: u(u_lo(1):u_hi(1),u_lo(2):u_hi(2),u_lo(3):u_hi(3),NVAR)
+    real(rt)        , intent(in   ) :: q(q_lo(1):q_hi(1),q_lo(2):q_hi(2),q_lo(3):q_hi(3),QVAR)
+    real(rt)        , intent(in   ) :: vol(vol_lo(1):vol_hi(1),vol_lo(2):vol_hi(2),vol_lo(3):vol_hi(3))
+    real(rt)        , intent(inout) :: flux1(flux1_lo(1):flux1_hi(1),flux1_lo(2):flux1_hi(2),flux1_lo(3):flux1_hi(3),NVAR)
+    real(rt)        , intent(in   ) :: area1(area1_lo(1):area1_hi(1),area1_lo(2):area1_hi(2),area1_lo(3):area1_hi(3))
 #if (BL_SPACEDIM >= 2)
-    double precision, intent(inout) :: flux2(flux2_lo(1):flux2_hi(1),flux2_lo(2):flux2_hi(2),flux2_lo(3):flux2_hi(3),NVAR)
-    double precision, intent(in   ) :: area2(area2_lo(1):area2_hi(1),area2_lo(2):area2_hi(2),area2_lo(3):area2_hi(3))
+    real(rt)        , intent(inout) :: flux2(flux2_lo(1):flux2_hi(1),flux2_lo(2):flux2_hi(2),flux2_lo(3):flux2_hi(3),NVAR)
+    real(rt)        , intent(in   ) :: area2(area2_lo(1):area2_hi(1),area2_lo(2):area2_hi(2),area2_lo(3):area2_hi(3))
 #endif
 #if (BL_SPACEDIM == 3)
-    double precision, intent(inout) :: flux3(flux3_lo(1):flux3_hi(1),flux3_lo(2):flux3_hi(2),flux3_lo(3):flux3_hi(3),NVAR)
-    double precision, intent(in   ) :: area3(area3_lo(1):area3_hi(1),area3_lo(2):area3_hi(2),area3_lo(3):area3_hi(3))
+    real(rt)        , intent(inout) :: flux3(flux3_lo(1):flux3_hi(1),flux3_lo(2):flux3_hi(2),flux3_lo(3):flux3_hi(3),NVAR)
+    real(rt)        , intent(in   ) :: area3(area3_lo(1):area3_hi(1),area3_lo(2):area3_hi(2),area3_lo(3):area3_hi(3))
 #endif
 
-    double precision, pointer :: thetap_dens(:,:,:), thetam_dens(:,:,:)
-    double precision, pointer :: thetap_rhoe(:,:,:), thetam_rhoe(:,:,:)
-    double precision, pointer :: small_rhoe(:,:,:)
+    real(rt)        , pointer :: thetap_dens(:,:,:), thetam_dens(:,:,:)
+    real(rt)        , pointer :: thetap_rhoe(:,:,:), thetam_rhoe(:,:,:)
+    real(rt)        , pointer :: small_rhoe(:,:,:)
 
     integer          :: i, j, k
 
-    double precision :: alpha_x, alpha_y, alpha_z
-    double precision :: rho, drho, fluxLF(NVAR), fluxL(NVAR), fluxR(NVAR), rhoLF, drhoLF, dtdx, theta
+    real(rt)         :: alpha_x, alpha_y, alpha_z
+    real(rt)         :: rho, drho, fluxLF(NVAR), fluxL(NVAR), fluxR(NVAR), rhoLF, drhoLF, dtdx, theta
     integer          :: dir
     logical          :: include_pressure
 
     type (eos_t) :: eos_state
-    double precision :: rhoe, drhoe, rhoeLF, drhoeLF
+    real(rt)         :: rhoe, drhoe, rhoeLF, drhoeLF
 
     ! The following algorithm comes from Hu, Adams, and Shu (2013), JCP, 242, 169,
     ! "Positivity-preserving method for high-order conservative schemes solving
@@ -859,7 +868,7 @@ contains
                 ! No limiting in this case. Set to a value large enough that it should
                 ! never be obtained under normal circumstances.
 
-                small_rhoe(i,j,k) = -1.d200
+                small_rhoe(i,j,k) = -1.e200_rt
 
              endif
 

--- a/Source/Src_nd/amrinfo.f90
+++ b/Source/Src_nd/amrinfo.f90
@@ -3,13 +3,14 @@
 
 module amrinfo_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   integer :: amr_level = 0
   integer :: amr_iteration = 0
   integer :: amr_ncycle = 0
 
-  double precision :: amr_time = 0.0
-  double precision :: amr_dt = 0.0
+  real(rt)         :: amr_time = 0.0
+  real(rt)         :: amr_dt = 0.0
   
 end module amrinfo_module

--- a/Source/Src_nd/bc_fill_nd.F90
+++ b/Source/Src_nd/bc_fill_nd.F90
@@ -1,5 +1,6 @@
 module bc_fill_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   public
@@ -15,6 +16,7 @@ contains
     use meth_params_module, only: NVAR
     use prob_params_module, only: dim
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     include 'bc_types.fi'
@@ -22,8 +24,8 @@ contains
     integer          :: adv_lo(3),adv_hi(3)
     integer          :: bc(dim,2,*)
     integer          :: domlo(3), domhi(3)
-    double precision :: delta(3), xlo(3), time
-    double precision :: adv(adv_lo(1):adv_hi(1),adv_lo(2):adv_hi(2),adv_lo(3):adv_hi(3),NVAR)
+    real(rt)         :: delta(3), xlo(3), time
+    real(rt)         :: adv(adv_lo(1):adv_hi(1),adv_lo(2):adv_hi(2),adv_lo(3):adv_hi(3),NVAR)
 
     integer          :: n
 
@@ -40,6 +42,7 @@ contains
 
     use prob_params_module, only: dim  
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     include 'bc_types.fi'
@@ -47,8 +50,8 @@ contains
     integer          :: adv_lo(3),adv_hi(3)
     integer          :: bc(dim,2,*)
     integer          :: domlo(3), domhi(3)
-    double precision :: delta(3), xlo(3), time
-    double precision :: adv(adv_lo(1):adv_hi(1),adv_lo(2):adv_hi(2),adv_lo(3):adv_hi(3))
+    real(rt)         :: delta(3), xlo(3), time
+    real(rt)         :: adv(adv_lo(1):adv_hi(1),adv_lo(2):adv_hi(2),adv_lo(3):adv_hi(3))
 
     call filcc_nd(adv,adv_lo,adv_hi,domlo,domhi,delta,xlo,bc)
 
@@ -62,6 +65,7 @@ contains
 
     use prob_params_module, only: dim  
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     include 'bc_types.fi'
@@ -69,8 +73,8 @@ contains
     integer          :: phi_lo(3),phi_hi(3)
     integer          :: bc(dim,2,*)
     integer          :: domlo(3), domhi(3)
-    double precision :: delta(3), xlo(3), time
-    double precision :: phi(phi_lo(1):phi_hi(1),phi_lo(2):phi_hi(2),phi_lo(3):phi_hi(3))
+    real(rt)         :: delta(3), xlo(3), time
+    real(rt)         :: phi(phi_lo(1):phi_hi(1),phi_lo(2):phi_hi(2),phi_lo(3):phi_hi(3))
 
     call filcc_nd(phi,phi_lo,phi_hi,domlo,domhi,delta,xlo,bc)
 
@@ -83,6 +87,7 @@ contains
 
     use prob_params_module, only: dim  
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     include 'bc_types.fi'
@@ -90,8 +95,8 @@ contains
     integer          :: grav_lo(3),grav_hi(3)
     integer          :: bc(dim,2,*)
     integer          :: domlo(3), domhi(3)
-    double precision :: delta(3), xlo(3), time
-    double precision :: grav(grav_lo(1):grav_hi(1),grav_lo(2):grav_hi(2),grav_lo(3):grav_hi(3))
+    real(rt)         :: delta(3), xlo(3), time
+    real(rt)         :: grav(grav_lo(1):grav_hi(1),grav_lo(2):grav_hi(2),grav_lo(3):grav_hi(3))
 
     call filcc_nd(grav,grav_lo,grav_hi,domlo,domhi,delta,xlo,bc)
 
@@ -104,6 +109,7 @@ contains
 
     use prob_params_module, only: dim  
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     include 'bc_types.fi'
@@ -111,8 +117,8 @@ contains
     integer          :: grav_lo(3),grav_hi(3)
     integer          :: bc(dim,2,*)
     integer          :: domlo(3), domhi(3)
-    double precision :: delta(3), xlo(3), time
-    double precision :: grav(grav_lo(1):grav_hi(1),grav_lo(2):grav_hi(2),grav_lo(3):grav_hi(3))
+    real(rt)         :: delta(3), xlo(3), time
+    real(rt)         :: grav(grav_lo(1):grav_hi(1),grav_lo(2):grav_hi(2),grav_lo(3):grav_hi(3))
 
     call filcc_nd(grav,grav_lo,grav_hi,domlo,domhi,delta,xlo,bc)
 
@@ -125,6 +131,7 @@ contains
 
     use prob_params_module, only: dim
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     include 'bc_types.fi'
@@ -132,8 +139,8 @@ contains
     integer          :: grav_lo(3),grav_hi(3)
     integer          :: bc(dim,2,*)
     integer          :: domlo(3), domhi(3)
-    double precision :: delta(3), xlo(3), time
-    double precision :: grav(grav_lo(1):grav_hi(1),grav_lo(2):grav_hi(2),grav_lo(3):grav_hi(3))
+    real(rt)         :: delta(3), xlo(3), time
+    real(rt)         :: grav(grav_lo(1):grav_hi(1),grav_lo(2):grav_hi(2),grav_lo(3):grav_hi(3))
 
     call filcc_nd(grav,grav_lo,grav_hi,domlo,domhi,delta,xlo,bc)
 
@@ -148,6 +155,7 @@ contains
 
     use prob_params_module, only: dim  
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     include 'bc_types.fi'
@@ -155,8 +163,8 @@ contains
     integer          :: phi_lo(3),phi_hi(3)
     integer          :: bc(dim,2,*)
     integer          :: domlo(3), domhi(3)
-    double precision :: delta(3), xlo(3), time
-    double precision :: phi(phi_lo(1):phi_hi(1),phi_lo(2):phi_hi(2),phi_lo(3):phi_hi(3))
+    real(rt)         :: delta(3), xlo(3), time
+    real(rt)         :: phi(phi_lo(1):phi_hi(1),phi_lo(2):phi_hi(2),phi_lo(3):phi_hi(3))
 
     call filcc_nd(phi,phi_lo,phi_hi,domlo,domhi,delta,xlo,bc)
 
@@ -169,6 +177,7 @@ contains
 
     use prob_params_module, only: dim  
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     include 'bc_types.fi'
@@ -176,8 +185,8 @@ contains
     integer          :: rot_lo(3),rot_hi(3)
     integer          :: bc(dim,2,*)
     integer          :: domlo(3), domhi(3)
-    double precision :: delta(3), xlo(3), time
-    double precision :: rot(rot_lo(1):rot_hi(1),rot_lo(2):rot_hi(2),rot_lo(3):rot_hi(3))
+    real(rt)         :: delta(3), xlo(3), time
+    real(rt)         :: rot(rot_lo(1):rot_hi(1),rot_lo(2):rot_hi(2),rot_lo(3):rot_hi(3))
 
     call filcc_nd(rot,rot_lo,rot_hi,domlo,domhi,delta,xlo,bc)
 
@@ -190,6 +199,7 @@ contains
 
     use prob_params_module, only: dim  
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     include 'bc_types.fi'
@@ -197,8 +207,8 @@ contains
     integer          :: rot_lo(3),rot_hi(3)
     integer          :: bc(dim,2,*)
     integer          :: domlo(3), domhi(3)
-    double precision :: delta(3), xlo(3), time
-    double precision :: rot(rot_lo(1):rot_hi(1),rot_lo(2):rot_hi(2),rot_lo(3):rot_hi(3))
+    real(rt)         :: delta(3), xlo(3), time
+    real(rt)         :: rot(rot_lo(1):rot_hi(1),rot_lo(2):rot_hi(2),rot_lo(3):rot_hi(3))
 
     call filcc_nd(rot,rot_lo,rot_hi,domlo,domhi,delta,xlo,bc)
 
@@ -211,6 +221,7 @@ contains
 
     use prob_params_module, only: dim
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     include 'bc_types.fi'
@@ -218,8 +229,8 @@ contains
     integer          :: rot_lo(3),rot_hi(3)
     integer          :: bc(dim,2,*)
     integer          :: domlo(3), domhi(3)
-    double precision :: delta(3), xlo(3), time
-    double precision :: rot(rot_lo(1):rot_hi(1),rot_lo(2):rot_hi(2),rot_lo(3):rot_hi(3))
+    real(rt)         :: delta(3), xlo(3), time
+    real(rt)         :: rot(rot_lo(1):rot_hi(1),rot_lo(2):rot_hi(2),rot_lo(3):rot_hi(3))
 
     call filcc_nd(rot,rot_lo,rot_hi,domlo,domhi,delta,xlo,bc)
 
@@ -233,6 +244,7 @@ contains
 
     use prob_params_module, only: dim  
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     include 'bc_types.fi'
@@ -240,8 +252,8 @@ contains
     integer          :: react_lo(3),react_hi(3)
     integer          :: bc(dim,2,*)
     integer          :: domlo(3), domhi(3)
-    double precision :: delta(3), xlo(3), time
-    double precision :: react(react_lo(1):react_hi(1),react_lo(2):react_hi(2),react_lo(3):react_hi(3))
+    real(rt)         :: delta(3), xlo(3), time
+    real(rt)         :: react(react_lo(1):react_hi(1),react_lo(2):react_hi(2),react_lo(3):react_hi(3))
 
     call filcc_nd(react,react_lo,react_hi,domlo,domhi,delta,xlo,bc)
 
@@ -256,6 +268,7 @@ contains
 
     use prob_params_module, only: dim  
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     include 'bc_types.fi'
@@ -263,8 +276,8 @@ contains
     integer          :: rad_lo(3),rad_hi(3)
     integer          :: bc(dim,2,*)
     integer          :: domlo(3), domhi(3)
-    double precision :: delta(3), xlo(3), time
-    double precision :: rad(rad_lo(1):rad_hi(1),rad_lo(2):rad_hi(2),rad_lo(3):rad_hi(3))
+    real(rt)         :: delta(3), xlo(3), time
+    real(rt)         :: rad(rad_lo(1):rad_hi(1),rad_lo(2):rad_hi(2),rad_lo(3):rad_hi(3))
 
     call filcc_nd(rad,rad_lo,rad_hi,domlo,domhi,delta,xlo,bc)
 

--- a/Source/Src_nd/ext_src_nd.F90
+++ b/Source/Src_nd/ext_src_nd.F90
@@ -25,16 +25,17 @@
     use bl_constants_module, only: ZERO
     use meth_params_module, only : NVAR
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer          :: lo(3),hi(3)
     integer          :: os_lo(3),os_hi(3)
     integer          :: ns_lo(3),ns_hi(3)
     integer          :: src_lo(3),src_hi(3)
-    double precision :: old_state(os_lo(1):os_hi(1),os_lo(2):os_hi(2),os_lo(3):os_hi(3),NVAR)
-    double precision :: new_state(ns_lo(1):ns_hi(1),ns_lo(2):ns_hi(2),ns_lo(3):ns_hi(3),NVAR)
-    double precision :: src(src_lo(1):src_hi(1),src_lo(2):src_hi(2),src_lo(3):src_hi(3),NVAR)
-    double precision :: problo(3),dx(3),time,dt
+    real(rt)         :: old_state(os_lo(1):os_hi(1),os_lo(2):os_hi(2),os_lo(3):os_hi(3),NVAR)
+    real(rt)         :: new_state(ns_lo(1):ns_hi(1),ns_lo(2):ns_hi(2),ns_lo(3):ns_hi(3),NVAR)
+    real(rt)         :: src(src_lo(1):src_hi(1),src_lo(2):src_hi(2),src_lo(3):src_hi(3),NVAR)
+    real(rt)         :: problo(3),dx(3),time,dt
 
     ! lo and hi specify work region
     src(lo(1):hi(1),lo(2):hi(2),lo(3):hi(3),:) = ZERO ! Fill work region only

--- a/Source/Src_nd/filcc_nd.F90
+++ b/Source/Src_nd/filcc_nd.F90
@@ -6,6 +6,7 @@ subroutine filcc_nd(adv,adv_lo,adv_hi,domlo,domhi,delta,xlo,bc)
 
   use prob_params_module, only: dim
   
+  use bl_fort_module, only : rt => c_real
   implicit none
   
   include 'bc_types.fi'  
@@ -13,8 +14,8 @@ subroutine filcc_nd(adv,adv_lo,adv_hi,domlo,domhi,delta,xlo,bc)
   integer          :: adv_lo(3),adv_hi(3)
   integer          :: bc(dim,2)
   integer          :: domlo(3), domhi(3)
-  double precision :: delta(3), xlo(3)
-  double precision :: adv(adv_lo(1):adv_hi(1),adv_lo(2):adv_hi(2),adv_lo(3):adv_hi(3))
+  real(rt)         :: delta(3), xlo(3)
+  real(rt)         :: adv(adv_lo(1):adv_hi(1),adv_lo(2):adv_hi(2),adv_lo(3):adv_hi(3))
 
 #if (BL_SPACEDIM == 1)
 

--- a/Source/Src_nd/flatten_nd.F90
+++ b/Source/Src_nd/flatten_nd.F90
@@ -3,6 +3,7 @@ module flatten_module
   use mempool_module, only : bl_allocate, bl_deallocate
   use bl_constants_module, only : ZERO
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   private
@@ -24,26 +25,27 @@ contains
     use prob_params_module, only : dg
     use bl_constants_module
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer, intent(in) :: lo(3), hi(3)
     integer, intent(in) :: q_lo(3), q_hi(3)
 
-    double precision, intent(in) :: p(q_lo(1):q_hi(1),q_lo(2):q_hi(2),q_lo(3):q_hi(3))
-    double precision, intent(in) :: u(q_lo(1):q_hi(1),q_lo(2):q_hi(2),q_lo(3):q_hi(3))
-    double precision, intent(in) :: v(q_lo(1):q_hi(1),q_lo(2):q_hi(2),q_lo(3):q_hi(3))
-    double precision, intent(in) :: w(q_lo(1):q_hi(1),q_lo(2):q_hi(2),q_lo(3):q_hi(3))
-    double precision, intent(inout) :: flatn(q_lo(1):q_hi(1),q_lo(2):q_hi(2),q_lo(3):q_hi(3))
+    real(rt)        , intent(in) :: p(q_lo(1):q_hi(1),q_lo(2):q_hi(2),q_lo(3):q_hi(3))
+    real(rt)        , intent(in) :: u(q_lo(1):q_hi(1),q_lo(2):q_hi(2),q_lo(3):q_hi(3))
+    real(rt)        , intent(in) :: v(q_lo(1):q_hi(1),q_lo(2):q_hi(2),q_lo(3):q_hi(3))
+    real(rt)        , intent(in) :: w(q_lo(1):q_hi(1),q_lo(2):q_hi(2),q_lo(3):q_hi(3))
+    real(rt)        , intent(inout) :: flatn(q_lo(1):q_hi(1),q_lo(2):q_hi(2),q_lo(3):q_hi(3))
 
     integer :: i, j, k, ishft
 
-    double precision :: denom, zeta, tst, tmp, ftmp
+    real(rt)         :: denom, zeta, tst, tmp, ftmp
 
     ! Local arrays
-    double precision, pointer :: dp(:,:,:), z(:,:,:), chi(:,:,:)
+    real(rt)        , pointer :: dp(:,:,:), z(:,:,:), chi(:,:,:)
 
     ! Knobs for detection of strong shock
-    double precision, parameter :: shktst = 0.33d0, zcut1 = 0.75d0, zcut2 = 0.85d0, dzcut = ONE/(zcut2-zcut1)
+    real(rt)        , parameter :: shktst = 0.33e0_rt, zcut1 = 0.75e0_rt, zcut2 = 0.85e0_rt, dzcut = ONE/(zcut2-zcut1)
 
     call bl_allocate(dp ,lo(1)-1,hi(1)+1,lo(2)-1,hi(2)+1,lo(3)-1,hi(3)+1)
     call bl_allocate(z  ,lo(1)-1,hi(1)+1,lo(2)-1,hi(2)+1,lo(3)-1,hi(3)+1)
@@ -167,21 +169,22 @@ contains
 
     use meth_params_module, only : QPRES, QU, QV, QW, flatten_pp_threshold, QPTOT
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer, intent(in) :: lo(3), hi(3)
     integer, intent(in) :: q_lo(3), q_hi(3)
 
-    double precision, intent(in) :: p(q_lo(1):q_hi(1),q_lo(2):q_hi(2),q_lo(3):q_hi(3))
-    double precision, intent(in) :: ptot(q_lo(1):q_hi(1),q_lo(2):q_hi(2),q_lo(3):q_hi(3))
-    double precision, intent(in) :: u(q_lo(1):q_hi(1),q_lo(2):q_hi(2),q_lo(3):q_hi(3))
-    double precision, intent(in) :: v(q_lo(1):q_hi(1),q_lo(2):q_hi(2),q_lo(3):q_hi(3))
-    double precision, intent(in) :: w(q_lo(1):q_hi(1),q_lo(2):q_hi(2),q_lo(3):q_hi(3))
-    double precision, intent(inout) :: flatn(q_lo(1):q_hi(1),q_lo(2):q_hi(2),q_lo(3):q_hi(3))
+    real(rt)        , intent(in) :: p(q_lo(1):q_hi(1),q_lo(2):q_hi(2),q_lo(3):q_hi(3))
+    real(rt)        , intent(in) :: ptot(q_lo(1):q_hi(1),q_lo(2):q_hi(2),q_lo(3):q_hi(3))
+    real(rt)        , intent(in) :: u(q_lo(1):q_hi(1),q_lo(2):q_hi(2),q_lo(3):q_hi(3))
+    real(rt)        , intent(in) :: v(q_lo(1):q_hi(1),q_lo(2):q_hi(2),q_lo(3):q_hi(3))
+    real(rt)        , intent(in) :: w(q_lo(1):q_hi(1),q_lo(2):q_hi(2),q_lo(3):q_hi(3))
+    real(rt)        , intent(inout) :: flatn(q_lo(1):q_hi(1),q_lo(2):q_hi(2),q_lo(3):q_hi(3))
 
     integer :: i, j, k
 
-    double precision, pointer :: flatg(:,:,:)
+    real(rt)        , pointer :: flatg(:,:,:)
 
     call uflaten(lo, hi, ptot, u, v, w, flatn, q_lo, q_hi)
 

--- a/Source/Src_nd/gravity_sources_nd.F90
+++ b/Source/Src_nd/gravity_sources_nd.F90
@@ -1,5 +1,6 @@
 module gravity_sources_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   public
@@ -22,6 +23,7 @@ contains
 #endif
     use prob_params_module, only: center
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer          :: lo(3), hi(3)
@@ -32,25 +34,25 @@ contains
     integer          :: src_lo(3), src_hi(3)
     integer          :: vol_lo(3), vol_hi(3)
 
-    double precision :: phi(phi_lo(1):phi_hi(1),phi_lo(2):phi_hi(2),phi_lo(3):phi_hi(3))
-    double precision :: grav(grav_lo(1):grav_hi(1),grav_lo(2):grav_hi(2),grav_lo(3):grav_hi(3),3)
-    double precision :: uold(uold_lo(1):uold_hi(1),uold_lo(2):uold_hi(2),uold_lo(3):uold_hi(3),NVAR)
-    double precision :: source(src_lo(1):src_hi(1),src_lo(2):src_hi(2),src_lo(3):src_hi(3),NVAR)
-    double precision :: vol(vol_lo(1):vol_hi(1),vol_lo(2):vol_hi(2),vol_lo(3):vol_hi(3))
-    double precision :: dx(3), dt, time
-    double precision :: E_added, mom_added(3)
+    real(rt)         :: phi(phi_lo(1):phi_hi(1),phi_lo(2):phi_hi(2),phi_lo(3):phi_hi(3))
+    real(rt)         :: grav(grav_lo(1):grav_hi(1),grav_lo(2):grav_hi(2),grav_lo(3):grav_hi(3),3)
+    real(rt)         :: uold(uold_lo(1):uold_hi(1),uold_lo(2):uold_hi(2),uold_lo(3):uold_hi(3),NVAR)
+    real(rt)         :: source(src_lo(1):src_hi(1),src_lo(2):src_hi(2),src_lo(3):src_hi(3),NVAR)
+    real(rt)         :: vol(vol_lo(1):vol_hi(1),vol_lo(2):vol_hi(2),vol_lo(3):vol_hi(3))
+    real(rt)         :: dx(3), dt, time
+    real(rt)         :: E_added, mom_added(3)
 
-    double precision :: rho, rhoInv
-    double precision :: Sr(3), SrE
-    double precision :: old_rhoeint, new_rhoeint, old_ke, new_ke, old_re, old_mom(3)
-    double precision :: loc(3)
+    real(rt)         :: rho, rhoInv
+    real(rt)         :: Sr(3), SrE
+    real(rt)         :: old_rhoeint, new_rhoeint, old_ke, new_ke, old_re, old_mom(3)
+    real(rt)         :: loc(3)
     integer          :: i, j, k
 
-    double precision :: src(NVAR)
+    real(rt)         :: src(NVAR)
 
     ! Temporary array for seeing what the new state would be if the update were applied here.
 
-    double precision :: snew(NVAR)
+    real(rt)         :: snew(NVAR)
 
     ! Gravitational source options for how to add the work to (rho E):
     ! grav_source_type =
@@ -171,6 +173,7 @@ contains
     use hybrid_advection_module, only : add_hybrid_momentum_source
 #endif
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer          :: lo(3), hi(3)
@@ -190,55 +193,55 @@ contains
 
     ! Old and new time gravitational potential
 
-    double precision :: pold(po_lo(1):po_hi(1),po_lo(2):po_hi(2),po_lo(3):po_hi(3))
-    double precision :: pnew(pn_lo(1):pn_hi(1),pn_lo(2):pn_hi(2),pn_lo(3):pn_hi(3))
+    real(rt)         :: pold(po_lo(1):po_hi(1),po_lo(2):po_hi(2),po_lo(3):po_hi(3))
+    real(rt)         :: pnew(pn_lo(1):pn_hi(1),pn_lo(2):pn_hi(2),pn_lo(3):pn_hi(3))
 
     ! Old and new time gravitational acceleration
 
-    double precision :: gold(go_lo(1):go_hi(1),go_lo(2):go_hi(2),go_lo(3):go_hi(3),3)
-    double precision :: gnew(gn_lo(1):gn_hi(1),gn_lo(2):gn_hi(2),gn_lo(3):gn_hi(3),3)
+    real(rt)         :: gold(go_lo(1):go_hi(1),go_lo(2):go_hi(2),go_lo(3):go_hi(3),3)
+    real(rt)         :: gnew(gn_lo(1):gn_hi(1),gn_lo(2):gn_hi(2),gn_lo(3):gn_hi(3),3)
 
     ! Old and new time state data
 
-    double precision :: uold(uo_lo(1):uo_hi(1),uo_lo(2):uo_hi(2),uo_lo(3):uo_hi(3),NVAR)
-    double precision :: unew(un_lo(1):un_hi(1),un_lo(2):un_hi(2),un_lo(3):un_hi(3),NVAR)
+    real(rt)         :: uold(uo_lo(1):uo_hi(1),uo_lo(2):uo_hi(2),uo_lo(3):uo_hi(3),NVAR)
+    real(rt)         :: unew(un_lo(1):un_hi(1),un_lo(2):un_hi(2),un_lo(3):un_hi(3),NVAR)
 
     ! The source term to send back
 
-    double precision :: source(sr_lo(1):sr_hi(1),sr_lo(2):sr_hi(2),sr_lo(3):sr_hi(3),NVAR)
+    real(rt)         :: source(sr_lo(1):sr_hi(1),sr_lo(2):sr_hi(2),sr_lo(3):sr_hi(3),NVAR)
 
     ! Hydrodynamics fluxes
 
-    double precision :: flux1(f1_lo(1):f1_hi(1),f1_lo(2):f1_hi(2),f1_lo(3):f1_hi(3),NVAR)
-    double precision :: flux2(f2_lo(1):f2_hi(1),f2_lo(2):f2_hi(2),f2_lo(3):f2_hi(3),NVAR)
-    double precision :: flux3(f3_lo(1):f3_hi(1),f3_lo(2):f3_hi(2),f3_lo(3):f3_hi(3),NVAR)
+    real(rt)         :: flux1(f1_lo(1):f1_hi(1),f1_lo(2):f1_hi(2),f1_lo(3):f1_hi(3),NVAR)
+    real(rt)         :: flux2(f2_lo(1):f2_hi(1),f2_lo(2):f2_hi(2),f2_lo(3):f2_hi(3),NVAR)
+    real(rt)         :: flux3(f3_lo(1):f3_hi(1),f3_lo(2):f3_hi(2),f3_lo(3):f3_hi(3),NVAR)
 
-    double precision :: vol(vol_lo(1):vol_hi(1),vol_lo(2):vol_hi(2),vol_lo(3):vol_hi(3))
-    double precision :: dx(3), dt, time
-    double precision :: E_added, mom_added(3)
+    real(rt)         :: vol(vol_lo(1):vol_hi(1),vol_lo(2):vol_hi(2),vol_lo(3):vol_hi(3))
+    real(rt)         :: dx(3), dt, time
+    real(rt)         :: E_added, mom_added(3)
 
     integer          :: i, j, k
 
-    double precision :: Sr_old(3), Sr_new(3), Srcorr(3)
-    double precision :: vold(3), vnew(3)
-    double precision :: SrE_old, SrE_new, SrEcorr
-    double precision :: rhoo, rhooinv, rhon, rhoninv
+    real(rt)         :: Sr_old(3), Sr_new(3), Srcorr(3)
+    real(rt)         :: vold(3), vnew(3)
+    real(rt)         :: SrE_old, SrE_new, SrEcorr
+    real(rt)         :: rhoo, rhooinv, rhon, rhoninv
 
-    double precision :: old_ke, old_rhoeint, old_re
-    double precision :: new_ke, new_rhoeint
-    double precision :: old_mom(3), loc(3)
+    real(rt)         :: old_ke, old_rhoeint, old_re
+    real(rt)         :: new_ke, new_rhoeint
+    real(rt)         :: old_mom(3), loc(3)
 
-    double precision :: src(NVAR)
+    real(rt)         :: src(NVAR)
 
     ! Temporary array for seeing what the new state would be if the update were applied here.
 
-    double precision :: snew(NVAR)
+    real(rt)         :: snew(NVAR)
 
-    double precision, pointer :: phi(:,:,:)
-    double precision, pointer :: grav(:,:,:,:)
-    double precision, pointer :: gravx(:,:,:)
-    double precision, pointer :: gravy(:,:,:)
-    double precision, pointer :: gravz(:,:,:)
+    real(rt)        , pointer :: phi(:,:,:)
+    real(rt)        , pointer :: grav(:,:,:,:)
+    real(rt)        , pointer :: gravx(:,:,:)
+    real(rt)        , pointer :: gravy(:,:,:)
+    real(rt)        , pointer :: gravz(:,:,:)
 
     ! Gravitational source options for how to add the work to (rho E):
     ! grav_source_type =
@@ -519,6 +522,7 @@ contains
     use hybrid_advection_module, only: add_hybrid_momentum_source
 #endif
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer          :: lo(3), hi(3)
@@ -526,20 +530,20 @@ contains
     integer          :: uold_lo(3), uold_hi(3)
     integer          :: src_lo(3), src_hi(3)
 
-    double precision :: uold(uold_lo(1):uold_hi(1),uold_lo(2):uold_hi(2),uold_lo(3):uold_hi(3),NVAR)
-    double precision :: source(src_lo(1):src_hi(1),src_lo(2):src_hi(2),src_lo(3):src_hi(3),NVAR)
-    double precision :: dx(3), dt, time
+    real(rt)         :: uold(uold_lo(1):uold_hi(1),uold_lo(2):uold_hi(2),uold_lo(3):uold_hi(3),NVAR)
+    real(rt)         :: source(src_lo(1):src_hi(1),src_lo(2):src_hi(2),src_lo(3):src_hi(3),NVAR)
+    real(rt)         :: dx(3), dt, time
 
-    double precision :: rho, rhoInv
-    double precision :: Sr(3), SrE
-    double precision :: old_rhoeint, new_rhoeint, old_ke, new_ke, old_re, old_mom(3)
+    real(rt)         :: rho, rhoInv
+    real(rt)         :: Sr(3), SrE
+    real(rt)         :: old_rhoeint, new_rhoeint, old_ke, new_ke, old_re, old_mom(3)
     integer          :: i, j, k
 
-    double precision :: src(NVAR)
+    real(rt)         :: src(NVAR)
 
     ! Temporary array for seeing what the new state would be if the update were applied here.
 
-    double precision :: snew(NVAR)
+    real(rt)         :: snew(NVAR)
 
     ! Gravitational source options for how to add the work to (rho E):
     ! grav_source_type =
@@ -565,7 +569,7 @@ contains
              old_mom = snew(UMX:UMZ)
              ! ****   End Diagnostics ****
 
-             Sr(:)   = 0.d0
+             Sr(:)   = 0.e0_rt
              Sr(dim) = rho * const_grav
 
              src(UMX:UMZ) = Sr
@@ -648,6 +652,7 @@ contains
     use hybrid_advection_module, only : add_hybrid_momentum_source
 #endif
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer          :: lo(3), hi(3)
@@ -664,38 +669,38 @@ contains
 
     ! Old and new time state data
 
-    double precision :: uold(uo_lo(1):uo_hi(1),uo_lo(2):uo_hi(2),uo_lo(3):uo_hi(3),NVAR)
-    double precision :: unew(un_lo(1):un_hi(1),un_lo(2):un_hi(2),un_lo(3):un_hi(3),NVAR)
+    real(rt)         :: uold(uo_lo(1):uo_hi(1),uo_lo(2):uo_hi(2),uo_lo(3):uo_hi(3),NVAR)
+    real(rt)         :: unew(un_lo(1):un_hi(1),un_lo(2):un_hi(2),un_lo(3):un_hi(3),NVAR)
 
     ! The source term to send back
 
-    double precision :: source(sr_lo(1):sr_hi(1),sr_lo(2):sr_hi(2),sr_lo(3):sr_hi(3),NVAR)
+    real(rt)         :: source(sr_lo(1):sr_hi(1),sr_lo(2):sr_hi(2),sr_lo(3):sr_hi(3),NVAR)
 
     ! Hydrodynamics fluxes
 
-    double precision :: flux1(f1_lo(1):f1_hi(1),f1_lo(2):f1_hi(2),f1_lo(3):f1_hi(3),NVAR)
-    double precision :: flux2(f2_lo(1):f2_hi(1),f2_lo(2):f2_hi(2),f2_lo(3):f2_hi(3),NVAR)
-    double precision :: flux3(f3_lo(1):f3_hi(1),f3_lo(2):f3_hi(2),f3_lo(3):f3_hi(3),NVAR)
+    real(rt)         :: flux1(f1_lo(1):f1_hi(1),f1_lo(2):f1_hi(2),f1_lo(3):f1_hi(3),NVAR)
+    real(rt)         :: flux2(f2_lo(1):f2_hi(1),f2_lo(2):f2_hi(2),f2_lo(3):f2_hi(3),NVAR)
+    real(rt)         :: flux3(f3_lo(1):f3_hi(1),f3_lo(2):f3_hi(2),f3_lo(3):f3_hi(3),NVAR)
 
-    double precision :: vol(vol_lo(1):vol_hi(1),vol_lo(2):vol_hi(2),vol_lo(3):vol_hi(3))
-    double precision :: dx(3), dt, time
+    real(rt)         :: vol(vol_lo(1):vol_hi(1),vol_lo(2):vol_hi(2),vol_lo(3):vol_hi(3))
+    real(rt)         :: dx(3), dt, time
 
     integer          :: i, j, k
 
-    double precision :: Sr_old(3), Sr_new(3), Srcorr(3)
-    double precision :: vold(3), vnew(3)
-    double precision :: SrE_old, SrE_new, SrEcorr
-    double precision :: rhoo, rhooinv, rhon, rhoninv
+    real(rt)         :: Sr_old(3), Sr_new(3), Srcorr(3)
+    real(rt)         :: vold(3), vnew(3)
+    real(rt)         :: SrE_old, SrE_new, SrEcorr
+    real(rt)         :: rhoo, rhooinv, rhon, rhoninv
 
-    double precision :: old_ke, old_rhoeint, old_re
-    double precision :: new_ke, new_rhoeint
-    double precision :: old_mom(3)
+    real(rt)         :: old_ke, old_rhoeint, old_re
+    real(rt)         :: new_ke, new_rhoeint
+    real(rt)         :: old_mom(3)
 
-    double precision :: src(NVAR)
+    real(rt)         :: src(NVAR)
 
     ! Temporary array for seeing what the new state would be if the update were applied here.
 
-    double precision :: snew(NVAR)
+    real(rt)         :: snew(NVAR)
 
     ! Gravitational source options for how to add the work to (rho E):
     ! grav_source_type =
@@ -728,7 +733,7 @@ contains
 
              vold = uold(i,j,k,UMX:UMZ) * rhooinv
 
-             Sr_old(1:3) = 0.d0
+             Sr_old(1:3) = 0.e0_rt
              Sr_old(dim) = rhoo * const_grav
              SrE_old     = dot_product(vold, Sr_old)
 
@@ -736,7 +741,7 @@ contains
 
              vnew = snew(UMX:UMZ) * rhoninv
 
-             Sr_new(1:3) = 0.d0
+             Sr_new(1:3) = 0.e0_rt
              Sr_new(dim) = rhon * const_grav
              SrE_new     = dot_product(vnew, Sr_new)
 

--- a/Source/Src_nd/hybrid_advection_nd.F90
+++ b/Source/Src_nd/hybrid_advection_nd.F90
@@ -1,5 +1,6 @@
 module hybrid_advection_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
 contains
@@ -13,14 +14,15 @@ contains
     use castro_util_module, only: position
     use prob_params_module, only: center
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer          :: lo(3), hi(3)
     integer          :: s_lo(3), s_hi(3)
-    double precision :: state(s_lo(1):s_hi(1),s_lo(2):s_hi(2),s_lo(3):s_hi(3),NVAR)
+    real(rt)         :: state(s_lo(1):s_hi(1),s_lo(2):s_hi(2),s_lo(3):s_hi(3),NVAR)
 
     integer          :: i, j, k
-    double precision :: loc(3)
+    real(rt)         :: loc(3)
 
     do k = lo(3), hi(3)
        do j = lo(2), hi(2)
@@ -48,16 +50,17 @@ contains
     use network, only: nspec, naux
     use eos_module
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer          :: lo(3), hi(3)
     integer          :: s_lo(3), s_hi(3)
     integer          :: e_lo(3), e_hi(3)
-    double precision :: state(s_lo(1):s_hi(1),s_lo(2):s_hi(2),s_lo(3):s_hi(3),NVAR)
-    double precision :: ext_src(e_lo(1):e_hi(1),e_lo(2):e_hi(2),e_lo(3):e_hi(3),NVAR)
+    real(rt)         :: state(s_lo(1):s_hi(1),s_lo(2):s_hi(2),s_lo(3):s_hi(3),NVAR)
+    real(rt)         :: ext_src(e_lo(1):e_hi(1),e_lo(2):e_hi(2),e_lo(3):e_hi(3),NVAR)
 
     integer          :: i, j, k
-    double precision :: loc(3), R, rhoInv
+    real(rt)         :: loc(3), R, rhoInv
 
     do k = lo(3), hi(3)
        do j = lo(2), hi(2)
@@ -86,12 +89,13 @@ contains
 
     use bl_constants_module, only: ZERO
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
-    double precision, intent(in) :: loc(3), mom_in(3)
-    double precision :: mom_out(3)
+    real(rt)        , intent(in) :: loc(3), mom_in(3)
+    real(rt)         :: mom_out(3)
 
-    double precision :: R
+    real(rt)         :: R
 
     R = sqrt( loc(1)**2 + loc(2)**2 )
 
@@ -119,12 +123,13 @@ contains
 
     use bl_constants_module, only: ZERO
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
-    double precision, intent(in) :: loc(3), mom_in(3)
-    double precision :: mom_out(3)
+    real(rt)        , intent(in) :: loc(3), mom_in(3)
+    real(rt)         :: mom_out(3)
 
-    double precision :: R
+    real(rt)         :: R
 
     R = sqrt( loc(1)**2 + loc(2)**2 )
 
@@ -142,12 +147,13 @@ contains
 
   subroutine add_hybrid_momentum_source(loc, mom, source)
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
-    double precision, intent(in   ) :: loc(3), source(3)
-    double precision, intent(inout) :: mom(3)
+    real(rt)        , intent(in   ) :: loc(3), source(3)
+    real(rt)        , intent(inout) :: mom(3)
 
-    double precision :: R
+    real(rt)         :: R
 
     R = sqrt( loc(1)**2 + loc(2)**2 )
 
@@ -168,17 +174,18 @@ contains
     use prob_params_module, only: center
     use castro_util_module, only: position
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
-    double precision :: state(NGDNV)
-    double precision :: flux(NVAR)
+    real(rt)         :: state(NGDNV)
+    real(rt)         :: flux(NVAR)
     integer          :: idir, idx(3)
     logical, optional :: cell_centered
 
-    double precision :: linear_mom(3), hybrid_mom(3)
-    double precision :: loc(3), R
+    real(rt)         :: linear_mom(3), hybrid_mom(3)
+    real(rt)         :: loc(3), R
 
-    double precision :: u_adv
+    real(rt)         :: u_adv
     logical :: cc
 
     cc = .false.
@@ -247,6 +254,7 @@ contains
     use castro_util_module, only: position
     use amrinfo_module, only: amr_level
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer          :: lo(3), hi(3)
@@ -254,14 +262,14 @@ contains
     integer          :: qx_lo(3), qx_hi(3)
     integer          :: qy_lo(3), qy_hi(3)
     integer          :: qz_lo(3), qz_hi(3)
-    double precision :: update(u_lo(1):u_hi(1),u_lo(2):u_hi(2),u_lo(3):u_hi(3),NVAR)
-    double precision :: qx(qx_lo(1):qx_hi(1),qx_lo(2):qx_hi(2),qx_lo(3):qx_hi(3),NGDNV)
-    double precision :: qy(qy_lo(1):qy_hi(1),qy_lo(2):qy_hi(2),qy_lo(3):qy_hi(3),NGDNV)
-    double precision :: qz(qz_lo(1):qz_hi(1),qz_lo(2):qz_hi(2),qz_lo(3):qz_hi(3),NGDNV)
-    double precision :: dt
+    real(rt)         :: update(u_lo(1):u_hi(1),u_lo(2):u_hi(2),u_lo(3):u_hi(3),NVAR)
+    real(rt)         :: qx(qx_lo(1):qx_hi(1),qx_lo(2):qx_hi(2),qx_lo(3):qx_hi(3),NGDNV)
+    real(rt)         :: qy(qy_lo(1):qy_hi(1),qy_lo(2):qy_hi(2),qy_lo(3):qy_hi(3),NGDNV)
+    real(rt)         :: qz(qz_lo(1):qz_hi(1),qz_lo(2):qz_hi(2),qz_lo(3):qz_hi(3),NGDNV)
+    real(rt)         :: dt
 
     integer          :: i, j, k
-    double precision :: loc(3), R, dx(3)
+    real(rt)         :: loc(3), R, dx(3)
 
     dx = dx_level(:,amr_level)
 
@@ -293,14 +301,15 @@ contains
     use castro_util_module, only: position
     use prob_params_module, only: center
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer          :: lo(3), hi(3)
     integer          :: state_lo(3), state_hi(3)
-    double precision :: state(state_lo(1):state_hi(1),state_lo(2):state_hi(2),state_lo(3):state_hi(3),NVAR)
+    real(rt)         :: state(state_lo(1):state_hi(1),state_lo(2):state_hi(2),state_lo(3):state_hi(3),NVAR)
 
     integer          :: i, j, k
-    double precision :: loc(3)
+    real(rt)         :: loc(3)
 
     do k = lo(3), hi(3)
        do j = lo(2), hi(2)

--- a/Source/Src_nd/interpolate.f90
+++ b/Source/Src_nd/interpolate.f90
@@ -1,5 +1,6 @@
 module interpolate_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   contains
@@ -10,15 +11,16 @@ module interpolate_module
 !     find the value of model_var at point r using linear interpolation.
 !     Eventually, we can do something fancier here.
       
-      double precision, intent(in   ) :: r
+      use bl_fort_module, only : rt => c_real
+      real(rt)        , intent(in   ) :: r
       integer         , intent(in   ) :: npts_model
-      double precision, intent(in   ) :: model_r(npts_model), model_var(npts_model)
+      real(rt)        , intent(in   ) :: model_r(npts_model), model_var(npts_model)
       integer, intent(in), optional   :: iloc
-      double precision                :: interpolate
+      real(rt)                        :: interpolate
 
       ! Local variables
       integer                         :: id
-      double precision                :: slope,minvar,maxvar
+      real(rt)                        :: slope,minvar,maxvar
       
 !     find the location in the coordinate array where we want to interpolate
       if (present(iloc)) then
@@ -89,18 +91,19 @@ module interpolate_module
       ! tri-linear interpolation; useful for EOS tables
       ! this is stricly interpolation, so if the point (x,y,z) is outside
       ! the bounds of model_x,model_y,model_z, then we abort
-      double precision, intent(in   ) :: x,y,z
+      use bl_fort_module, only : rt => c_real
+      real(rt)        , intent(in   ) :: x,y,z
       integer,          intent(in   ) :: npts_x, npts_y, npts_z
-      double precision, intent(in   ) :: model_x(npts_x), &
+      real(rt)        , intent(in   ) :: model_x(npts_x), &
                                          model_y(npts_y), &
                                          model_z(npts_z), &
                                          model_var(npts_x,npts_y,npts_z)
-      double precision, intent(  out) :: interp_var, derivs(3)
+      real(rt)        , intent(  out) :: interp_var, derivs(3)
       logical,          intent(  out) :: error
 
       integer :: ix,iy,iz
-      double precision :: deltax, deltay, deltaz
-      double precision :: c(8), delta(8)
+      real(rt)         :: deltax, deltay, deltaz
+      real(rt)         :: c(8), delta(8)
 
       error = .false.
 
@@ -158,8 +161,9 @@ module interpolate_module
 
 
     function locate(x, n, xs)
+      use bl_fort_module, only : rt => c_real
       integer, intent(in) :: n
-      double precision, intent(in) :: x, xs(n)
+      real(rt)        , intent(in) :: x, xs(n)
       integer :: locate      
 
       integer :: ilo, ihi, imid

--- a/Source/Src_nd/io.f90
+++ b/Source/Src_nd/io.f90
@@ -1,5 +1,6 @@
 module io_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   public
@@ -10,6 +11,7 @@ contains
 
     use iso_fortran_env, only: output_unit
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     flush(output_unit)

--- a/Source/Src_nd/math.f90
+++ b/Source/Src_nd/math.f90
@@ -8,10 +8,11 @@ contains
 
   function cross_product(A,B) result(C)
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
-    double precision :: A(3), B(3)
-    double precision :: C(3)
+    real(rt)         :: A(3), B(3)
+    real(rt)         :: C(3)
 
     C(1) = A(2)*B(3) - A(3)*B(2)
     C(2) = A(3)*B(1) - A(1)*B(3)

--- a/Source/Src_nd/meth_params.F90
+++ b/Source/Src_nd/meth_params.F90
@@ -14,6 +14,7 @@ module meth_params_module
 
   use bl_error_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   ! number of ghost cells for the hyperbolic solver
@@ -44,7 +45,7 @@ module meth_params_module
   logical, save :: do_inelastic_scattering
   logical, save :: comoving
 
-  double precision, save :: flatten_pp_threshold = -1.d0
+  real(rt)        , save :: flatten_pp_threshold = -1.e0_rt
 #endif
 
   integer, save :: npassive
@@ -60,14 +61,14 @@ module meth_params_module
 
   integer         , save :: numpts_1d
 
-  double precision, save, allocatable :: outflow_data_old(:,:)
-  double precision, save, allocatable :: outflow_data_new(:,:)
-  double precision, save :: outflow_data_old_time
-  double precision, save :: outflow_data_new_time
+  real(rt)        , save, allocatable :: outflow_data_old(:,:)
+  real(rt)        , save, allocatable :: outflow_data_new(:,:)
+  real(rt)        , save :: outflow_data_old_time
+  real(rt)        , save :: outflow_data_new_time
   logical         , save :: outflow_data_allocated
-  double precision, save :: max_dist
+  real(rt)        , save :: max_dist
 
-  double precision, save :: diffuse_cutoff_density
+  real(rt)        , save :: diffuse_cutoff_density
 
   character(len=:), allocatable :: gravity_type
 
@@ -99,11 +100,11 @@ module meth_params_module
 
   ! Begin the declarations of the ParmParse parameters
 
-  double precision, save :: difmag
-  double precision, save :: small_dens
-  double precision, save :: small_temp
-  double precision, save :: small_pres
-  double precision, save :: small_ener
+  real(rt)        , save :: difmag
+  real(rt)        , save :: small_dens
+  real(rt)        , save :: small_temp
+  real(rt)        , save :: small_pres
+  real(rt)        , save :: small_ener
   integer         , save :: do_hydro
   integer         , save :: hybrid_hydro
   integer         , save :: ppm_type
@@ -115,16 +116,16 @@ module meth_params_module
   integer         , save :: hybrid_riemann
   integer         , save :: riemann_solver
   integer         , save :: cg_maxiter
-  double precision, save :: cg_tol
+  real(rt)        , save :: cg_tol
   integer         , save :: cg_blend
   integer         , save :: use_flattening
   integer         , save :: transverse_use_eos
   integer         , save :: transverse_reset_density
   integer         , save :: transverse_reset_rhoe
   integer         , save :: dual_energy_update_E_from_e
-  double precision, save :: dual_energy_eta1
-  double precision, save :: dual_energy_eta2
-  double precision, save :: dual_energy_eta3
+  real(rt)        , save :: dual_energy_eta1
+  real(rt)        , save :: dual_energy_eta2
+  real(rt)        , save :: dual_energy_eta3
   integer         , save :: use_pslope
   integer         , save :: fix_mass_flux
   integer         , save :: limit_fluxes_on_small_dens
@@ -143,22 +144,22 @@ module meth_params_module
   integer         , save :: hse_zero_vels
   integer         , save :: hse_interp_temp
   integer         , save :: hse_reflect_vels
-  double precision, save :: cfl
-  double precision, save :: dtnuc_e
-  double precision, save :: dtnuc_X
+  real(rt)        , save :: cfl
+  real(rt)        , save :: dtnuc_e
+  real(rt)        , save :: dtnuc_X
   integer         , save :: dtnuc_mode
-  double precision, save :: dxnuc
+  real(rt)        , save :: dxnuc
   integer         , save :: do_react
-  double precision, save :: react_T_min
-  double precision, save :: react_T_max
-  double precision, save :: react_rho_min
-  double precision, save :: react_rho_max
+  real(rt)        , save :: react_T_min
+  real(rt)        , save :: react_T_max
+  real(rt)        , save :: react_rho_min
+  real(rt)        , save :: react_rho_max
   integer         , save :: disable_shock_burning
   integer         , save :: do_grav
   integer         , save :: grav_source_type
   integer         , save :: do_rotation
-  double precision, save :: rot_period
-  double precision, save :: rot_period_dot
+  real(rt)        , save :: rot_period
+  real(rt)        , save :: rot_period_dot
   integer         , save :: rotation_include_centrifugal
   integer         , save :: rotation_include_coriolis
   integer         , save :: rotation_include_domegadt
@@ -166,11 +167,11 @@ module meth_params_module
   integer         , save :: rot_source_type
   integer         , save :: implicit_rotation_update
   integer         , save :: rot_axis
-  double precision, save :: point_mass
+  real(rt)        , save :: point_mass
   integer         , save :: point_mass_fix_solution
   integer         , save :: do_acc
   integer         , save :: track_grid_losses
-  double precision, save :: const_grav
+  real(rt)        , save :: const_grav
   integer         , save :: get_g_from_phi
 
   !$acc declare &
@@ -200,7 +201,7 @@ module meth_params_module
 
   ! End the declarations of the ParmParse parameters
 
-  double precision, save :: rot_vec(3)
+  real(rt)        , save :: rot_vec(3)
 
 contains
 
@@ -208,17 +209,18 @@ contains
 
     use parmparse_module, only: parmparse_build, parmparse_destroy, ParmParse
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     type (ParmParse) :: pp
 
     call parmparse_build(pp, "castro")
 
-    difmag = 0.1d0;
-    small_dens = -1.d200;
-    small_temp = -1.d200;
-    small_pres = -1.d200;
-    small_ener = -1.d200;
+    difmag = 0.1e0_rt;
+    small_dens = -1.e200_rt;
+    small_temp = -1.e200_rt;
+    small_pres = -1.e200_rt;
+    small_ener = -1.e200_rt;
     do_hydro = -1;
     hybrid_hydro = 0;
     ppm_type = 1;
@@ -230,16 +232,16 @@ contains
     hybrid_riemann = 0;
     riemann_solver = 0;
     cg_maxiter = 12;
-    cg_tol = 1.0d-5;
+    cg_tol = 1.0e-5_rt;
     cg_blend = 2;
     use_flattening = 1;
     transverse_use_eos = 0;
     transverse_reset_density = 1;
     transverse_reset_rhoe = 0;
     dual_energy_update_E_from_e = 1;
-    dual_energy_eta1 = 1.0d0;
-    dual_energy_eta2 = 1.0d-4;
-    dual_energy_eta3 = 1.0d0;
+    dual_energy_eta1 = 1.0e0_rt;
+    dual_energy_eta2 = 1.0e-4_rt;
+    dual_energy_eta3 = 1.0e0_rt;
     use_pslope = 1;
     fix_mass_flux = 0;
     limit_fluxes_on_small_dens = 0;
@@ -258,22 +260,22 @@ contains
     hse_zero_vels = 0;
     hse_interp_temp = 0;
     hse_reflect_vels = 0;
-    cfl = 0.8d0;
-    dtnuc_e = 1.d200;
-    dtnuc_X = 1.d200;
+    cfl = 0.8e0_rt;
+    dtnuc_e = 1.e200_rt;
+    dtnuc_X = 1.e200_rt;
     dtnuc_mode = 1;
-    dxnuc = 1.d200;
+    dxnuc = 1.e200_rt;
     do_react = -1;
-    react_T_min = 0.0d0;
-    react_T_max = 1.d200;
-    react_rho_min = 0.0d0;
-    react_rho_max = 1.d200;
+    react_T_min = 0.0e0_rt;
+    react_T_max = 1.e200_rt;
+    react_rho_min = 0.0e0_rt;
+    react_rho_max = 1.e200_rt;
     disable_shock_burning = 0;
     do_grav = -1;
     grav_source_type = 4;
     do_rotation = -1;
-    rot_period = -1.d200;
-    rot_period_dot = 0.0d0;
+    rot_period = -1.e200_rt;
+    rot_period_dot = 0.0e0_rt;
     rotation_include_centrifugal = 1;
     rotation_include_coriolis = 1;
     rotation_include_domegadt = 1;
@@ -281,11 +283,11 @@ contains
     rot_source_type = 4;
     implicit_rotation_update = 1;
     rot_axis = 3;
-    point_mass = 0.0d0;
+    point_mass = 0.0e0_rt;
     point_mass_fix_solution = 0;
     do_acc = -1;
     track_grid_losses = 0;
-    const_grav = 0.0d0;
+    const_grav = 0.0e0_rt;
     get_g_from_phi = 0;
 
     call pp%query("difmag", difmag)
@@ -474,6 +476,7 @@ contains
 #ifdef RADIATION
   subroutine get_qradvar(qradvar_in) bind(C, name="get_qradvar")
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer, intent(inout) :: qradvar_in
@@ -487,8 +490,9 @@ contains
 
     use rad_params_module, only : ngroups
 
+    use bl_fort_module, only : rt => c_real
     integer, intent(in) :: fsp_type_in, do_is_in, com_in
-    double precision, intent(in) :: fppt
+    real(rt)        , intent(in) :: fppt
 
     QPTOT  = QVAR+1
     QREITOT = QVAR+2
@@ -532,7 +536,7 @@ contains
     !$acc device(fspace_type) &
     !$acc device(do_inelastic_scattering) &
     !$acc device(comoving)
-    !$acc device(flatten_pp_threshold = -1.d0)
+    !$acc device(flatten_pp_threshold = -1.e0_rt)
 
   end subroutine ca_init_radhydro_pars
 #endif

--- a/Source/Src_nd/parmparse_mod.f90
+++ b/Source/Src_nd/parmparse_mod.f90
@@ -3,6 +3,7 @@ module parmparse_module
   use iso_c_binding
   use string_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   private
@@ -29,6 +30,7 @@ module parmparse_module
   interface
      subroutine fi_new_parmparse (pp, name) bind(c)
        use iso_c_binding
+       use bl_fort_module, only : rt => c_real
        implicit none
        type(c_ptr) :: pp
        character(c_char), intent(in) :: name(*)
@@ -36,12 +38,14 @@ module parmparse_module
 
      subroutine fi_delete_parmparse (pp) bind(c)
        use iso_c_binding
+       use bl_fort_module, only : rt => c_real
        implicit none
        type(c_ptr), value :: pp
      end subroutine fi_delete_parmparse
 
      subroutine fi_parmparse_get_int (pp, name, v) bind(c)
        use iso_c_binding
+       use bl_fort_module, only : rt => c_real
        implicit none
        type(c_ptr), value :: pp
        character(c_char), intent(in) :: name(*)
@@ -50,6 +54,7 @@ module parmparse_module
 
      subroutine fi_parmparse_get_double (pp, name, v) bind(c)
        use iso_c_binding
+       use bl_fort_module, only : rt => c_real
        implicit none
        type(c_ptr), value :: pp
        character(c_char), intent(in) :: name(*)
@@ -58,6 +63,7 @@ module parmparse_module
 
      subroutine fi_parmparse_get_bool (pp, name, v) bind(c)
        use iso_c_binding
+       use bl_fort_module, only : rt => c_real
        implicit none
        type(c_ptr), value :: pp
        character(c_char), intent(in) :: name(*)
@@ -66,6 +72,7 @@ module parmparse_module
 
      subroutine fi_parmparse_get_string (pp, name, v, len) bind(c)
        use iso_c_binding
+       use bl_fort_module, only : rt => c_real
        implicit none
        type(c_ptr), value :: pp
        character(c_char), intent(in) :: name(*)
@@ -75,6 +82,7 @@ module parmparse_module
 
      subroutine fi_parmparse_query_int (pp, name, v) bind(c)
        use iso_c_binding
+       use bl_fort_module, only : rt => c_real
        implicit none
        type(c_ptr), value :: pp
        character(c_char), intent(in) :: name(*)
@@ -83,6 +91,7 @@ module parmparse_module
 
      subroutine fi_parmparse_query_double (pp, name, v) bind(c)
        use iso_c_binding
+       use bl_fort_module, only : rt => c_real
        implicit none
        type(c_ptr), value :: pp
        character(c_char), intent(in) :: name(*)
@@ -91,6 +100,7 @@ module parmparse_module
 
      subroutine fi_parmparse_query_bool (pp, name, v) bind(c)
        use iso_c_binding
+       use bl_fort_module, only : rt => c_real
        implicit none
        type(c_ptr), value :: pp
        character(c_char), intent(in) :: name(*)
@@ -99,6 +109,7 @@ module parmparse_module
 
      subroutine fi_parmparse_query_string (pp, name, v, len) bind(c)
        use iso_c_binding
+       use bl_fort_module, only : rt => c_real
        implicit none
        type(c_ptr), value :: pp
        character(c_char), intent(in) :: name(*)
@@ -110,12 +121,14 @@ module parmparse_module
 contains
 
   subroutine parmparse_build (pp, name)
+    use bl_fort_module, only : rt => c_real
     type(ParmParse) :: pp
     character(*), intent(in) :: name
     call fi_new_parmparse(pp%p, string_f_to_c(name))
   end subroutine parmparse_build
 
   subroutine parmparse_destroy (this)
+    use bl_fort_module, only : rt => c_real
     type(ParmParse) :: this
     if (c_associated(this%p)) then
        call fi_delete_parmparse(this%p)
@@ -124,6 +137,7 @@ contains
   end subroutine parmparse_destroy
 
   subroutine get_int (this, name, v)
+    use bl_fort_module, only : rt => c_real
     class(ParmParse), intent(in) :: this
     character(len=*), intent(in) :: name
     integer :: v
@@ -131,13 +145,15 @@ contains
   end subroutine get_int
 
   subroutine get_double (this, name, v)
+    use bl_fort_module, only : rt => c_real
     class(ParmParse), intent(in) :: this
     character(*), intent(in) :: name
-    double precision :: v
+    real(rt)         :: v
     call fi_parmparse_get_double (this%p, string_f_to_c(name), v)
   end subroutine get_double
 
   subroutine get_logical (this, name, v)
+    use bl_fort_module, only : rt => c_real
     class(ParmParse), intent(in) :: this
     character(*), intent(in) :: name
     logical :: v
@@ -147,6 +163,7 @@ contains
   end subroutine get_logical
 
   subroutine get_string (this, name, v)
+    use bl_fort_module, only : rt => c_real
     class(ParmParse), intent(in) :: this
     character(*), intent(in) :: name
     character(*), intent(inout) :: v
@@ -161,6 +178,7 @@ contains
   end subroutine get_string
 
   subroutine query_int (this, name, v)
+    use bl_fort_module, only : rt => c_real
     class(ParmParse), intent(in) :: this
     character(len=*), intent(in) :: name
     integer :: v
@@ -168,13 +186,15 @@ contains
   end subroutine query_int
 
   subroutine query_double (this, name, v)
+    use bl_fort_module, only : rt => c_real
     class(ParmParse), intent(in) :: this
     character(*), intent(in) :: name
-    double precision :: v
+    real(rt)         :: v
     call fi_parmparse_query_double (this%p, string_f_to_c(name), v)
   end subroutine query_double
 
   subroutine query_logical (this, name, v)
+    use bl_fort_module, only : rt => c_real
     class(ParmParse), intent(in) :: this
     character(*), intent(in) :: name
     logical :: v
@@ -184,6 +204,7 @@ contains
   end subroutine query_logical
 
   subroutine query_string (this, name, v)
+    use bl_fort_module, only : rt => c_real
     class(ParmParse), intent(in) :: this
     character(*), intent(in) :: name
     character(*), intent(inout) :: v

--- a/Source/Src_nd/pointmass_nd.f90
+++ b/Source/Src_nd/pointmass_nd.f90
@@ -11,17 +11,18 @@
        use fundamental_constants_module, only : Gconst
        use prob_params_module          , only : center
 
+       use bl_fort_module, only : rt => c_real
        implicit none
        integer         , intent(in   ) :: lo(3), hi(3)
        integer         , intent(in   ) :: grav_lo(3), grav_hi(3)
        integer         , intent(in   ) :: phi_lo(3), phi_hi(3)
-       double precision, intent(in   ) :: point_mass
-       double precision, intent(inout) :: phi(phi_lo(1):phi_hi(1),phi_lo(2):phi_hi(2),phi_lo(3):phi_hi(3))
-       double precision, intent(inout) :: grav(grav_lo(1):grav_hi(1),grav_lo(2):grav_hi(2),grav_lo(3):grav_hi(3),3)
-       double precision, intent(in   ) :: problo(3),dx(3)
+       real(rt)        , intent(in   ) :: point_mass
+       real(rt)        , intent(inout) :: phi(phi_lo(1):phi_hi(1),phi_lo(2):phi_hi(2),phi_lo(3):phi_hi(3))
+       real(rt)        , intent(inout) :: grav(grav_lo(1):grav_hi(1),grav_lo(2):grav_hi(2),grav_lo(3):grav_hi(3),3)
+       real(rt)        , intent(in   ) :: problo(3),dx(3)
 
        integer          :: i,j,k
-       double precision :: x,y,z,rsq,radial_force,rinv
+       real(rt)         :: x,y,z,rsq,radial_force,rinv
 
 !      This computes radial gravity due to a point mass at center().
        do k = lo(3), hi(3)
@@ -34,7 +35,7 @@
                 rsq = x*x + y*y + z*z
                 radial_force = -Gconst * point_mass / rsq
 
-                rinv = 1.d0/sqrt(rsq)
+                rinv = 1.e0_rt/sqrt(rsq)
 
                 ! Note that grav may have more ghost zones than
                 ! phi, so we need to check that we're doing
@@ -72,6 +73,7 @@
       use meth_params_module, only : NVAR, URHO
       use prob_params_module, only : center
 
+      use bl_fort_module, only : rt => c_real
       implicit none
 
       integer :: lo(3),      hi(3)
@@ -79,16 +81,16 @@
       integer :: uout_lo(3), uout_hi(3)
       integer :: vol_lo(3),  vol_hi(3)
 
-      double precision   ::   delta_mass
-      double precision   ::   uin(uin_lo(1):uin_hi(1),uin_lo(2):uin_hi(2),  &
+      real(rt)           ::   delta_mass
+      real(rt)           ::   uin(uin_lo(1):uin_hi(1),uin_lo(2):uin_hi(2),  &
                                   uin_lo(3):uin_hi(3),NVAR)
-      double precision   ::  uout(uout_lo(1):uout_hi(1),uout_lo(2):uout_hi(2), &
+      real(rt)           ::  uout(uout_lo(1):uout_hi(1),uout_lo(2):uout_hi(2), &
                                   uout_lo(3):uout_hi(3),NVAR)
-      double precision   ::   vol(vol_lo(1):vol_hi(1),vol_lo(2):vol_hi(2), &
+      real(rt)           ::   vol(vol_lo(1):vol_hi(1),vol_lo(2):vol_hi(2), &
                                   vol_lo(3):vol_hi(3))
-      double precision   :: problo(3),dx(3),time,dt
+      real(rt)           :: problo(3),dx(3),time,dt
 
-      double precision   :: eps
+      real(rt)           :: eps
       integer            :: ii,icen,istart,iend
       integer            :: jj,jcen,jstart,jend
       integer            :: kk,kcen,kstart,kend
@@ -96,7 +98,7 @@
 
       ! This is just a small number to keep precision issues from making
       !   icen,jcen,kcen one cell too low.
-      eps = 1.d-8
+      eps = 1.e-8_rt
 
       ! This should be the cell whose lower left corner is at "center"
       icen = floor( (center(1)-problo(1))/dx(1) + eps)
@@ -135,19 +137,20 @@
       use meth_params_module, only : NVAR
       use prob_params_module, only : center
 
+      use bl_fort_module, only : rt => c_real
       implicit none
 
       integer :: lo(3),      hi(3)
       integer :: uin_lo(3),  uin_hi(3)
       integer :: uout_lo(3), uout_hi(3)
 
-      double precision   ::   uin(  uin_lo(1):uin_hi(1),    uin_lo(2):uin_hi(2),  &
+      real(rt)           ::   uin(  uin_lo(1):uin_hi(1),    uin_lo(2):uin_hi(2),  &
                                     uin_lo(3):uin_hi(3),NVAR)
-      double precision   ::  uout( uout_lo(1):uout_hi(1),  uout_lo(2):uout_hi(2), &
+      real(rt)           ::  uout( uout_lo(1):uout_hi(1),  uout_lo(2):uout_hi(2), &
                                     uout_lo(3):uout_hi(3),NVAR)
-      double precision   :: problo(3),dx(3),time,dt
+      real(rt)           :: problo(3),dx(3),time,dt
 
-      double precision   :: eps
+      real(rt)           :: eps
       integer            :: ii,icen,istart,iend
       integer            :: jj,jcen,jstart,jend
       integer            :: kk,kcen,kstart,kend
@@ -155,7 +158,7 @@
 
       ! This is just a small number to keep precision issues from making
       !   icen,jcen,kcen one cell too low.
-      eps = 1.d-8
+      eps = 1.e-8_rt
 
       ! This should be the cell whose lower left corner is at "center"
       icen = floor( (center(1)-problo(1))/dx(1) + eps)

--- a/Source/Src_nd/prescribe_grav_nd.f90
+++ b/Source/Src_nd/prescribe_grav_nd.f90
@@ -1,5 +1,6 @@
 module prescribe_grav_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
 contains
@@ -13,18 +14,19 @@ contains
     use prob_params_module, only: dim
     ! use prob_params_module, only: problo, center
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer          :: lo(3), hi(3)
     integer          :: g_lo(3), g_hi(3)
-    double precision :: grav(g_lo(1):g_hi(1),g_lo(2):g_hi(2),g_lo(3):g_hi(3),dim)
-    double precision :: dx(3)
+    real(rt)         :: grav(g_lo(1):g_hi(1),g_lo(2):g_hi(2),g_lo(3):g_hi(3),dim)
+    real(rt)         :: dx(3)
 
     ! Local variables
     !     integer          :: i, j, k
-    !     double precision :: x, y, z
-    !     double precision :: r, maggrav
-    !     double precision :: r_c, rho_c
+    !     real(rt)         :: x, y, z
+    !     real(rt)         :: r, maggrav
+    !     real(rt)         :: r_c, rho_c
 
     !     This is an example of how to specify a radial profile.
     !     Note that in this example r_c and rho_c could be saved 
@@ -33,8 +35,8 @@ contains
     !     in fewer than three dimensions; you may want to set
     !     z = 0 for 2D and y = 0 for 1D.
     !
-    !     r_c = 1.0d9
-    !     rho_c = 1.0d8
+    !     r_c = 1.0e9_rt
+    !     rho_c = 1.0e8_rt
     !
     !     do k = lo(3), hi(3)
     !        if (dim .eq. 3) then      

--- a/Source/Src_nd/prescribe_phi_nd.F90
+++ b/Source/Src_nd/prescribe_phi_nd.F90
@@ -1,5 +1,6 @@
 module prescribe_phi_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
 contains
@@ -12,18 +13,19 @@ contains
     ! use fundamental_constants_module, only: Gconst
     ! use prob_params_module, only: problo, center, dim
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer          :: lo(3), hi(3)
     integer          :: p_lo(3), p_hi(3)
-    double precision :: phi(p_lo(1):p_hi(1),p_lo(2):p_hi(2),p_lo(3):p_hi(3))
-    double precision :: dx(3)
+    real(rt)         :: phi(p_lo(1):p_hi(1),p_lo(2):p_hi(2),p_lo(3):p_hi(3))
+    real(rt)         :: dx(3)
 
     ! Local variables
     !     integer          :: i, j, k
-    !     double precision :: x, y, z
-    !     double precision :: r, maggrav
-    !     double precision :: M_c
+    !     real(rt)         :: x, y, z
+    !     real(rt)         :: r, maggrav
+    !     real(rt)         :: M_c
 
     !     This is an example of how to specify a radial profile.
     !     Note that in this example M_c could be saved 
@@ -32,7 +34,7 @@ contains
     !     in fewer than three dimensions; you may want to set
     !     z = 0 for 2D and y = 0 for 1D.
     !
-    !     M_c = 1.0d33
+    !     M_c = 1.0e33_rt
     !
     !     do k = lo(3), hi(3)
     !        if (dim .eq. 3) then      

--- a/Source/Src_nd/prob_params.f90
+++ b/Source/Src_nd/prob_params.f90
@@ -4,6 +4,7 @@
 
 module prob_params_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   ! boundary condition information
@@ -13,7 +14,7 @@ module prob_params_module
 
   ! geometry information
   integer         , save :: coord_type
-  double precision, save :: center(3), problo(3), probhi(3)
+  real(rt)        , save :: center(3), problo(3), probhi(3)
 
   ! dimension information
   integer         , save :: dim
@@ -25,7 +26,7 @@ module prob_params_module
 
   ! grid information
   integer         , save              :: max_level
-  double precision, save, allocatable :: dx_level(:,:)
+  real(rt)        , save, allocatable :: dx_level(:,:)
   integer         , save, allocatable :: domlo_level(:,:)
   integer         , save, allocatable :: domhi_level(:,:)
   integer         , save, allocatable :: ref_ratio(:,:)

--- a/Source/Src_nd/problem_tagging_nd.F90
+++ b/Source/Src_nd/problem_tagging_nd.F90
@@ -1,5 +1,6 @@
 module problem_tagging_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   public
@@ -18,16 +19,17 @@ contains
 
     use meth_params_module, only : NVAR
     
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer          :: lo(3),hi(3)
     integer          :: state_lo(3),state_hi(3)
     integer          :: tag_lo(3),tag_hi(3)
-    double precision :: state(state_lo(1):state_hi(1), &
+    real(rt)         :: state(state_lo(1):state_hi(1), &
                         state_lo(2):state_hi(2), &
                         state_lo(3):state_hi(3),NVAR)
     integer          :: tag(tag_lo(1):tag_hi(1),tag_lo(2):tag_hi(2),tag_lo(3):tag_hi(3))
-    double precision :: problo(3),dx(3),time
+    real(rt)         :: problo(3),dx(3),time
     integer          :: level,set,clear
 
   end subroutine set_problem_tags

--- a/Source/Src_nd/riemann_util.f90
+++ b/Source/Src_nd/riemann_util.f90
@@ -3,6 +3,7 @@ module riemann_util_module
   use bl_types
   use bl_constants_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
 contains
@@ -56,13 +57,13 @@ contains
 
     ! compute the lagrangian wave speeds.
 
-    double precision, intent(in) :: p,v,gam,gdot,pstar,csq,gmin,gmax
-    double precision, intent(out) :: wsq, gstar
+    real(rt)        , intent(in) :: p,v,gam,gdot,pstar,csq,gmin,gmax
+    real(rt)        , intent(out) :: wsq, gstar
 
-    double precision, parameter :: smlp1 = 1.d-10
-    double precision, parameter :: small = 1.d-7
+    real(rt)        , parameter :: smlp1 = 1.e-10_rt
+    real(rt)        , parameter :: small = 1.e-7_rt
 
-    double precision :: alpha, beta
+    real(rt)         :: alpha, beta
 
     ! First predict a value of game across the shock
 
@@ -102,16 +103,16 @@ contains
                                                   
     use meth_params_module, only : cg_maxiter, cg_tol
 
-    double precision, intent(inout) :: pstar_lo, pstar_hi
-    double precision, intent(in) :: ul, pl, taul, gamel, clsql
-    double precision, intent(in) :: ur, pr, taur, gamer, clsqr
-    double precision, intent(in) :: gdot, gmin, gmax
-    double precision, intent(out) :: pstar, gamstar
+    real(rt)        , intent(inout) :: pstar_lo, pstar_hi
+    real(rt)        , intent(in) :: ul, pl, taul, gamel, clsql
+    real(rt)        , intent(in) :: ur, pr, taur, gamer, clsqr
+    real(rt)        , intent(in) :: gdot, gmin, gmax
+    real(rt)        , intent(out) :: pstar, gamstar
     logical, intent(out) :: converged
-    double precision, intent(out) :: pstar_hist_extra(:)
+    real(rt)        , intent(out) :: pstar_hist_extra(:)
 
-    double precision :: pstar_c, ustar_l, ustar_r, f_lo, f_hi, f_c
-    double precision :: wl, wr, wlsq, wrsq
+    real(rt)         :: pstar_c, ustar_l, ustar_r, f_lo, f_hi, f_c
+    real(rt)         :: wl, wr, wlsq, wrsq
 
     integer :: iter
 
@@ -196,20 +197,21 @@ contains
                                    npassive, upass_map, qpass_map
     use prob_params_module, only : coord_type
 
-    double precision, intent(in) :: ql(QVAR), qr(QVAR), cl, cr
-    double precision, intent(inout) :: f(NVAR)
+    use bl_fort_module, only : rt => c_real
+    real(rt)        , intent(in) :: ql(QVAR), qr(QVAR), cl, cr
+    real(rt)        , intent(inout) :: f(NVAR)
     integer, intent(in) :: idir, ndim
 
     integer :: ivel, ivelt, iveltt, imom, imomt, imomtt
-    double precision :: a1, a4, bd, bl, bm, bp, br
-    double precision :: cavg, uavg
-    double precision :: fl_tmp, fr_tmp
-    double precision :: rhod, rhoEl, rhoEr, rhol_sqrt, rhor_sqrt
+    real(rt)         :: a1, a4, bd, bl, bm, bp, br
+    real(rt)         :: cavg, uavg
+    real(rt)         :: fl_tmp, fr_tmp
+    real(rt)         :: rhod, rhoEl, rhoEr, rhol_sqrt, rhor_sqrt
     integer :: n, nq
 
     integer :: ipassive
 
-    double precision, parameter :: small = 1.d-10
+    real(rt)        , parameter :: small = 1.e-10_rt
 
     select case (idir)
     case (1)
@@ -351,8 +353,8 @@ contains
          NVAR, URHO, UMX, UMY, UMZ, UEDEN, UEINT, UTEMP, &
          npassive, upass_map, qpass_map
 
-    real (kind=dp_t), intent(in)  :: q(QVAR)
-    real (kind=dp_t), intent(out) :: U(NVAR)
+    real(rt)        , intent(in)  :: q(QVAR)
+    real(rt)        , intent(out) :: U(NVAR)
 
     integer :: ipassive, n, nq
 
@@ -387,11 +389,11 @@ contains
          npassive, upass_map, qpass_map
 
     integer, intent(in) :: idir
-    real (kind=dp_t), intent(in)  :: S_k, S_c
-    real (kind=dp_t), intent(in)  :: q(QVAR)
-    real (kind=dp_t), intent(out) :: U(NVAR)
+    real(rt)        , intent(in)  :: S_k, S_c
+    real(rt)        , intent(in)  :: q(QVAR)
+    real(rt)        , intent(out) :: U(NVAR)
 
-    real (kind=dp_t) :: hllc_factor, u_k
+    real(rt)         :: hllc_factor, u_k
     integer :: ipassive, n, nq
 
     if (idir == 1) then
@@ -441,12 +443,12 @@ contains
     use prob_params_module, only : coord_type
 
     integer, intent(in) :: idir, ndim, bnd_fac
-    real (kind=dp_t), intent(in) :: U(NVAR)
-    real (kind=dp_t), intent(in) :: p
-    real (kind=dp_t), intent(out) :: F(NVAR)
+    real(rt)        , intent(in) :: U(NVAR)
+    real(rt)        , intent(in) :: p
+    real(rt)        , intent(out) :: F(NVAR)
 
     integer :: ipassive, n
-    real (kind=dp_t) :: u_flx
+    real(rt)         :: u_flx
 
     if (idir == 1) then
        u_flx = U(UMX)/U(URHO)

--- a/Source/Src_nd/rotation_sources_nd.F90
+++ b/Source/Src_nd/rotation_sources_nd.F90
@@ -1,5 +1,6 @@
 module rotation_sources_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   public
@@ -20,6 +21,7 @@ contains
     use hybrid_advection_module, only: add_hybrid_momentum_source
 #endif
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer         , intent(in   ) :: lo(3), hi(3)
@@ -30,26 +32,26 @@ contains
     integer         , intent(in   ) :: src_lo(3), src_hi(3)
     integer         , intent(in   ) :: vol_lo(3), vol_hi(3)
 
-    double precision, intent(in   ) :: phi(phi_lo(1):phi_hi(1),phi_lo(2):phi_hi(2),phi_lo(3):phi_hi(3))
-    double precision, intent(in   ) :: rot(rot_lo(1):rot_hi(1),rot_lo(2):rot_hi(2),rot_lo(3):rot_hi(3),3)
-    double precision, intent(in   ) :: uold(uold_lo(1):uold_hi(1),uold_lo(2):uold_hi(2),uold_lo(3):uold_hi(3),NVAR)
-    double precision, intent(inout) :: source(src_lo(1):src_hi(1),src_lo(2):src_hi(2),src_lo(3):src_hi(3),NVAR)
-    double precision, intent(in   ) :: vol(vol_lo(1):vol_hi(1),vol_lo(2):vol_hi(2),vol_lo(3):vol_hi(3))
-    double precision, intent(in   ) :: dx(3), dt, time
+    real(rt)        , intent(in   ) :: phi(phi_lo(1):phi_hi(1),phi_lo(2):phi_hi(2),phi_lo(3):phi_hi(3))
+    real(rt)        , intent(in   ) :: rot(rot_lo(1):rot_hi(1),rot_lo(2):rot_hi(2),rot_lo(3):rot_hi(3),3)
+    real(rt)        , intent(in   ) :: uold(uold_lo(1):uold_hi(1),uold_lo(2):uold_hi(2),uold_lo(3):uold_hi(3),NVAR)
+    real(rt)        , intent(inout) :: source(src_lo(1):src_hi(1),src_lo(2):src_hi(2),src_lo(3):src_hi(3),NVAR)
+    real(rt)        , intent(in   ) :: vol(vol_lo(1):vol_hi(1),vol_lo(2):vol_hi(2),vol_lo(3):vol_hi(3))
+    real(rt)        , intent(in   ) :: dx(3), dt, time
 
     integer          :: i, j ,k
-    double precision :: Sr(3),SrE
-    double precision :: rho, rhoInv
+    real(rt)         :: Sr(3),SrE
+    real(rt)         :: rho, rhoInv
 
-    double precision :: old_rhoeint, new_rhoeint, old_ke, new_ke, old_re
-    double precision :: old_mom(3), loc(3)
-    double precision :: E_added, mom_added(3)
+    real(rt)         :: old_rhoeint, new_rhoeint, old_ke, new_ke, old_re
+    real(rt)         :: old_mom(3), loc(3)
+    real(rt)         :: E_added, mom_added(3)
 
-    double precision :: src(NVAR)
+    real(rt)         :: src(NVAR)
 
     ! Temporary array for seeing what the new state would be if the update were applied here.
 
-    double precision :: snew(NVAR)
+    real(rt)         :: snew(NVAR)
 
     do k = lo(3), hi(3)
        do j = lo(2), hi(2)
@@ -172,6 +174,7 @@ contains
     use hybrid_advection_module, only: add_hybrid_momentum_source
 #endif
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer          :: lo(3), hi(3)
@@ -191,50 +194,50 @@ contains
 
     ! Old and new time rotational potential
 
-    double precision :: pold(po_lo(1):po_hi(1),po_lo(2):po_hi(2),po_lo(3):po_hi(3))
-    double precision :: pnew(pn_lo(1):pn_hi(1),pn_lo(2):pn_hi(2),pn_lo(3):pn_hi(3))
+    real(rt)         :: pold(po_lo(1):po_hi(1),po_lo(2):po_hi(2),po_lo(3):po_hi(3))
+    real(rt)         :: pnew(pn_lo(1):pn_hi(1),pn_lo(2):pn_hi(2),pn_lo(3):pn_hi(3))
 
     ! Old and new time rotational acceleration
 
-    double precision :: rold(ro_lo(1):ro_hi(1),ro_lo(2):ro_hi(2),ro_lo(3):ro_hi(3),3)
-    double precision :: rnew(rn_lo(1):rn_hi(1),rn_lo(2):rn_hi(2),rn_lo(3):rn_hi(3),3)
+    real(rt)         :: rold(ro_lo(1):ro_hi(1),ro_lo(2):ro_hi(2),ro_lo(3):ro_hi(3),3)
+    real(rt)         :: rnew(rn_lo(1):rn_hi(1),rn_lo(2):rn_hi(2),rn_lo(3):rn_hi(3),3)
 
     ! Old and new time state data
 
-    double precision :: uold(uo_lo(1):uo_hi(1),uo_lo(2):uo_hi(2),uo_lo(3):uo_hi(3),NVAR)
-    double precision :: unew(un_lo(1):un_hi(1),un_lo(2):un_hi(2),un_lo(3):un_hi(3),NVAR)
+    real(rt)         :: uold(uo_lo(1):uo_hi(1),uo_lo(2):uo_hi(2),uo_lo(3):uo_hi(3),NVAR)
+    real(rt)         :: unew(un_lo(1):un_hi(1),un_lo(2):un_hi(2),un_lo(3):un_hi(3),NVAR)
 
     ! The source term to send back
 
-    double precision :: source(sr_lo(1):sr_hi(1),sr_lo(2):sr_hi(2),sr_lo(3):sr_hi(3),NVAR)
+    real(rt)         :: source(sr_lo(1):sr_hi(1),sr_lo(2):sr_hi(2),sr_lo(3):sr_hi(3),NVAR)
 
     ! Hydrodynamics fluxes
 
-    double precision :: flux1(f1_lo(1):f1_hi(1),f1_lo(2):f1_hi(2),f1_lo(3):f1_hi(3),NVAR)
-    double precision :: flux2(f2_lo(1):f2_hi(1),f2_lo(2):f2_hi(2),f2_lo(3):f2_hi(3),NVAR)
-    double precision :: flux3(f3_lo(1):f3_hi(1),f3_lo(2):f3_hi(2),f3_lo(3):f3_hi(3),NVAR)
+    real(rt)         :: flux1(f1_lo(1):f1_hi(1),f1_lo(2):f1_hi(2),f1_lo(3):f1_hi(3),NVAR)
+    real(rt)         :: flux2(f2_lo(1):f2_hi(1),f2_lo(2):f2_hi(2),f2_lo(3):f2_hi(3),NVAR)
+    real(rt)         :: flux3(f3_lo(1):f3_hi(1),f3_lo(2):f3_hi(2),f3_lo(3):f3_hi(3),NVAR)
 
-    double precision :: vol(vol_lo(1):vol_hi(1),vol_lo(2):vol_hi(2),vol_lo(3):vol_hi(3))
+    real(rt)         :: vol(vol_lo(1):vol_hi(1),vol_lo(2):vol_hi(2),vol_lo(3):vol_hi(3))
 
-    double precision :: dx(3), dt, time
-    double precision :: E_added, mom_added(3)
+    real(rt)         :: dx(3), dt, time
+    real(rt)         :: E_added, mom_added(3)
 
     integer          :: i,j,k
-    double precision :: loc(3)
-    double precision :: vnew(3),vold(3),omega_old(3),omega_new(3),domegadt_old(3),domegadt_new(3)
-    double precision :: Sr_old(3), Sr_new(3), Srcorr(3), SrEcorr, SrE_old, SrE_new
-    double precision :: rhoo, rhon, rhooinv, rhoninv
+    real(rt)         :: loc(3)
+    real(rt)         :: vnew(3),vold(3),omega_old(3),omega_new(3),domegadt_old(3),domegadt_new(3)
+    real(rt)         :: Sr_old(3), Sr_new(3), Srcorr(3), SrEcorr, SrE_old, SrE_new
+    real(rt)         :: rhoo, rhon, rhooinv, rhoninv
 
-    double precision :: old_ke, old_rhoeint, old_re, new_ke, new_rhoeint
-    double precision :: old_mom(3), dt_omega_matrix(3,3), dt_omega(3), new_mom(3)
+    real(rt)         :: old_ke, old_rhoeint, old_re, new_ke, new_rhoeint
+    real(rt)         :: old_mom(3), dt_omega_matrix(3,3), dt_omega(3), new_mom(3)
 
-    double precision :: src(NVAR)
+    real(rt)         :: src(NVAR)
 
     ! Temporary array for seeing what the new state would be if the update were applied here.
 
-    double precision :: snew(NVAR)
+    real(rt)         :: snew(NVAR)
 
-    double precision, pointer :: phi(:,:,:)
+    real(rt)        , pointer :: phi(:,:,:)
 
     ! Rotation source options for how to add the work to (rho E):
     ! rot_source_type =

--- a/Source/Src_nd/sponge_nd.F90
+++ b/Source/Src_nd/sponge_nd.F90
@@ -1,11 +1,12 @@
 module sponge_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
-  double precision, save :: sponge_lower_factor, sponge_upper_factor
-  double precision, save :: sponge_lower_radius, sponge_upper_radius
-  double precision, save :: sponge_lower_density, sponge_upper_density
-  double precision, save :: sponge_timescale
+  real(rt)        , save :: sponge_lower_factor, sponge_upper_factor
+  real(rt)        , save :: sponge_lower_radius, sponge_upper_radius
+  real(rt)        , save :: sponge_lower_density, sponge_upper_density
+  real(rt)        , save :: sponge_timescale
 
 contains
 
@@ -21,30 +22,31 @@ contains
     use hybrid_advection_module, only: add_hybrid_momentum_source
 #endif
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer          :: lo(3),hi(3)
     integer          :: state_lo(3), state_hi(3)
     integer          :: src_lo(3), src_hi(3)
     integer          :: vol_lo(3), vol_hi(3)
-    double precision :: state(state_lo(1):state_hi(1),state_lo(2):state_hi(2),state_lo(3):state_hi(3),NVAR)
-    double precision :: source(src_lo(1):src_hi(1),src_lo(2):src_hi(2),src_lo(3):src_hi(3),NVAR)
-    double precision :: vol(vol_lo(1):vol_hi(1),vol_lo(2):vol_hi(2),vol_lo(3):vol_hi(3))
-    double precision :: dx(3), dt, time
-    double precision :: E_added, mom_added(3)
+    real(rt)         :: state(state_lo(1):state_hi(1),state_lo(2):state_hi(2),state_lo(3):state_hi(3),NVAR)
+    real(rt)         :: source(src_lo(1):src_hi(1),src_lo(2):src_hi(2),src_lo(3):src_hi(3),NVAR)
+    real(rt)         :: vol(vol_lo(1):vol_hi(1),vol_lo(2):vol_hi(2),vol_lo(3):vol_hi(3))
+    real(rt)         :: dx(3), dt, time
+    real(rt)         :: E_added, mom_added(3)
 
     ! Local variables
 
-    double precision :: r(3), radius
-    double precision :: ke_old, E_old, mom_old(3)
-    double precision :: sponge_factor, alpha
-    double precision :: delta_r, delta_rho
-    double precision :: rho, rhoInv
-    double precision :: update_factor
+    real(rt)         :: r(3), radius
+    real(rt)         :: ke_old, E_old, mom_old(3)
+    real(rt)         :: sponge_factor, alpha
+    real(rt)         :: delta_r, delta_rho
+    real(rt)         :: rho, rhoInv
+    real(rt)         :: update_factor
 
     integer          :: i, j, k
 
-    double precision :: src(NVAR), snew(NVAR)
+    real(rt)         :: src(NVAR), snew(NVAR)
 
     ! Radial distance between upper and lower boundaries.
 

--- a/Source/Src_nd/string_mod.f90
+++ b/Source/Src_nd/string_mod.f90
@@ -3,6 +3,7 @@ module string_module
 
   use iso_c_binding
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   private
@@ -12,6 +13,7 @@ module string_module
 contains
 
   function string_f_to_c (fstr) result(cstr)
+    use bl_fort_module, only : rt => c_real
     character(*), intent(in) :: fstr
     character(c_char) :: cstr(len_trim(fstr)+1)
     integer :: i, n
@@ -23,6 +25,7 @@ contains
   end function string_f_to_c
 
   function string_c_to_f (cstr) result(fstr)
+    use bl_fort_module, only : rt => c_real
     character(c_char), intent(in) :: cstr(:)
     character(len=size(cstr)-1) :: fstr
     integer :: i, n

--- a/Source/Src_nd/sums_nd.f90
+++ b/Source/Src_nd/sums_nd.f90
@@ -1,5 +1,6 @@
 module castro_sums_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   public
@@ -11,14 +12,15 @@ contains
 
     use bl_constants_module
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer          :: lo(3), hi(3)
     integer          :: r_lo(3), r_hi(3)
     integer          :: v_lo(3), v_hi(3)
-    double precision :: mass, dx(3)
-    double precision :: rho(r_lo(1):r_hi(1),r_lo(2):r_hi(2),r_lo(3):r_hi(3))
-    double precision :: vol(v_lo(1):v_hi(1),v_lo(2):v_hi(2),v_lo(3):v_hi(3))
+    real(rt)         :: mass, dx(3)
+    real(rt)         :: rho(r_lo(1):r_hi(1),r_lo(2):r_hi(2),r_lo(3):r_hi(3))
+    real(rt)         :: vol(v_lo(1):v_hi(1),v_lo(2):v_hi(2),v_lo(3):v_hi(3))
 
     integer          :: i, j, k
 
@@ -41,14 +43,15 @@ contains
 
     use bl_constants_module
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer          :: lo(3), hi(3)
     integer          :: r_lo(3), r_hi(3)
     integer          :: v_lo(3), v_hi(3)
-    double precision :: mass, dx(3)
-    double precision :: rho(r_lo(1):r_hi(1),r_lo(2):r_hi(2),r_lo(3):r_hi(3))
-    double precision :: vol(v_lo(1):v_hi(1),v_lo(2):v_hi(2),v_lo(3):v_hi(3))
+    real(rt)         :: mass, dx(3)
+    real(rt)         :: rho(r_lo(1):r_hi(1),r_lo(2):r_hi(2),r_lo(3):r_hi(3))
+    real(rt)         :: vol(v_lo(1):v_hi(1),v_lo(2):v_hi(2),v_lo(3):v_hi(3))
 
     integer          :: i, j, k
 
@@ -72,19 +75,20 @@ contains
     use prob_params_module, only: problo, center, probhi, dim, physbc_lo, physbc_hi, Symmetry
     use bl_constants_module
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer          :: idir
     integer          :: lo(3), hi(3)
     integer          :: r_lo(3), r_hi(3)
     integer          :: v_lo(3), v_hi(3)
-    double precision :: mass, dx(3)
-    double precision :: rho(r_lo(1):r_hi(1),r_lo(2):r_hi(2),r_lo(3):r_hi(3))
-    double precision :: vol(v_lo(1):v_hi(1),v_lo(2):v_hi(2),v_lo(3):v_hi(3))
+    real(rt)         :: mass, dx(3)
+    real(rt)         :: rho(r_lo(1):r_hi(1),r_lo(2):r_hi(2),r_lo(3):r_hi(3))
+    real(rt)         :: vol(v_lo(1):v_hi(1),v_lo(2):v_hi(2),v_lo(3):v_hi(3))
 
     integer          :: i, j, k
-    double precision :: x, y, z
-    double precision :: symlo, symhi
+    real(rt)         :: x, y, z
+    real(rt)         :: symlo, symhi
 
     mass = ZERO
 
@@ -151,19 +155,20 @@ contains
     use prob_params_module, only: problo, center, probhi, dim, physbc_lo, physbc_hi, Symmetry
     use bl_constants_module
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer          :: idir1, idir2
     integer          :: lo(3), hi(3)
     integer          :: r_lo(3), r_hi(3)
     integer          :: v_lo(3), v_hi(3)
-    double precision :: mass, dx(3)
-    double precision :: rho(r_lo(1):r_hi(1),r_lo(2):r_hi(2),r_lo(3):r_hi(3))
-    double precision :: vol(v_lo(1):v_hi(1),v_lo(2):v_hi(2),v_lo(3):v_hi(3))
+    real(rt)         :: mass, dx(3)
+    real(rt)         :: rho(r_lo(1):r_hi(1),r_lo(2):r_hi(2),r_lo(3):r_hi(3))
+    real(rt)         :: vol(v_lo(1):v_hi(1),v_lo(2):v_hi(2),v_lo(3):v_hi(3))
 
     integer          :: i, j, k
-    double precision :: x, y, z
-    double precision :: symlo1, symhi1, symlo2, symhi2
+    real(rt)         :: x, y, z
+    real(rt)         :: symlo1, symhi1, symlo2, symhi2
 
     mass = ZERO
 
@@ -322,18 +327,19 @@ contains
     use prob_params_module, only: problo, center, dim
     use bl_constants_module
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer          :: idir
     integer          :: lo(3), hi(3)
     integer          :: r_lo(3), r_hi(3)
     integer          :: v_lo(3), v_hi(3)
-    double precision :: mass, dx(3)
-    double precision :: rho(r_lo(1):r_hi(1),r_lo(2):r_hi(2),r_lo(3):r_hi(3))
-    double precision :: vol(v_lo(1):v_hi(1),v_lo(2):v_hi(2),v_lo(3):v_hi(3))
+    real(rt)         :: mass, dx(3)
+    real(rt)         :: rho(r_lo(1):r_hi(1),r_lo(2):r_hi(2),r_lo(3):r_hi(3))
+    real(rt)         :: vol(v_lo(1):v_hi(1),v_lo(2):v_hi(2),v_lo(3):v_hi(3))
 
     integer          :: i, j, k
-    double precision :: x, y, z
+    real(rt)         :: x, y, z
 
     mass = ZERO
 
@@ -375,17 +381,18 @@ contains
 
     use bl_constants_module
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer          :: lo(3), hi(3)
     integer          :: f1_lo(3), f1_hi(3)
     integer          :: f2_lo(3), f2_hi(3)
     integer          :: v_lo(3), v_hi(3)
-    double precision :: product
-    double precision :: dx(3)
-    double precision :: f1(f1_lo(1):f1_hi(1),f1_lo(2):f1_hi(2),f1_lo(3):f1_hi(3))
-    double precision :: f2(f2_lo(1):f2_hi(1),f2_lo(2):f2_hi(2),f2_lo(3):f2_hi(3))
-    double precision :: vol(v_lo(1):v_hi(1),v_lo(2):v_hi(2),v_lo(3):v_hi(3))
+    real(rt)         :: product
+    real(rt)         :: dx(3)
+    real(rt)         :: f1(f1_lo(1):f1_hi(1),f1_lo(2):f1_hi(2),f1_lo(3):f1_hi(3))
+    real(rt)         :: f2(f2_lo(1):f2_hi(1),f2_lo(2):f2_hi(2),f2_lo(3):f2_hi(3))
+    real(rt)         :: vol(v_lo(1):v_hi(1),v_lo(2):v_hi(2),v_lo(3):v_hi(3))
 
     integer          :: i, j, k
 

--- a/Source/Src_nd/timestep.F90
+++ b/Source/Src_nd/timestep.F90
@@ -1,5 +1,6 @@
 module timestep_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
 
   public
@@ -21,20 +22,21 @@ contains
     use amrinfo_module, only: amr_time
 #endif
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer          :: lo(3), hi(3)
     integer          :: u_lo(3), u_hi(3)
-    double precision :: u(u_lo(1):u_hi(1),u_lo(2):u_hi(2),u_lo(3):u_hi(3),NVAR)
-    double precision :: dx(3), dt
+    real(rt)         :: u(u_lo(1):u_hi(1),u_lo(2):u_hi(2),u_lo(3):u_hi(3),NVAR)
+    real(rt)         :: dx(3), dt
 
-    double precision :: rhoInv, ux, uy, uz, c, dt1, dt2, dt3
+    real(rt)         :: rhoInv, ux, uy, uz, c, dt1, dt2, dt3
     integer          :: i, j, k
 
     type (eos_t) :: eos_state
 
 #ifdef ROTATION
-    double precision :: vel(3)
+    real(rt)         :: vel(3)
 #endif
 
     ! Call EOS for the purpose of computing sound speed
@@ -114,6 +116,7 @@ contains
     use eos_type_module
     use extern_probin_module, only: small_x
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer          :: so_lo(3), so_hi(3)
@@ -121,18 +124,18 @@ contains
     integer          :: ro_lo(3), ro_hi(3)
     integer          :: rn_lo(3), rn_hi(3)
     integer          :: lo(3), hi(3)
-    double precision :: sold(so_lo(1):so_hi(1),so_lo(2):so_hi(2),so_lo(3):so_hi(3),NVAR)
-    double precision :: snew(sn_lo(1):sn_hi(1),sn_lo(2):sn_hi(2),sn_lo(3):sn_hi(3),NVAR)
-    double precision :: rold(ro_lo(1):ro_hi(1),ro_lo(2):ro_hi(2),ro_lo(3):ro_hi(3),nspec+2)
-    double precision :: rnew(rn_lo(1):rn_hi(1),rn_lo(2):rn_hi(2),rn_lo(3):rn_hi(3),nspec+2)
-    double precision :: dx(3), dt, dt_old
+    real(rt)         :: sold(so_lo(1):so_hi(1),so_lo(2):so_hi(2),so_lo(3):so_hi(3),NVAR)
+    real(rt)         :: snew(sn_lo(1):sn_hi(1),sn_lo(2):sn_hi(2),sn_lo(3):sn_hi(3),NVAR)
+    real(rt)         :: rold(ro_lo(1):ro_hi(1),ro_lo(2):ro_hi(2),ro_lo(3):ro_hi(3),nspec+2)
+    real(rt)         :: rnew(rn_lo(1):rn_hi(1),rn_lo(2):rn_hi(2),rn_lo(3):rn_hi(3),nspec+2)
+    real(rt)         :: dx(3), dt, dt_old
 
-    double precision :: e, X(nspec), dedt, dXdt(nspec)
+    real(rt)         :: e, X(nspec), dedt, dXdt(nspec)
     integer          :: i, j, k
 
     type (burn_t)    :: state_old, state_new
     type (eos_t)     :: eos_state
-    double precision :: rhooinv, rhoninv
+    real(rt)         :: rhooinv, rhoninv
 
     ! We want to limit the timestep so that it is not larger than
     ! dtnuc_e * (e / (de/dt)).  If the timestep factor dtnuc is
@@ -154,7 +157,7 @@ contains
     ! values for the thermodynamic data like abar, zbar, etc.
     ! But we will call in (rho, T) mode, which is inexpensive.
 
-    if (dtnuc_e > 1.d199 .and. dtnuc_X > 1.d199) return
+    if (dtnuc_e > 1.e199_rt .and. dtnuc_X > 1.e199_rt) return
 
     do k = lo(3), hi(3)
        do j = lo(2), hi(2)
@@ -218,8 +221,8 @@ contains
 
              endif
 
-             dedt = max(abs(dedt), 1.d-50)
-             dXdt = max(abs(dXdt), 1.d-50)
+             dedt = max(abs(dedt), 1.e-50_rt)
+             dXdt = max(abs(dXdt), 1.e-50_rt)
 
              dt = min(dt, dtnuc_e * e / dedt)
              dt = min(dt, dtnuc_X * minval(X / dXdt))
@@ -246,16 +249,17 @@ contains
     use bl_constants_module
     use conductivity_module
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer          :: lo(3), hi(3)
     integer          :: s_lo(3), s_hi(3)
-    double precision :: state(s_lo(1):s_hi(1),s_lo(2):s_hi(2),s_lo(3):s_hi(3),NVAR)
-    double precision :: dx(3), dt
+    real(rt)         :: state(s_lo(1):s_hi(1),s_lo(2):s_hi(2),s_lo(3):s_hi(3),NVAR)
+    real(rt)         :: dx(3), dt
 
-    double precision :: dt1, dt2, dt3, rho_inv
+    real(rt)         :: dt1, dt2, dt3, rho_inv
     integer          :: i, j, k
-    double precision :: cond, D
+    real(rt)         :: cond, D
 
     type (eos_t) :: eos_state
 
@@ -322,16 +326,17 @@ contains
     use bl_constants_module
     use conductivity_module
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer          :: lo(3), hi(3)
     integer          :: s_lo(3), s_hi(3)
-    double precision :: state(s_lo(1):s_hi(1),s_lo(2):s_hi(2),s_lo(3):s_hi(3),NVAR)
-    double precision :: dx(3), dt
+    real(rt)         :: state(s_lo(1):s_hi(1),s_lo(2):s_hi(2),s_lo(3):s_hi(3),NVAR)
+    real(rt)         :: dx(3), dt
 
-    double precision :: dt1, dt2, dt3, rho_inv
+    real(rt)         :: dt1, dt2, dt3, rho_inv
     integer          :: i, j, k
-    double precision :: cond, D
+    real(rt)         :: cond, D
 
     type (eos_t) :: eos_state
 
@@ -411,6 +416,7 @@ contains
     use extern_probin_module, only: small_x
     use eos_module
 
+    use bl_fort_module, only : rt => c_real
     implicit none
 
     integer          :: lo(3), hi(3)
@@ -420,25 +426,25 @@ contains
     integer          :: ro_lo(3), ro_hi(3)
     integer          :: rn_lo(3), rn_hi(3)
 #endif
-    double precision :: s_old(so_lo(1):so_hi(1),so_lo(2):so_hi(2),so_lo(3):so_hi(3),NVAR)
-    double precision :: s_new(sn_lo(1):sn_hi(1),sn_lo(2):sn_hi(2),sn_lo(3):sn_hi(3),NVAR)
+    real(rt)         :: s_old(so_lo(1):so_hi(1),so_lo(2):so_hi(2),so_lo(3):so_hi(3),NVAR)
+    real(rt)         :: s_new(sn_lo(1):sn_hi(1),sn_lo(2):sn_hi(2),sn_lo(3):sn_hi(3),NVAR)
 #ifdef REACTIONS
-    double precision :: r_old(ro_lo(1):ro_hi(1),ro_lo(2):ro_hi(2),ro_lo(3):ro_hi(3),nspec+2)
-    double precision :: r_new(rn_lo(1):rn_hi(1),rn_lo(2):rn_hi(2),rn_lo(3):rn_hi(3),nspec+2)
+    real(rt)         :: r_old(ro_lo(1):ro_hi(1),ro_lo(2):ro_hi(2),ro_lo(3):ro_hi(3),nspec+2)
+    real(rt)         :: r_new(rn_lo(1):rn_hi(1),rn_lo(2):rn_hi(2),rn_lo(3):rn_hi(3),nspec+2)
 #endif
-    double precision :: dx(3), dt_old, dt_new
+    real(rt)         :: dx(3), dt_old, dt_new
 
     integer          :: i, j, k
-    double precision :: rhooinv, rhoninv
+    real(rt)         :: rhooinv, rhoninv
 #ifdef REACTIONS
-    double precision :: X_old(nspec), X_new(nspec), X_avg(nspec), X_dot(nspec)
-    double precision :: e_old, e_new, e_avg, e_dot
-    double precision :: tau_X, tau_e
+    real(rt)         :: X_old(nspec), X_new(nspec), X_avg(nspec), X_dot(nspec)
+    real(rt)         :: e_old, e_new, e_avg, e_dot
+    real(rt)         :: tau_X, tau_e
 #endif
-    double precision :: tau_CFL
+    real(rt)         :: tau_CFL
 
 
-    double precision :: v(3), c
+    real(rt)         :: v(3), c
     type (eos_t)     :: eos_state
 
     do k = lo(3), hi(3)
@@ -496,7 +502,7 @@ contains
                 X_avg = max(small_x, HALF * (X_old + X_new))
                 X_dot = HALF * (r_old(i,j,k,1:nspec) + r_new(i,j,k,1:nspec))
 
-                X_dot = max(abs(X_dot), 1.d-50)
+                X_dot = max(abs(X_dot), 1.e-50_rt)
                 tau_X = minval( X_avg / X_dot )
 
                 e_old = s_old(i,j,k,UEINT) * rhooinv
@@ -504,7 +510,7 @@ contains
                 e_avg = HALF * (e_old + e_new)
                 e_dot = HALF * (r_old(i,j,k,nspec+1) + r_new(i,j,k,nspec+1))
 
-                e_dot = max(abs(e_dot), 1.d-50)
+                e_dot = max(abs(e_dot), 1.e-50_rt)
                 tau_e = e_avg / e_dot
 
                 if (dt_old > dtnuc_e * tau_e) then

--- a/Source/Src_nd/update_sponge_params.f90
+++ b/Source/Src_nd/update_sponge_params.f90
@@ -7,8 +7,9 @@ subroutine update_sponge_params(time) bind(C, name="update_sponge_params")
 
   use sponge_module
 
+  use bl_fort_module, only : rt => c_real
   implicit none
   
-  double precision, intent(in) :: time
+  real(rt)        , intent(in) :: time
   
 end subroutine update_sponge_params


### PR DESCRIPTION
use the BoxLib-compatible c_real type so we support single
and double precision options.  This was updated using
dpconvert.py.  This addresses issue #34