### PR TITLE
Exec/hydro_tests/KH/*.p5: fix problem number and filename reference

### DIFF
--- a/Exec/hydro_tests/KH/inputs.2d.p5
+++ b/Exec/hydro_tests/KH/inputs.2d.p5
@@ -62,4 +62,4 @@ amr.plot_vars = ALL
 amr.derive_plot_vars = NONE
 
 # PROBIN FILENAME
-amr.probin_file = probin.p4
+amr.probin_file = probin.p5

--- a/Exec/hydro_tests/KH/probin.p5
+++ b/Exec/hydro_tests/KH/probin.p5
@@ -1,6 +1,6 @@
 &fortin
 
-   problem = 4
+   problem = 5
 
    rho1 = 1.0
    rho2 = 2.0


### PR DESCRIPTION
The filename and the contents are inconsistent. Filenames are referring to problem 5, but the contents are referring to problem 4.

I tried to trace the history but it's difficult to see the history because of the reorganization in commit 9359f31. So here I made a guess that problem 5 is correct and 4 is wrong.

In case my guess is wrong and it should actually be problem 4, choose #119 instead.