### PR TITLE
Writing particle information to the plotfiles using the standard BoxLib format

### DIFF
--- a/Source/Castro.H
+++ b/Source/Castro.H
@@ -160,6 +160,10 @@ public:
     //
     void ParticleCheckPoint (const std::string& dir);
     //
+    // Write particles in plotfile directories
+    //
+    void ParticlePlotFile (const std::string& dir);
+    //
     // How to initialize at restart
     //
     void ParticlePostRestart (const std::string& restart_file);

--- a/Source/CastroParticles.cpp
+++ b/Source/CastroParticles.cpp
@@ -104,6 +104,18 @@ Castro::ParticleCheckPoint(const std::string& dir)
 }
 
 void
+Castro::ParticlePlotFile(const std::string& dir)
+{
+    if (level == 0)
+    {
+      //  We call TracerPC->Checkpoint instead of TracerPC->WritePlotFile
+      //  so that the particle ids also get written out.
+        if (TracerPC)
+            TracerPC->Checkpoint(dir, chk_tracer_particle_file);
+    }
+}
+
+void
 Castro::ParticlePostRestart (const std::string& restart_file)
 {
     if (level == 0)

--- a/Source/Castro_io.cpp
+++ b/Source/Castro_io.cpp
@@ -807,6 +807,11 @@ Castro::writePlotFile (const std::string& dir,
                        ostream&       os,
                        VisMF::How     how)
 {
+
+#ifdef PARTICLES
+  ParticleCheckPoint(dir);
+#endif
+
     int i, n;
     //
     // The list of indices of State to write to plotfile.

--- a/Source/Castro_io.cpp
+++ b/Source/Castro_io.cpp
@@ -809,7 +809,7 @@ Castro::writePlotFile (const std::string& dir,
 {
 
 #ifdef PARTICLES
-  ParticleCheckPoint(dir);
+  ParticlePlotFile(dir);
 #endif
 
     int i, n;


### PR DESCRIPTION
This will allow the particles to be read in by visualization / analysis codes that support the BoxLib format, such as yt. 