### PR TITLE
Diagnostics updates

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,13 @@
 # changes since the last release:
 
+  -- diagnostic information about how source terms update the
+     state has been overhauled and made uniform. All source terms,
+     including hydro and resets, print their changes to the state
+     in the same format. The parameter print_energy_diagnostics
+     has been renamed print_update_diagnostics, and a new parameter
+     coalesce_update_diagnostics has been added so that you can
+     combine all of the old-time and new-time updates into one print.
+
   -- to support both single and double precision, all of the 
      floating point declarations use the c_real type defined
      in the bl_fort_module -- this is set to single or double

--- a/Docs/runtime_parameters/runtime_parameters.tex
+++ b/Docs/runtime_parameters/runtime_parameters.tex
@@ -90,16 +90,18 @@
 
 
 \rowcolor{tableShade}
+\runparamNS{coalesce\_update\_diagnostics}{castro} &  if we're printing diagnostic information about the updates, should we break down the information into the constitent source terms? & (0, 1) \\
 \runparamNS{hard\_cfl\_limit}{castro} &  abort if we exceed CFL = 1 over the cource of a timestep & 1 \\
-\runparamNS{job\_name}{castro} &  a string describing the simulation that will be copied into the plotfile's {\tt job\_info} file & "" \\
 \rowcolor{tableShade}
-\runparamNS{print\_energy\_diagnostics}{castro} &  display breakdown of energy sources & (0, 1) \\
+\runparamNS{job\_name}{castro} &  a string describing the simulation that will be copied into the plotfile's {\tt job\_info} file & "" \\
 \runparamNS{print\_fortran\_warnings}{castro} &  display warnings in Fortran90 routines & (0, 1) \\
 \rowcolor{tableShade}
+\runparamNS{print\_update\_diagnostics}{castro} &  display information about updates to the state (how much mass, momentum, energy added) & (0, 1) \\
 \runparamNS{show\_center\_of\_mass}{castro} &  display center of mass diagnostics & 0 \\
-\runparamNS{sum\_interval}{castro} &  how often (number of coarse timesteps) to compute integral sums (for runtime diagnostics) & -1 \\
 \rowcolor{tableShade}
+\runparamNS{sum\_interval}{castro} &  how often (number of coarse timesteps) to compute integral sums (for runtime diagnostics) & -1 \\
 \runparamNS{sum\_per}{castro} &  how often (simulation time) to compute integral sums (for runtime diagnostics) & -1.0e0 \\
+\rowcolor{tableShade}
 \runparamNS{track\_grid\_losses}{castro} &  calculate losses of material through physical grid boundaries & 0 \\
 
 

--- a/Source/Castro.H
+++ b/Source/Castro.H
@@ -48,12 +48,9 @@ enum StateType { State_Type = 0,
 
 // Create storage for all source terms.
 
-enum sources {
+enum sources { ext_src = 0,
 #ifdef SPONGE
-               sponge_src = 0,
-               ext_src,
-#else
-               ext_src = 0,
+               sponge_src,
 #endif
 #ifdef DIFFUSION
                diff_src,

--- a/Source/Castro.H
+++ b/Source/Castro.H
@@ -267,6 +267,8 @@ public:
 
     void print_source_change(Array<Real> update);
 
+    void print_all_source_changes(Real dt, bool is_new);
+
     void sum_of_sources(MultiFab& source);
 
     void time_center_source_terms (MultiFab& S_new,

--- a/Source/Castro.H
+++ b/Source/Castro.H
@@ -262,6 +262,10 @@ public:
 
     void construct_new_source(int src, Real time, Real dt, int amr_iteration = -1, int amr_ncycle = -1, int sub_iteration = -1, int sub_ncycle = -1);
 
+    Array<Real> evaluate_source_change(MultiFab& update, Real dt, bool local = false);
+
+    void print_source_change(Array<Real> update);
+
     void sum_of_sources(MultiFab& source);
 
     void time_center_source_terms (MultiFab& S_new,

--- a/Source/Castro.H
+++ b/Source/Castro.H
@@ -48,11 +48,12 @@ enum StateType { State_Type = 0,
 
 // Create storage for all source terms.
 
+enum sources {
 #ifdef SPONGE
-enum sources { sponge_src = 0,
+               sponge_src = 0,
                ext_src,
 #else
-enum sources { ext_src = 0,
+               ext_src = 0,
 #endif
 #ifdef DIFFUSION
                diff_src,
@@ -541,6 +542,8 @@ public:
     static int       FirstAdv,  NumAdv;
     static int       FirstSpec, NumSpec;
     static int       FirstAux,  NumAux;
+
+    static Array<std::string> source_names;
 
     //
     // This MultiFab is on the coarser level.  This is useful for the coarser level

--- a/Source/Castro.cpp
+++ b/Source/Castro.cpp
@@ -2699,7 +2699,7 @@ Castro::reset_internal_energy(MultiFab& S_new)
 
     // Make a copy of the state so we can evaluate how much changed.
 
-    if (parent->finestLevel() == 0 && print_update_diagnostics)
+    if (print_update_diagnostics)
     {
 	old_state.define(S_new.boxArray(), S_new.nComp(), 0, Fab_allocate);
         MultiFab::Copy(old_state, S_new, 0, 0, S_new.nComp(), 0);
@@ -2725,7 +2725,7 @@ Castro::reset_internal_energy(MultiFab& S_new)
     if (verbose)
       flush_output();
 
-    if (parent->finestLevel() == 0 && print_update_diagnostics)
+    if (print_update_diagnostics)
     {
 	// Evaluate what the effective reset source was.
 

--- a/Source/Castro.cpp
+++ b/Source/Castro.cpp
@@ -2422,7 +2422,7 @@ Castro::enforce_min_density (MultiFab& S_old, MultiFab& S_new)
 
     }
 
-    if (print_energy_diagnostics)
+    if (print_update_diagnostics)
     {
 
         Real foo[3] = {mass_added, eint_added, eden_added};
@@ -2701,7 +2701,7 @@ Castro::reset_internal_energy(MultiFab& S_new)
     Real sum  = 0.;
     Real sum0 = 0.;
 
-    if (parent->finestLevel() == 0 && print_energy_diagnostics)
+    if (parent->finestLevel() == 0 && print_update_diagnostics)
     {
         // Pass in the multifab and the component
         sum0 = volWgtSumMF(&S_new,Eden,true);
@@ -2727,7 +2727,7 @@ Castro::reset_internal_energy(MultiFab& S_new)
     if (verbose)
       flush_output();
 
-    if (parent->finestLevel() == 0 && print_energy_diagnostics)
+    if (parent->finestLevel() == 0 && print_update_diagnostics)
     {
         // Pass in the multifab and the component
         sum = volWgtSumMF(&S_new,Eden,true);

--- a/Source/Castro.cpp
+++ b/Source/Castro.cpp
@@ -88,6 +88,8 @@ int          Castro::QRADVAR       = 0;
 int          Castro::NQAUX         = -1;
 int          Castro::NQ            = -1;
 
+Array<std::string> Castro::source_names;
+
 #include <castro_defaults.H>
 
 #ifdef SELF_GRAVITY

--- a/Source/Castro_F.H
+++ b/Source/Castro_F.H
@@ -488,11 +488,6 @@ extern "C"
 #ifdef RADIATION
      const int* priv_nstep_fsp,
 #endif
-     Real& mass_added_flux,
-     Real& xmom_added_flux,
-     Real& ymom_added_flux,
-     Real& zmom_added_flux,
-     Real& E_added_flux,
      Real& mass_lost,
      Real& xmom_lost,
      Real& ymom_lost,

--- a/Source/Castro_F.H
+++ b/Source/Castro_F.H
@@ -141,9 +141,7 @@ extern "C"
      const Real* S_new, const int* s_new_lo, const int* s_new_hi,
      const Real* vol, const int* vol_lo, const int* vol_hi,
      const int* lo, const int* hi,
-     const Real* mass_added, const Real* e_added,
-     const Real* E_added, const Real* frac_change,
-     const int* verbose);
+     const Real* frac_change, const int* verbose);
 
   void ca_normalize_species
     (BL_FORT_FAB_ARG_3D(S_new), const int* lo, const int* hi);

--- a/Source/Castro_F.H
+++ b/Source/Castro_F.H
@@ -518,8 +518,7 @@ extern "C"
      BL_FORT_FAB_ARG_3D(state),
      BL_FORT_FAB_ARG_3D(source),
      BL_FORT_FAB_ARG_3D(vol),
-     const Real* dx, const Real& dt, const Real* time,
-     const Real& E_added, const Real* mom_added);
+     const Real* dx, const Real& dt, const Real* time);
 
   void update_sponge_params(const Real* time);
 #endif
@@ -555,8 +554,7 @@ extern "C"
      const BL_FORT_FAB_ARG_3D(s_old),
      BL_FORT_FAB_ARG_3D(source),
      const BL_FORT_FAB_ARG_3D(vol),
-     const Real* dx, const Real& dt, const Real* time,
-     const Real& E_added, const Real* mom_added);
+     const Real* dx, const Real& dt, const Real* time);
 
   void ca_corrgsrc
     (const int* lo, const int* hi,
@@ -572,8 +570,7 @@ extern "C"
      BL_FORT_FAB_ARG_3D(yflux),
      BL_FORT_FAB_ARG_3D(zflux),
      const Real* dx, const Real& dt, const Real* time,
-     const BL_FORT_FAB_ARG_3D(volume), 
-     const Real& E_added, const Real* mom_added);
+     const BL_FORT_FAB_ARG_3D(volume));
 
 #else
 
@@ -620,8 +617,7 @@ extern "C"
      const BL_FORT_FAB_ARG_3D(s_old),
      BL_FORT_FAB_ARG_3D(source),
      const BL_FORT_FAB_ARG_3D(vol),
-     const Real* dx, const Real& dt, const Real* time,
-     const Real& E_added, const Real* mom_added);
+     const Real* dx, const Real& dt, const Real* time);
 
   void ca_corrrsrc
     (const int* lo, const int* hi,
@@ -637,8 +633,7 @@ extern "C"
      const BL_FORT_FAB_ARG_3D(yflux),
      const BL_FORT_FAB_ARG_3D(zflux),
      const Real* dx, const Real& dt, const Real* time,
-     const BL_FORT_FAB_ARG_3D(volume),
-     const Real& E_added, const Real* mom_added);
+     const BL_FORT_FAB_ARG_3D(volume));
 
 #endif
 

--- a/Source/Castro_hydro.cpp
+++ b/Source/Castro_hydro.cpp
@@ -332,7 +332,7 @@ Castro::construct_hydro_source(Real time, Real dt)
 	material_lost_through_boundary_temp[7] += zang_lost;
     }
 
-    if (print_energy_diagnostics)
+    if (print_update_diagnostics)
     {
 	Real foo[5] = {E_added_flux, xmom_added_flux, ymom_added_flux,
 		       zmom_added_flux, mass_added_flux};

--- a/Source/Castro_hydro.cpp
+++ b/Source/Castro_hydro.cpp
@@ -85,11 +85,6 @@ Castro::construct_hydro_source(Real time, Real dt)
 #endif
 
     // note: the radiation consup currently does not fill these
-    Real E_added_flux    = 0.;
-    Real mass_added_flux = 0.;
-    Real xmom_added_flux = 0.;
-    Real ymom_added_flux = 0.;
-    Real zmom_added_flux = 0.;
     Real mass_lost       = 0.;
     Real xmom_lost       = 0.;
     Real ymom_lost       = 0.;
@@ -105,9 +100,7 @@ Castro::construct_hydro_source(Real time, Real dt)
 #ifdef RADIATION
 #pragma omp parallel
 #else
-#pragma omp parallel reduction(+:E_added_flux,mass_added_flux) \
-		     reduction(+:xmom_added_flux,ymom_added_flux,zmom_added_flux) \
-		     reduction(+:mass_lost,xmom_lost,ymom_lost,zmom_lost) \
+#pragma omp parallel reduction(+:mass_lost,xmom_lost,ymom_lost,zmom_lost) \
 		     reduction(+:eden_lost,xang_lost,yang_lost,zang_lost)
 #endif
 #endif
@@ -242,11 +235,6 @@ Castro::construct_hydro_source(Real time, Real dt)
 #ifdef RADIATION
 	     &priv_nstep_fsp,
 #endif
-	     mass_added_flux,
-	     xmom_added_flux,
-	     ymom_added_flux,
-	     zmom_added_flux,
-	     E_added_flux,
 	     mass_lost, xmom_lost, ymom_lost, zmom_lost,
 	     eden_lost, xang_lost, yang_lost, zang_lost);
 
@@ -334,33 +322,20 @@ Castro::construct_hydro_source(Real time, Real dt)
 
     if (print_update_diagnostics)
     {
-	Real foo[5] = {E_added_flux, xmom_added_flux, ymom_added_flux,
-		       zmom_added_flux, mass_added_flux};
+
+	bool local = true;
+	Array<Real> hydro_update = evaluate_source_change(hydro_source, dt, local);
 
 #ifdef BL_LAZY
 	Lazy::QueueReduction( [=] () mutable {
 #endif
-	    ParallelDescriptor::ReduceRealSum(foo, 5, ParallelDescriptor::IOProcessorNumber());
+	    ParallelDescriptor::ReduceRealSum(hydro_update.dataPtr(), hydro_update.size(), ParallelDescriptor::IOProcessorNumber());
 
 	    if (ParallelDescriptor::IOProcessor())
-	      {
-	        E_added_flux    = foo[0];
-	        xmom_added_flux = foo[1];
-	        ymom_added_flux = foo[2];
-	        zmom_added_flux = foo[3];
-	        mass_added_flux = foo[4];
-		
-		std::cout << "mass added from fluxes                      : " <<
-		  mass_added_flux << std::endl;
-		std::cout << "xmom added from fluxes                      : " <<
-		  xmom_added_flux << std::endl;
-		std::cout << "ymom added from fluxes                      : " <<
-		  ymom_added_flux << std::endl;
-		std::cout << "zmom added from fluxes                      : " <<
-		  zmom_added_flux << std::endl;
-		std::cout << "(rho E) added from fluxes                   : " <<
-		  E_added_flux << std::endl;
-	      }
+		std::cout << std::endl << "  Contributions to the state from the hydro source:" << std::endl;
+
+	    print_source_change(hydro_update);
+
 #ifdef BL_LAZY
 	});
 #endif

--- a/Source/Castro_rotation.cpp
+++ b/Source/Castro_rotation.cpp
@@ -25,23 +25,16 @@ void Castro::construct_old_rotation_source(Real time, Real dt)
 
     fill_rotation_field(phirot_old, rot_old, Sborder, time);
 
-    Real E_added    = 0.;
-    Real xmom_added = 0.;
-    Real ymom_added = 0.;
-    Real zmom_added = 0.;
-
     const Real *dx = geom.CellSize();
     const int* domlo = geom.Domain().loVect();
     const int* domhi = geom.Domain().hiVect();
 
 #ifdef _OPENMP
-#pragma omp parallel reduction(+:E_added,xmom_added,ymom_added,zmom_added)
+#pragma omp parallel
 #endif
     for (MFIter mfi(Sborder,true); mfi.isValid(); ++mfi)
     {
 	const Box& bx = mfi.growntilebox();
-
-	Real mom_added[3] = { 0.0 };
 
 	ca_rsrc(ARLIM_3D(bx.loVect()), ARLIM_3D(bx.hiVect()),
 		ARLIM_3D(domlo), ARLIM_3D(domhi),
@@ -50,36 +43,8 @@ void Castro::construct_old_rotation_source(Real time, Real dt)
 		BL_TO_FORTRAN_3D(Sborder[mfi]),
 		BL_TO_FORTRAN_3D(old_sources[rot_src][mfi]),
 		BL_TO_FORTRAN_3D(volume[mfi]),
-		ZFILL(dx),dt,&time,
-		E_added,mom_added);
+		ZFILL(dx),dt,&time);
 
-	xmom_added += mom_added[0];
-	ymom_added += mom_added[1];
-	zmom_added += mom_added[2];
-
-    }
-
-    if (print_energy_diagnostics)
-    {
-	Real foo[4] = {E_added, xmom_added, ymom_added, zmom_added};
-#ifdef BL_LAZY
-	Lazy::QueueReduction( [=] () mutable {
-#endif
-		ParallelDescriptor::ReduceRealSum(foo, 4, ParallelDescriptor::IOProcessorNumber());
-		if (ParallelDescriptor::IOProcessor()) {
-		    E_added = foo[0];
-		    xmom_added = foo[1],
-			ymom_added = foo[2],
-			zmom_added = foo[3];
-
-		    std::cout << "(rho E) added from rot. source  terms          : " << E_added << std::endl;
-		    std::cout << "xmom added from rot. source terms              : " << xmom_added << std::endl;
-		    std::cout << "ymom added from rot. source terms              : " << ymom_added << std::endl;
-		    std::cout << "zmom added from rot. source terms              : " << zmom_added << std::endl;
-		}
-#ifdef BL_LAZY
-	    });
-#endif
     }
 
 }
@@ -116,24 +81,17 @@ void Castro::construct_new_rotation_source(Real time, Real dt)
 
     // Now do corrector part of rotation source term update
 
-    Real E_added    = 0.;
-    Real xmom_added = 0.;
-    Real ymom_added = 0.;
-    Real zmom_added = 0.;
-
     const Real *dx = geom.CellSize();
     const int* domlo = geom.Domain().loVect();
     const int* domhi = geom.Domain().hiVect();
 
 #ifdef _OPENMP
-#pragma omp parallel reduction(+:E_added,xmom_added,ymom_added,zmom_added)
+#pragma omp parallel
 #endif
     {
 	for (MFIter mfi(S_new,true); mfi.isValid(); ++mfi)
 	{
 	    const Box& bx = mfi.tilebox();
-
-	    Real mom_added[3] = { 0.0 };
 
 	    ca_corrrsrc(ARLIM_3D(bx.loVect()), ARLIM_3D(bx.hiVect()),
 			ARLIM_3D(domlo), ARLIM_3D(domhi),
@@ -148,36 +106,8 @@ void Castro::construct_new_rotation_source(Real time, Real dt)
 			BL_TO_FORTRAN_3D(fluxes[1][mfi]),
 			BL_TO_FORTRAN_3D(fluxes[2][mfi]),
 			ZFILL(dx),dt,&time,
-			BL_TO_FORTRAN_3D(volume[mfi]),
-			E_added,mom_added);
-
-	    xmom_added += mom_added[0];
-	    ymom_added += mom_added[1];
-	    zmom_added += mom_added[2];
+			BL_TO_FORTRAN_3D(volume[mfi]));
 	}
-    }
-
-    if (print_energy_diagnostics)
-    {
-	Real foo[4] = {E_added, xmom_added, ymom_added, zmom_added};
-#ifdef BL_LAZY
-	Lazy::QueueReduction( [=] () mutable {
-#endif
-		ParallelDescriptor::ReduceRealSum(foo, 4, ParallelDescriptor::IOProcessorNumber());
-		if (ParallelDescriptor::IOProcessor()) {
-		    E_added = foo[0];
-		    xmom_added = foo[1],
-			ymom_added = foo[2],
-			zmom_added = foo[3];
-
-		    std::cout << "(rho E) added from rot. corr.  terms          : " << E_added << std::endl;
-		    std::cout << "xmom added from rot. corr. terms              : " << xmom_added << std::endl;
-		    std::cout << "ymom added from rot. corr. terms              : " << ymom_added << std::endl;
-		    std::cout << "zmom added from rot. corr. terms              : " << zmom_added << std::endl;
-		}
-#ifdef BL_LAZY
-	    });
-#endif
     }
 
 }

--- a/Source/Castro_setup.cpp
+++ b/Source/Castro_setup.cpp
@@ -519,12 +519,12 @@ Castro::variableSetUp ()
 
   // Source term array will use standard hyperbolic fill.
 
-  Array<std::string> sources_name(NUM_STATE);
+  Array<std::string> state_type_source_names(NUM_STATE);
 
   for (int i = 0; i < NUM_STATE; i++)
-    sources_name[i] = name[i] + "_source";
+    state_type_source_names[i] = name[i] + "_source";
 
-  desc_lst.setComponent(Source_Type,Density,sources_name,bcs,BndryFunc(ca_denfill,ca_hypfill));
+  desc_lst.setComponent(Source_Type,Density,state_type_source_names,bcs,BndryFunc(ca_denfill,ca_hypfill));
 
 #ifdef REACTIONS
   std::string name_react;
@@ -540,8 +540,8 @@ Castro::variableSetUp ()
 
 #ifdef SDC
   for (int i = 0; i < NUM_STATE; ++i)
-      sources_name[i] = "sdc_sources_" + name[i];
-  desc_lst.setComponent(SDC_Source_Type,Density,sources_name,bcs,BndryFunc(ca_denfill,ca_hypfill));
+      state_type_source_names[i] = "sdc_sources_" + name[i];
+  desc_lst.setComponent(SDC_Source_Type,Density,state_type_source_names,bcs,BndryFunc(ca_denfill,ca_hypfill));
 #ifdef REACTIONS
   for (int i = 0; i < QVAR; ++i) {
       char buf[64];
@@ -889,5 +889,38 @@ Castro::variableSetUp ()
   // DEFINE ERROR ESTIMATION QUANTITIES
   //
   ErrorSetUp();
+
+  //
+  // Construct an array holding the names of the source terms.
+  //
+
+  source_names.resize(num_src);
+
+  // Fill with an empty string to initialize.
+
+  for (int n = 0; n < num_src; ++n)
+    source_names[n] = "";
+
+  source_names[ext_src] = "user-defined external";
+
+#ifdef SPONGE
+  source_names[sponge_src] = "sponge";
+#endif
+
+#ifdef DIFFUSION
+  source_names[diff_src] = "diffusion";
+#endif
+
+#ifdef HYBRID_MOMENTUM
+  source_names[hybrid_src] = "hybrid";
+#endif
+
+#ifdef GRAVITY
+  source_names[grav_src] = "gravity";
+#endif
+
+#ifdef ROTATION
+  source_names[rot_src] = "rotation";
+#endif
 
 }

--- a/Source/Castro_sources.cpp
+++ b/Source/Castro_sources.cpp
@@ -305,6 +305,7 @@ Castro::print_source_change(Array<Real> update)
 #if (BL_SPACEDIM == 3)
     std::cout << "       zmom added: " << update[Zmom] << std::endl;
 #endif
+    std::cout << "       eint added: " << update[Eint] << std::endl;
     std::cout << "       ener added: " << update[Eden] << std::endl;
 
     std::cout << std::endl;

--- a/Source/Castro_sources.cpp
+++ b/Source/Castro_sources.cpp
@@ -340,18 +340,43 @@ Castro::print_all_source_changes(Real dt, bool is_new)
 #ifdef BL_LAZY
   Lazy::QueueReduction( [=] () mutable {
 #endif
-      for (int n = 0; n < num_src; ++n) {
+      if (coalesce_update_diagnostics) {
 
-	if (!source_flag(n)) continue;
+	  Array<Real> coalesced_update(NUM_STATE, 0.0);
 
-	ParallelDescriptor::ReduceRealSum(summed_updates[n].dataPtr(), NUM_STATE, ParallelDescriptor::IOProcessorNumber());
+	  for (int n = 0; n < num_src; ++n) {
+	      if (!source_flag(n)) continue;
 
-	std::string time = is_new ? "new" : "old";
+	      for (int s = 0; s < NUM_STATE; ++s) {
+		  coalesced_update[s] += summed_updates[n][s];
+	      }
+	  }
 
-	if (ParallelDescriptor::IOProcessor())
-	  std::cout << std::endl << "  Contributions to the state from the " << time << "-time " << source_names[n] << " source:" << std::endl;
+	  ParallelDescriptor::ReduceRealSum(coalesced_update.dataPtr(), NUM_STATE, ParallelDescriptor::IOProcessorNumber());
 
-	print_source_change(summed_updates[n]);
+	  std::string time = is_new ? "new" : "old";
+
+	  if (ParallelDescriptor::IOProcessor())
+	      std::cout << std::endl << "  Contributions to the state from the " << time << "-time sources:" << std::endl;
+
+	  print_source_change(coalesced_update);
+
+      } else {
+
+	  for (int n = 0; n < num_src; ++n) {
+
+	      if (!source_flag(n)) continue;
+
+	      ParallelDescriptor::ReduceRealSum(summed_updates[n].dataPtr(), NUM_STATE, ParallelDescriptor::IOProcessorNumber());
+
+	      std::string time = is_new ? "new" : "old";
+
+	      if (ParallelDescriptor::IOProcessor())
+		  std::cout << std::endl << "  Contributions to the state from the " << time << "-time " << source_names[n] << " source:" << std::endl;
+
+	      print_source_change(summed_updates[n]);
+
+	  }
 
       }
 

--- a/Source/Castro_sources.cpp
+++ b/Source/Castro_sources.cpp
@@ -99,7 +99,7 @@ Castro::do_old_sources(Real time, Real dt, int amr_iteration, int amr_ncycle, in
     // Optionally print out diagnostic information about how much
     // these source terms changed the state.
 
-    if (print_energy_diagnostics) {
+    if (print_update_diagnostics) {
       bool is_new = false;
       print_all_source_changes(dt, is_new);
     }
@@ -147,7 +147,7 @@ Castro::do_new_sources(Real time, Real dt, int amr_iteration, int amr_ncycle, in
     // Optionally print out diagnostic information about how much
     // these source terms changed the state.
 
-    if (print_energy_diagnostics) {
+    if (print_update_diagnostics) {
       bool is_new = true;
       print_all_source_changes(dt, is_new);
     }

--- a/Source/Castro_sponge.cpp
+++ b/Source/Castro_sponge.cpp
@@ -13,56 +13,21 @@ Castro::construct_old_sponge_source(Real time, Real dt)
 
     update_sponge_params(&time);
 
-    Real E_added    = 0.;
-    Real xmom_added = 0.;
-    Real ymom_added = 0.;
-    Real zmom_added = 0.;
-
     const Real *dx = geom.CellSize();
 
 #ifdef _OPENMP
-#pragma omp parallel reduction(+:E_added,xmom_added,ymom_added,zmom_added)
+#pragma omp parallel
 #endif
     for (MFIter mfi(Sborder,true); mfi.isValid(); ++mfi)
     {
 	const Box& bx = mfi.tilebox();
 
-	Real mom_added[3] = { 0.0 };
-
 	ca_sponge(ARLIM_3D(bx.loVect()), ARLIM_3D(bx.hiVect()),
 		  BL_TO_FORTRAN_3D(Sborder[mfi]),
 		  BL_TO_FORTRAN_3D(old_sources[sponge_src][mfi]),
 		  BL_TO_FORTRAN_3D(volume[mfi]),
-		  ZFILL(dx), dt, &time,
-		  E_added,mom_added);
+		  ZFILL(dx), dt, &time);
 
-	xmom_added += mom_added[0];
-	ymom_added += mom_added[1];
-	zmom_added += mom_added[2];
-
-    }
-
-    if (print_energy_diagnostics)
-    {
-	Real foo[4] = {E_added, xmom_added, ymom_added, zmom_added};
-#ifdef BL_LAZY
-	Lazy::QueueReduction( [=] () mutable {
-#endif
-		ParallelDescriptor::ReduceRealSum(foo, 4, ParallelDescriptor::IOProcessorNumber());
-		if (ParallelDescriptor::IOProcessor()) {
-		    E_added = foo[0];
-		    xmom_added = foo[1];
-		    ymom_added = foo[2];
-		    zmom_added = foo[3];
-
-		    std::cout << "(rho E) added from sponge                      : " << E_added << std::endl;
-		    std::cout << "xmom added from sponge                         : " << xmom_added << std::endl;
-		    std::cout << "ymom added from sponge                         : " << ymom_added << std::endl;
-		    std::cout << "zmom added from sponge                         : " << zmom_added << std::endl;
-		}
-#ifdef BL_LAZY
-	    });
-#endif
     }
 
 }
@@ -80,32 +45,20 @@ Castro::construct_new_sponge_source(Real time, Real dt)
 
     update_sponge_params(&time);
 
-    Real E_added    = 0.;
-    Real xmom_added = 0.;
-    Real ymom_added = 0.;
-    Real zmom_added = 0.;
-
     const Real *dx = geom.CellSize();
 
 #ifdef _OPENMP
-#pragma omp parallel reduction(+:E_added,xmom_added,ymom_added,zmom_added)
+#pragma omp parallel
 #endif
     for (MFIter mfi(S_new,true); mfi.isValid(); ++mfi)
     {
 	const Box& bx = mfi.tilebox();
 
-	Real mom_added[3] = { 0.0 };
-
 	ca_sponge(ARLIM_3D(bx.loVect()), ARLIM_3D(bx.hiVect()),
 		  BL_TO_FORTRAN_3D(S_new[mfi]),
 		  BL_TO_FORTRAN_3D(new_sources[sponge_src][mfi]),
 		  BL_TO_FORTRAN_3D(volume[mfi]),
-		  ZFILL(dx), dt, &time,
-		  E_added,mom_added);
-
-	xmom_added += mom_added[0];
-	ymom_added += mom_added[1];
-	zmom_added += mom_added[2];
+		  ZFILL(dx), dt, &time);
 
     }
 
@@ -117,27 +70,5 @@ Castro::construct_new_sponge_source(Real time, Real dt)
 	MultiFab::Saxpy(new_sources[sponge_src],-0.5,old_sources[sponge_src],0,0,NUM_STATE,ng);
     }
 
-    if (print_energy_diagnostics)
-    {
-	Real foo[4] = {E_added, xmom_added, ymom_added, zmom_added};
-#ifdef BL_LAZY
-	Lazy::QueueReduction( [=] () mutable {
-#endif
-		ParallelDescriptor::ReduceRealSum(foo, 4, ParallelDescriptor::IOProcessorNumber());
-		if (ParallelDescriptor::IOProcessor()) {
-		    E_added = foo[0];
-		    xmom_added = foo[1];
-		    ymom_added = foo[2];
-		    zmom_added = foo[3];
-
-		    std::cout << "(rho E) added from sponge                      : " << E_added << std::endl;
-		    std::cout << "xmom added from sponge                         : " << xmom_added << std::endl;
-		    std::cout << "ymom added from sponge                         : " << ymom_added << std::endl;
-		    std::cout << "zmom added from sponge                         : " << zmom_added << std::endl;
-		}
-#ifdef BL_LAZY
-	    });
-#endif
-    }
 }
 #endif

--- a/Source/Src_1d/Castro_1d.F90
+++ b/Source/Src_1d/Castro_1d.F90
@@ -23,8 +23,7 @@ subroutine ca_umdrv(is_finest_level, time, &
 #ifdef RADIATION
                     nstep_fsp, &
 #endif
-                    mass_added_flux, xmom_added_flux, ymom_added_flux, zmom_added_flux, &
-                    E_added_flux, mass_lost, xmom_lost, ymom_lost, zmom_lost, &
+                    mass_lost, xmom_lost, ymom_lost, zmom_lost, &
                     eden_lost, xang_lost, yang_lost, zang_lost) bind(C, name="ca_umdrv")
 
   use meth_params_module, only : NQ, QVAR, QU, QV, QW, QPRES, &
@@ -86,8 +85,6 @@ subroutine ca_umdrv(is_finest_level, time, &
   real(rt)        , intent(in) :: delta(1), dt, time
   real(rt)        , intent(inout) :: courno
 
-  real(rt)        , intent(inout) :: E_added_flux, mass_added_flux
-  real(rt)        , intent(inout) :: xmom_added_flux, ymom_added_flux, zmom_added_flux
   real(rt)        , intent(inout) :: mass_lost, xmom_lost, ymom_lost, zmom_lost
   real(rt)        , intent(inout) :: eden_lost, xang_lost, yang_lost, zang_lost
 
@@ -208,8 +205,6 @@ subroutine ca_umdrv(is_finest_level, time, &
               area, area_l1, area_h1, &
               vol, vol_l1, vol_h1, &
               div, pdivu, lo, hi, dx, dt, &
-              mass_added_flux, E_added_flux, &
-              xmom_added_flux, ymom_added_flux, zmom_added_flux, &
               mass_lost, xmom_lost, ymom_lost, zmom_lost, &
               eden_lost, xang_lost, yang_lost, zang_lost, &
               verbose)

--- a/Source/Src_1d/Castro_advection_1d.F90
+++ b/Source/Src_1d/Castro_advection_1d.F90
@@ -191,8 +191,6 @@ contains
                     area, area_l1, area_h1, &
                     vol, vol_l1, vol_h1, &
                     div, pdivu, lo, hi, dx, dt, &
-                    mass_added_flux, E_added_flux, &
-                    xmom_added_flux, ymom_added_flux, zmom_added_flux, &
                     mass_lost, xmom_lost, ymom_lost, zmom_lost, &
                     eden_lost, xang_lost, yang_lost, zang_lost, &
                     verbose)
@@ -254,8 +252,6 @@ contains
     real(rt)        , intent(in) :: div(lo(1):hi(1)+1)
     real(rt)        , intent(in) :: pdivu(lo(1):hi(1)  )
     real(rt)        , intent(in) :: dx, dt
-    real(rt)        , intent(inout) :: E_added_flux, mass_added_flux
-    real(rt)        , intent(inout) :: xmom_added_flux, ymom_added_flux, zmom_added_flux
     real(rt)        , intent(inout) :: mass_lost, xmom_lost, ymom_lost, zmom_lost
     real(rt)        , intent(inout) :: eden_lost, xang_lost, yang_lost, zang_lost
 
@@ -479,20 +475,6 @@ contains
 
     ! Add up some diagnostic quantities. Note that we are not dividing
     ! by the cell volume.
-
-    if (verbose .eq. 1) then
-
-       do i = lo(1), hi(1)
-
-          mass_added_flux = mass_added_flux + ( flux(i,URHO ) - flux(i+1,URHO ) )
-          xmom_added_flux = xmom_added_flux + ( flux(i,UMX  ) - flux(i+1,UMX  ) )
-          ymom_added_flux = ymom_added_flux + ( flux(i,UMY  ) - flux(i+1,UMY  ) )
-          zmom_added_flux = zmom_added_flux + ( flux(i,UMZ  ) - flux(i+1,UMZ  ) )
-          E_added_flux    = E_added_flux    + ( flux(i,UEDEN) - flux(i+1,UEDEN) )
-
-       enddo
-
-    endif
 
     if (track_grid_losses .eq. 1) then
 

--- a/Source/Src_2d/Castro_2d.F90
+++ b/Source/Src_2d/Castro_2d.F90
@@ -26,8 +26,7 @@ subroutine ca_umdrv(is_finest_level, time, &
 #ifdef RADIATION
                     nstep_fsp, &
 #endif
-                    mass_added_flux, xmom_added_flux, ymom_added_flux, zmom_added_flux, &
-                    E_added_flux, mass_lost, xmom_lost, ymom_lost, zmom_lost, &
+                    mass_lost, xmom_lost, ymom_lost, zmom_lost, &
                     eden_lost, xang_lost, yang_lost, zang_lost) bind(C, name="ca_umdrv")
 
   use meth_params_module, only : NQ, QVAR, NVAR, NHYP, NGDNV, GDPRES, &
@@ -102,8 +101,6 @@ subroutine ca_umdrv(is_finest_level, time, &
   real(rt)        , intent(in) :: delta(2), dt, time
   real(rt)        , intent(inout) :: courno
 
-  real(rt)        , intent(inout) :: E_added_flux, mass_added_flux
-  real(rt)        , intent(inout) :: xmom_added_flux, ymom_added_flux, zmom_added_flux
   real(rt)        , intent(inout) :: mass_lost, xmom_lost, ymom_lost, zmom_lost
   real(rt)        , intent(inout) :: eden_lost, xang_lost, yang_lost, zang_lost
 
@@ -233,8 +230,6 @@ subroutine ca_umdrv(is_finest_level, time, &
               area2, area2_l1, area2_l2, area2_h1, area2_h2, &
               vol, vol_l1, vol_l2, vol_h1, vol_h2, &
               div, pdivu, lo, hi, dx, dy, dt, &
-              mass_added_flux, E_added_flux, &
-              xmom_added_flux, ymom_added_flux, zmom_added_flux, &
               mass_lost, xmom_lost, ymom_lost, zmom_lost, &
               eden_lost, xang_lost, yang_lost, zang_lost, &
               verbose)

--- a/Source/Src_2d/Castro_advection_2d.F90
+++ b/Source/Src_2d/Castro_advection_2d.F90
@@ -349,8 +349,7 @@ contains
                      area1,area1_l1,area1_l2,area1_h1,area1_h2, &
                      area2,area2_l1,area2_l2,area2_h1,area2_h2, &
                      vol,vol_l1,vol_l2,vol_h1,vol_h2, &
-                     div,pdivu,lo,hi,dx,dy,dt,mass_added_flux,E_added_flux, &
-                     xmom_added_flux,ymom_added_flux,zmom_added_flux, &
+                     div,pdivu,lo,hi,dx,dy,dt, &
                      mass_lost,xmom_lost,ymom_lost,zmom_lost, &
                      eden_lost,xang_lost,yang_lost,zang_lost, &
                      verbose)
@@ -422,8 +421,6 @@ contains
     real(rt)        , intent(in) :: div(lo(1):hi(1)+1,lo(2):hi(2)+1)
     real(rt)        , intent(in) :: pdivu(lo(1):hi(1),lo(2):hi(2))
     real(rt)        , intent(in) :: dx, dy, dt
-    real(rt)        , intent(inout) :: E_added_flux, mass_added_flux
-    real(rt)        , intent(inout) :: xmom_added_flux, ymom_added_flux, zmom_added_flux
     real(rt)        , intent(inout) :: mass_lost, xmom_lost, ymom_lost, zmom_lost
     real(rt)        , intent(inout) :: eden_lost, xang_lost, yang_lost, zang_lost
 
@@ -769,31 +766,6 @@ contains
 
 
     ! Add up some diagnostic quantities. Note that we are not dividing by the cell volume.
-
-    if (verbose .eq. 1) then
-
-       do j = lo(2), hi(2)
-          do i = lo(1), hi(1)
-
-             mass_added_flux = mass_added_flux + ( flux1(i,j,URHO) - flux1(i+1,j,URHO) + &
-                                                   flux2(i,j,URHO) - flux2(i,j+1,URHO) )
-
-             xmom_added_flux = xmom_added_flux + ( flux1(i,j,UMX) - flux1(i+1,j,UMX) + &
-                                                   flux2(i,j,UMX) - flux2(i,j+1,UMX) )
-
-             ymom_added_flux = ymom_added_flux + ( flux1(i,j,UMY) - flux1(i+1,j,UMY) + &
-                                                   flux2(i,j,UMY) - flux2(i,j+1,UMY) )
-
-             zmom_added_flux = zmom_added_flux + ( flux1(i,j,UMZ) - flux1(i+1,j,UMZ) + &
-                                                   flux2(i,j,UMZ) - flux2(i,j+1,UMZ) )
-
-             E_added_flux    = E_added_flux    + ( flux1(i,j,UEDEN) - flux1(i+1,j,UEDEN) + &
-                                                   flux2(i,j,UEDEN) - flux2(i,j+1,UEDEN) )
-
-          enddo
-       enddo
-
-    endif
 
     if (track_grid_losses .eq. 1) then
 

--- a/Source/Src_3d/Castro_3d.F90
+++ b/Source/Src_3d/Castro_3d.F90
@@ -27,8 +27,7 @@ subroutine ca_umdrv(is_finest_level, time, &
 #ifdef RADIATION
                     nstep_fsp, &
 #endif
-                    mass_added_flux, xmom_added_flux, ymom_added_flux, zmom_added_flux, &
-                    E_added_flux, mass_lost, xmom_lost, ymom_lost, zmom_lost, &
+                    mass_lost, xmom_lost, ymom_lost, zmom_lost, &
                     eden_lost, xang_lost, yang_lost, zang_lost) bind(C, name="ca_umdrv")
 
   use mempool_module, only : bl_allocate, bl_deallocate
@@ -108,8 +107,6 @@ subroutine ca_umdrv(is_finest_level, time, &
   real(rt)        , intent(in) :: delta(3), dt, time
   real(rt)        , intent(inout) :: courno
 
-  real(rt)        , intent(inout) :: E_added_flux, mass_added_flux
-  real(rt)        , intent(inout) :: xmom_added_flux, ymom_added_flux, zmom_added_flux
   real(rt)        , intent(inout) :: mass_lost, xmom_lost, ymom_lost, zmom_lost
   real(rt)        , intent(inout) :: eden_lost, xang_lost, yang_lost, zang_lost
 
@@ -298,8 +295,7 @@ subroutine ca_umdrv(is_finest_level, time, &
               area2, area2_lo, area2_hi, &
               area3, area3_lo, area3_hi, &
               vol, vol_lo, vol_hi, &
-              div,pdivu,lo,hi,delta,dt,mass_added_flux,E_added_flux, &
-              xmom_added_flux,ymom_added_flux,zmom_added_flux, &
+              div,pdivu,lo,hi,delta,dt, &
               mass_lost,xmom_lost,ymom_lost,zmom_lost, &
               eden_lost,xang_lost,yang_lost,zang_lost, &
               verbose)

--- a/Source/Src_3d/Castro_advection_3d.F90
+++ b/Source/Src_3d/Castro_advection_3d.F90
@@ -910,8 +910,6 @@ contains
                     area3, area3_lo, area3_hi, &
                     vol,vol_lo,vol_hi, &
                     div, pdivu, lo, hi, dx, dt, &
-                    mass_added_flux, E_added_flux, &
-                    xmom_added_flux, ymom_added_flux, zmom_added_flux, &
                     mass_lost, xmom_lost, ymom_lost, zmom_lost, &
                     eden_lost, xang_lost, yang_lost, zang_lost, &
                     verbose)
@@ -995,7 +993,6 @@ contains
     real(rt)         radflux3(radflux3_lo(1):radflux3_hi(1),radflux3_lo(2):radflux3_hi(2),radflux3_lo(3):radflux3_hi(3),0:ngroups-1)
 #endif
 
-    real(rt)        , intent(inout) :: mass_added_flux, E_added_flux, xmom_added_flux, ymom_added_flux, zmom_added_flux
     real(rt)        , intent(inout) :: mass_lost, xmom_lost, ymom_lost, zmom_lost
     real(rt)        , intent(inout) :: eden_lost, xang_lost, yang_lost, zang_lost
 
@@ -1402,32 +1399,6 @@ contains
 
 
     ! Add up some diagnostic quantities. Note that we are not dividing by the cell volume.
-
-    if (verbose .eq. 1) then
-
-       do k = lo(3), hi(3)
-          do j = lo(2), hi(2)
-             do i = lo(1), hi(1)
-                mass_added_flux = mass_added_flux + ( flux1(i,j,k,URHO) - flux1(i+1,j,k,URHO) + &
-                                                      flux2(i,j,k,URHO) - flux2(i,j+1,k,URHO) + &
-                                                      flux3(i,j,k,URHO) - flux3(i,j,k+1,URHO) )
-                xmom_added_flux = xmom_added_flux + ( flux1(i,j,k,UMX) - flux1(i+1,j,k,UMX) + &
-                                                      flux2(i,j,k,UMX) - flux2(i,j+1,k,UMX) + &
-                                                      flux3(i,j,k,UMX) - flux3(i,j,k+1,UMX) )
-                ymom_added_flux = ymom_added_flux + ( flux1(i,j,k,UMY) - flux1(i+1,j,k,UMY) + &
-                                                      flux2(i,j,k,UMY) - flux2(i,j+1,k,UMY) + &
-                                                      flux3(i,j,k,UMY) - flux3(i,j,k+1,UMY) )
-                zmom_added_flux = zmom_added_flux + ( flux1(i,j,k,UMZ) - flux1(i+1,j,k,UMZ) + &
-                                                      flux2(i,j,k,UMZ) - flux2(i,j+1,k,UMZ) + &
-                                                      flux3(i,j,k,UMZ) - flux3(i,j,k+1,UMZ) )
-                E_added_flux    = E_added_flux    + ( flux1(i,j,k,UEDEN) - flux1(i+1,j,k,UEDEN) + &
-                                                      flux2(i,j,k,UEDEN) - flux2(i,j+1,k,UEDEN) + &
-                                                      flux3(i,j,k,UEDEN) - flux3(i,j,k+1,UEDEN) )
-             enddo
-          enddo
-       enddo
-
-    endif
 
     if (track_grid_losses .eq. 1) then
 

--- a/Source/Src_nd/advection_util_nd.F90
+++ b/Source/Src_nd/advection_util_nd.F90
@@ -13,8 +13,7 @@ contains
   subroutine enforce_minimum_density(uin,uin_lo,uin_hi, &
                                      uout,uout_lo,uout_hi, &
                                      vol,vol_lo,vol_hi, &
-                                     lo,hi,mass_added,eint_added, &
-                                     eden_added,frac_change,verbose) &
+                                     lo,hi,frac_change,verbose) &
                                      bind(C, name="enforce_minimum_density")
 
     use network, only : nspec, naux
@@ -32,7 +31,7 @@ contains
     real(rt)        , intent(in) ::  uin( uin_lo(1): uin_hi(1), uin_lo(2): uin_hi(2), uin_lo(3): uin_hi(3),NVAR)
     real(rt)        , intent(inout) :: uout(uout_lo(1):uout_hi(1),uout_lo(2):uout_hi(2),uout_lo(3):uout_hi(3),NVAR)
     real(rt)        , intent(in) ::  vol( vol_lo(1): vol_hi(1), vol_lo(2): vol_hi(2), vol_lo(3): vol_hi(3))
-    real(rt)        , intent(inout) :: mass_added, eint_added, eden_added, frac_change
+    real(rt)        , intent(inout) :: frac_change
 
     ! Local variables
     integer          :: i,ii,j,jj,k,kk
@@ -191,12 +190,6 @@ contains
           enddo
        enddo
     enddo
-
-    if ( have_reset ) then
-       mass_added = mass_added + final_mass - initial_mass
-       eint_added = eint_added + final_eint - initial_eint
-       eden_added = eden_added + final_eden - initial_eden
-    endif
 
   end subroutine enforce_minimum_density
 

--- a/Source/Src_nd/sponge_nd.F90
+++ b/Source/Src_nd/sponge_nd.F90
@@ -11,7 +11,7 @@ module sponge_module
 contains
 
   subroutine ca_sponge(lo,hi,state,state_lo,state_hi,source,src_lo,src_hi, &
-                       vol,vol_lo,vol_hi,dx,dt,time,E_added,mom_added) &
+                       vol,vol_lo,vol_hi,dx,dt,time) &
                        bind(C, name="ca_sponge")
 
     use prob_params_module,   only: problo, center
@@ -33,12 +33,11 @@ contains
     real(rt)         :: source(src_lo(1):src_hi(1),src_lo(2):src_hi(2),src_lo(3):src_hi(3),NVAR)
     real(rt)         :: vol(vol_lo(1):vol_hi(1),vol_lo(2):vol_hi(2),vol_lo(3):vol_hi(3))
     real(rt)         :: dx(3), dt, time
-    real(rt)         :: E_added, mom_added(3)
 
     ! Local variables
 
     real(rt)         :: r(3), radius
-    real(rt)         :: ke_old, E_old, mom_old(3)
+    real(rt)         :: ke_old
     real(rt)         :: sponge_factor, alpha
     real(rt)         :: delta_r, delta_rho
     real(rt)         :: rho, rhoInv
@@ -81,11 +80,7 @@ contains
              src = ZERO
              snew = state(i,j,k,:)
 
-             ! Starting diagnostic quantities
-
-             E_old   = snew(UEDEN)
              ke_old  = HALF * sum(snew(UMX:UMZ)**2) * rhoInv
-             mom_old = snew(UMX:UMZ)
 
              ! Apply radial sponge. By default sponge_lower_radius will be zero
              ! so this sponge is applied only if set by the user.
@@ -157,11 +152,6 @@ contains
              src(UEDEN) = src(UEDEN) + (HALF * sum(snew(UMX:UMZ)**2) * rhoInv - ke_old) / dt
 
              snew(UEDEN) = snew(UEDEN) + dt * src(UEDEN)
-
-             ! Ending diagnostic quantities
-
-             E_added   = E_added   + (snew(UEDEN)   - E_old  ) * vol(i,j,k)
-             mom_added = mom_added + (snew(UMX:UMZ) - mom_old) * vol(i,j,k)
 
              ! Add terms to the source array.
 

--- a/Source/_cpp_parameters
+++ b/Source/_cpp_parameters
@@ -424,8 +424,12 @@ spherical_star               int           0
 # display warnings in Fortran90 routines
 print_fortran_warnings       int           (0, 1)
 
-# display breakdown of energy sources
+# display information about updates to the state (how much mass, momentum, energy added)
 print_update_diagnostics     int           (0, 1)
+
+# if we're printing diagnostic information about the updates, should we
+# break down the information into the constitent source terms?
+coalesce_update_diagnostics  int           (0, 1)
 
 # calculate losses of material through physical grid boundaries
 track_grid_losses            int            0                    y

--- a/Source/_cpp_parameters
+++ b/Source/_cpp_parameters
@@ -425,7 +425,7 @@ spherical_star               int           0
 print_fortran_warnings       int           (0, 1)
 
 # display breakdown of energy sources
-print_energy_diagnostics     int           (0, 1)
+print_update_diagnostics     int           (0, 1)
 
 # calculate losses of material through physical grid boundaries
 track_grid_losses            int            0                    y

--- a/Source/param_includes/castro_defaults.H
+++ b/Source/param_includes/castro_defaults.H
@@ -129,9 +129,9 @@ int         Castro::print_fortran_warnings = 1;
 int         Castro::print_fortran_warnings = 0;
 #endif
 #ifdef DEBUG
-int         Castro::print_energy_diagnostics = 1;
+int         Castro::print_update_diagnostics = 1;
 #else
-int         Castro::print_energy_diagnostics = 0;
+int         Castro::print_update_diagnostics = 0;
 #endif
 int         Castro::track_grid_losses = 0;
 int         Castro::sum_interval = -1;

--- a/Source/param_includes/castro_defaults.H
+++ b/Source/param_includes/castro_defaults.H
@@ -133,6 +133,11 @@ int         Castro::print_update_diagnostics = 1;
 #else
 int         Castro::print_update_diagnostics = 0;
 #endif
+#ifdef DEBUG
+int         Castro::coalesce_update_diagnostics = 1;
+#else
+int         Castro::coalesce_update_diagnostics = 0;
+#endif
 int         Castro::track_grid_losses = 0;
 int         Castro::sum_interval = -1;
 Real        Castro::sum_per = -1.0e0;

--- a/Source/param_includes/castro_params.H
+++ b/Source/param_includes/castro_params.H
@@ -125,6 +125,7 @@ static int do_special_tagging;
 static int spherical_star;
 static int print_fortran_warnings;
 static int print_update_diagnostics;
+static int coalesce_update_diagnostics;
 static int track_grid_losses;
 static int sum_interval;
 static Real sum_per;

--- a/Source/param_includes/castro_params.H
+++ b/Source/param_includes/castro_params.H
@@ -124,7 +124,7 @@ static int star_at_center;
 static int do_special_tagging;
 static int spherical_star;
 static int print_fortran_warnings;
-static int print_energy_diagnostics;
+static int print_update_diagnostics;
 static int track_grid_losses;
 static int sum_interval;
 static Real sum_per;

--- a/Source/param_includes/castro_queries.H
+++ b/Source/param_includes/castro_queries.H
@@ -124,7 +124,7 @@ pp.query("star_at_center", star_at_center);
 pp.query("do_special_tagging", do_special_tagging);
 pp.query("spherical_star", spherical_star);
 pp.query("print_fortran_warnings", print_fortran_warnings);
-pp.query("print_energy_diagnostics", print_energy_diagnostics);
+pp.query("print_update_diagnostics", print_update_diagnostics);
 pp.query("track_grid_losses", track_grid_losses);
 pp.query("sum_interval", sum_interval);
 pp.query("sum_per", sum_per);

--- a/Source/param_includes/castro_queries.H
+++ b/Source/param_includes/castro_queries.H
@@ -125,6 +125,7 @@ pp.query("do_special_tagging", do_special_tagging);
 pp.query("spherical_star", spherical_star);
 pp.query("print_fortran_warnings", print_fortran_warnings);
 pp.query("print_update_diagnostics", print_update_diagnostics);
+pp.query("coalesce_update_diagnostics", coalesce_update_diagnostics);
 pp.query("track_grid_losses", track_grid_losses);
 pp.query("sum_interval", sum_interval);
 pp.query("sum_per", sum_per);


### PR DESCRIPTION
This set of changes significantly simplifies how we print diagnostic information regarding updates to the state. Every source term -- including the user-defined external source terms, the built-in physics like gravity, the hydrodynamics, and density and energy resets -- will now print its updates in a uniform fashion if print_update_diagnostics == 1 (note that this parameter has been renamed from print_energy_diagnostics).

This allowed us to remove parameters like E_added from interfaces to Fortran kernels, which simplifies them a bit.

Also, to slightly simplify conditional logic, ext_src was placed first in the list of source terms to evaluate. This may result in small changes for some problems.